### PR TITLE
Updated __repr__ in Parameter class from parameter.py

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -108,10 +108,10 @@ class Parameter(object):
         if self.name is not None:
             s.append("'%s'" % self.name)
         sval = repr(self._val)
-        if self.stderr is not None:
-            sval = "value=%s +/- %.3g" % (sval, self.stderr)
         if not self.vary and self.expr is None:
             sval = "value=%s (fixed)" % (sval)
+        elif self.stderr is not None:
+            sval = "value=%s +/- %.3g" % (sval, self.stderr)
         s.append(sval)
         s.append("bounds=[%s:%s]" % (repr(self.min), repr(self.max)))
         if self.expr is not None:


### PR DESCRIPTION
After appling minimize the parameters adquire an std_err, even if they are fixed. For those parameters the **repr** return two times the word value, for example:
<Parameter 'c', value=value=0 +/- 0 (fixed), bounds=[-inf:inf]>

I have invert the order of the "if"s and put one of them as an "else if". The bad new is that know the uncertainty information of the fixed parameters is not shown... However I don't know why it should be printed...
