### PR TITLE
ENH: Add Model class and example.

### DIFF
--- a/examples/lmfit-model.ipynb
+++ b/examples/lmfit-model.ipynb
@@ -1,0 +1,293 @@
+{
+ "metadata": {
+  "name": ""
+ },
+ "nbformat": 3,
+ "nbformat_minor": 0,
+ "worksheets": [
+  {
+   "cells": [
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "The ``Model`` class is a flexible, concise curve fitter. I will illustrate three different usages, fitting example data to an exponential decay."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "def decay(t, N, tau):\n",
+      "    return N*np.exp(-t/tau)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 5
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "The parameters are in no particular order. We'll need some example data. I will use ``N=7`` and ``tau=3``, and I'll add a little noise."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "t = np.linspace(0, 5, num=1000)\n",
+      "data = decay(t, 7, 3) + np.random.randn(*t.shape)"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 6
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### Simplest Usage"
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from lmfit import Model\n",
+      "\n",
+      "model = Model(decay, independent_vars=['t'])\n",
+      "result = model.fit(data, t=t, N=10, tau=1)\n",
+      "result.params"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 7,
+       "text": [
+        "Parameters([('tau', <Parameter 'tau', value=2.9345371030289131 +/- 0.0664, bounds=[-inf:inf]>), ('N', <Parameter 'N', value=7.0259673483480816 +/- 0.0929, bounds=[-inf:inf]>)])"
+       ]
+      }
+     ],
+     "prompt_number": 7
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "* The Model infers the parameter names by inspecting the arguments of the function ``decay``.\n",
+      "* To ``fit``, I passed the independent variable, ``t``, and initial guesses for each parameter. A residual function is automatically defined.\n",
+      "* The result object is an [``lmfit.Mimimizer``](http://newville.github.io/lmfit-py/fitting.html#Minimizer) class."
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### Specifying Bounds and Holding Parameters Constant"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Above, the ``Model`` class implicitly builds ``Parameter`` objects from keyword arguments that match the argments of ``decay``. You can build the ``Parameter`` objects explicity; the following is equivalent."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "from lmfit import Parameter\n",
+      "\n",
+      "result = model.fit(data, t=t, \n",
+      "                   N=Parameter('N', value=10), \n",
+      "                   tau=Parameter('tau', value=1))\n",
+      "result.params"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 8,
+       "text": [
+        "Parameters([('tau', <Parameter 'tau', value=2.9345371030289131 +/- 0.0664, bounds=[-inf:inf]>), ('N', <Parameter 'N', value=7.0259673483480816 +/- 0.0929, bounds=[-inf:inf]>)])"
+       ]
+      }
+     ],
+     "prompt_number": 8
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "By building ``Parameter`` objects explicitly, you can specify bounds (``min``, ``max``) and set parameters constant (``vary=False``)."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "result = model.fit(data, t=t, \n",
+      "                   N=Parameter('N', value=7, vary=False), \n",
+      "                   tau=Parameter('tau', value=1, min=0))\n",
+      "result.params"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 9,
+       "text": [
+        "Parameters([('tau', <Parameter 'tau', value=2.9485373380193822 +/- 0.0439, bounds=[0:inf]>), ('N', <Parameter 'N', value=7 (fixed), bounds=[-inf:inf]>)])"
+       ]
+      }
+     ],
+     "prompt_number": 9
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### Defining Parameters in Advance"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Passing parameters to ``fit`` can become unwieldly. As an alternative, you can extract the parameters from ``model`` like so, set them individually, and pass them to ``fit``."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "params = model.params()"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 10
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "params['N'].value = 10  # initial guess\n",
+      "params['tau'].value = 1\n",
+      "params['tau'].min = 0"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [],
+     "prompt_number": 11
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "result = model.fit(data, params, t=t)\n",
+      "result.params"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 12,
+       "text": [
+        "Parameters([('tau', <Parameter 'tau', value=2.9345371070208484 +/- 0.0664, bounds=[0:inf]>), ('N', <Parameter 'N', value=7.0259673444703212 +/- 0.0929, bounds=[-inf:inf]>)])"
+       ]
+      }
+     ],
+     "prompt_number": 12
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "Keyword arguments override ``params``, resetting ``value`` and all other properties (``min``, ``max``, ``vary``)."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "result = model.fit(data, params, t=t, tau=1)\n",
+      "result.params"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "metadata": {},
+       "output_type": "pyout",
+       "prompt_number": 13,
+       "text": [
+        "Parameters([('tau', <Parameter 'tau', value=2.9345377563733717 +/- 0.0664, bounds=[-inf:inf]>), ('N', <Parameter 'N', value=7.0259666615208483 +/- 0.0929, bounds=[-inf:inf]>)])"
+       ]
+      }
+     ],
+     "prompt_number": 13
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "### A Helpful Exception"
+     ]
+    },
+    {
+     "cell_type": "markdown",
+     "metadata": {},
+     "source": [
+      "All this implicit magic makes it very easy for the user to neglect to set a parameter. The ``fit`` function checks for this and raises a helpful exception."
+     ]
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [
+      "result = model.fit(data, t=t, tau=1)  # N unspecified"
+     ],
+     "language": "python",
+     "metadata": {},
+     "outputs": [
+      {
+       "ename": "ValueError",
+       "evalue": "Assign each parameter an initial value by passing Parameters or keyword arguments to fit().",
+       "output_type": "pyerr",
+       "traceback": [
+        "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m\n\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
+        "\u001b[1;32m<ipython-input-14-6d8fedbef3f8>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[1;32m----> 1\u001b[1;33m \u001b[0mresult\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mmodel\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfit\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdata\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mt\u001b[0m\u001b[1;33m=\u001b[0m\u001b[0mt\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mtau\u001b[0m\u001b[1;33m=\u001b[0m\u001b[1;36m1\u001b[0m\u001b[1;33m)\u001b[0m  \u001b[1;31m# N unspecified\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m",
+        "\u001b[1;32m/home/dallan/lmfit-py/lmfit/model.py\u001b[0m in \u001b[0;36mfit\u001b[1;34m(self, data, params, *args, **kwargs)\u001b[0m\n\u001b[0;32m     92\u001b[0m             raise ValueError(\"Assign each parameter an initial value by \" +\n\u001b[0;32m     93\u001b[0m                              \u001b[1;34m\"passing Parameters or keyword arguments to \"\u001b[0m \u001b[1;33m+\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 94\u001b[1;33m                              \"fit().\")\n\u001b[0m\u001b[0;32m     95\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     96\u001b[0m         result = lmfit.minimize(self._build_residual(data), params, \n",
+        "\u001b[1;31mValueError\u001b[0m: Assign each parameter an initial value by passing Parameters or keyword arguments to fit()."
+       ]
+      }
+     ],
+     "prompt_number": 14
+    },
+    {
+     "cell_type": "code",
+     "collapsed": false,
+     "input": [],
+     "language": "python",
+     "metadata": {},
+     "outputs": []
+    }
+   ],
+   "metadata": {}
+  }
+ ]
+}

--- a/lmfit/__init__.py
+++ b/lmfit/__init__.py
@@ -22,6 +22,7 @@ from .printfuncs import (fit_report, ci_report,
                          report_fit, report_ci, report_errors)
 
 from .wrap      import wrap_function, make_paras_and_func
+from .model import Model
 
 from . import models1d
 from . import uncertainties

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1,0 +1,98 @@
+"""
+Concise nonlinear curve fitting.
+
+"""
+
+import lmfit
+import inspect
+
+class Model(object):
+
+    def __init__(self, model_func, independent_vars):
+        """Create a model.
+
+        Note
+        ----
+        Parameter names are inferred from the function arguments,
+        and a residual function is automatically constructed.
+
+        Example
+        -------
+        >>> def decay(t, tau, N):
+        ...     return N*np.exp(-t/tau)
+        ...
+        >>> my_model = Model(decay, independent_vars = 't')    
+        """
+        self.model_arg_names = inspect.getargspec(model_func)[0]
+        self.param_names = set(self.model_arg_names) - set(independent_vars)
+        self.model_func = model_func
+        self.independent_vars = independent_vars
+
+    def params(self):
+        """Return a blank copy of model params.
+        
+        Example
+        -------
+        >>> params = my_model.params()
+        >>> params['N'].value = 1.0  # initial guess
+        >>> params['tau'].value = 2.0  # initial guess
+        >>> params['tau'].min = 0  # (optional) lower bound
+        """
+        params = lmfit.Parameters()
+        [params.add(name) for name in self.param_names]
+        return params
+
+    def _build_residual(self, data):
+        "Generate and return a residual function."
+        def residual(params, *args, **kwargs):
+            # Unpack Parameter objects into simple key -> value pairs,
+            # and combine them with any non-parameter kwargs.
+            params = {name: p.value for name, p in params.items()}
+            kwargs = dict(params.items() + kwargs.items())
+            f = self.model_func(*args, **kwargs)
+            e = data - f
+            return e
+        return residual
+
+    def fit(self, data, params=None, *args, **kwargs):
+        """Fit the model to the data.
+
+        Examples
+        --------
+        # Take t to be the independent variable and data to be the
+        # curve we will fit.
+
+        # Using keyword arguments to set initial guesses
+        >>> result = fit(my_model, data, tau=5, N=3, t=t)
+
+        # Or, for more control, pass a Parameters object.
+        # See docstring for Model.params()
+        >>> result = fit(my_model, data, params, t=t)
+
+        # Keyword arguments override Parameters.
+        >>> result = fit(my_model, data, params, tau=5, t=t)
+
+        """
+        if params is None:
+            params = self.params()
+
+        # If any kwargs match parameter names, override params.
+        param_kwargs = set(kwargs.keys()) & self.param_names
+        for name in param_kwargs:
+            if isinstance(kwargs[name], lmfit.Parameter):
+                params[name] = kwargs[name]
+            else:
+                params[name] = lmfit.Parameter(name=name, value=kwargs[name])
+            del kwargs[name]
+
+        # If any parameter is not initialized raise a more helpful error.
+        missing_param = set(params.keys()) != self.param_names
+        blank_param = any([p.value is None for p in params.values()])
+        if missing_param or blank_param:
+            raise ValueError("Assign each parameter an initial value by " +
+                             "passing Parameters or keyword arguments to " +
+                             "fit().")
+
+        result = lmfit.minimize(self._build_residual(data), params, 
+                                args=args, kws=kwargs)
+        return result


### PR DESCRIPTION
This is an attempt to implement the `Model` API shared by @vnmanoharan in #56. This implementation also allows an even more concise usage, generating Parameters implicitly from keyword arguments. View [this IPython notebook](http://nbviewer.ipython.org/github/danielballan/lmfit-py/blob/4d4e0f1115bad70f7ad900f9da27d9d99ea996c9/examples/lmfit-model.ipynb) for some hasty documentation.

Thoughts?
