### PR TITLE
Added missing attributes to other fit methods

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -322,9 +322,9 @@ or set  leastsq_kws['maxfev']  to increase this maximum."""
         xout, fout, info = scipy_lbfgsb(self.penalty, self.vars, **lb_kws)
         self.nfev = info['funcalls']
         self.message = info['task']
-        self.chisqr = (self.penalty(xout)**2).sum()
-        if self.userargs != []:
-            self.ndata = len(self.userargs[0])
+        self.residual = self.__residual(xout)
+        self.chisqr = (self.residual**2).sum()
+        self.ndata = len(self.residual)
         self.nfree = (self.ndata - self.nvarys)       
         self.redchi = self.chisqr/self.nfree
         self.unprepare_fit()
@@ -343,9 +343,9 @@ or set  leastsq_kws['maxfev']  to increase this maximum."""
         ret = scipy_fmin(self.penalty, self.vars, **fmin_kws)
         xout, fout, iter, funccalls, warnflag, allvecs = ret
         self.nfev = funccalls
-        self.chisqr = (self.penalty(xout)**2).sum()
-        if self.userargs != []:
-            self.ndata = len(self.userargs[0])
+        self.residual = self.__residual(xout)
+        self.chisqr = (self.residual**2).sum()
+        self.ndata = len(self.residual)
         self.nfree = (self.ndata - self.nvarys)
         self.redchi = self.chisqr/self.nfree
         self.unprepare_fit()
@@ -390,11 +390,11 @@ or set  leastsq_kws['maxfev']  to increase this maximum."""
 
         ret = scipy_minimize(self.penalty, self.vars, **fmin_kws)
         xout = ret.x
-        self.message = ret.message
+        self.message = ret.message        
         self.nfev = ret.nfev
-        self.chisqr = (self.penalty(xout)**2).sum()       
-        if self.userargs != []:
-            self.ndata = len(self.userargs[0])
+        self.residual = self.__residual(xout)
+        self.chisqr = (self.residual**2).sum()
+        self.ndata = len(self.residual)
         self.nfree = (self.ndata - self.nvarys)
         self.redchi = self.chisqr/self.nfree
         self.unprepare_fit()


### PR DESCRIPTION
Greetings!

I started using LMFIT for my own project, where I switch between different fitting methods often and compare goodness of fit using reduced chisquared and Rsquared. I have discovered that all methods except least squares don't have defined redchi and residuals attributes. It was even pointed out on stackoverflow: http://stackoverflow.com/questions/17465701/attribute-error-from-minimizer-object-returned-from-scipy-optimize-minimize-fu

Hence the following changes were made to lbfgsb(), fmin() and scalar_minimize():
- Residual attribute added to the remaining methods. It is based on calling __residual() with optimized parameters
- Chisqr calculation is based on residuals
- Redchi added
- leastsq method is not changed

I tested this version with my project and haven't seen any issues. It also passed all available tests.
Please let me know if you have any questions or concerns.

Cheers
