### PR TITLE
Enhancement of Matplotlib import with nosetests

### DIFF
--- a/tests/test_algebraic_constraint2.py
+++ b/tests/test_algebraic_constraint2.py
@@ -5,19 +5,16 @@ from lmfit.printfuncs import report_fit
 import sys
 
 
-HASPYLAB = False
-# Turn off plotting if run by nosetests.
-if not sys.argv[0].endswith('nosetests'):
-    try:
-        import matplotlib
-        import pylab
-        HASPYLAB = True
-    except ImportError:
-        pass
+try:
+    import matplotlib
+    import pylab
+    HASPYLAB = True
+except ImportError:
+    HASPYLAB = False
 
 # Turn off plotting if run by nosetests.
-if sys.argv[0].endswith('nosetests'):
-    HASPYLAB = False 
+if 'nosetests' in sys.argv[0]:
+    HASPYLAB = False
 
 def test_constraints(with_plot=True):
     with_plot = with_plot and HASPYLAB
@@ -35,7 +32,7 @@ def test_constraints(with_plot=True):
             return model
         if sigma is None:
             return (model - data)
-        return (model - data)/sigma
+        return (model - data) / sigma
 
 
     n = 201


### PR DESCRIPTION
Hi,

I made this patch because I can't run the tests for archlinux packages (I'm the packager for lmfit). The problem is that archlinux uses nosetests2 or nosetests3, and it is not detected by endswith().

Also, this was checked twice in the test. I do not see a good reason for that.
