### PR TITLE
TST: Run all tests, now that uncertainties are fixed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 
 script:
     # Execute the unit tests
-    - nosetests tests
+    - nosetests
     # Generate the docs
     - if [[ $PYVER == '2.x' ]]; then
     -   cd doc


### PR DESCRIPTION
Now that the uncertainties tests are passing with nosetests, we can run _all_ tests on Travis. This brings the total number of test up to 57 from 23. It only takes about 25% more time.
