### PR TITLE
Don't print correlations when they are NaN

### DIFF
--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -18,6 +18,7 @@ Changes:
 """
 
 from __future__ import print_function
+from numpy import isnan
 
 
 def fit_report(params, modelpars=None, show_correl=True, min_correl=0.1):
@@ -78,6 +79,8 @@ def fit_report(params, modelpars=None, show_correl=True, min_correl=0.1):
                     if name != name2 and name2 in par.correl:
                         correls["%s, %s" % (name, name2)] = par.correl[name2]
 
+        # Remove correlations that are NaN
+        correls = {k: v for k, v in correls.iteritems() if not isnan(v)}
         sort_correl = sorted(correls.items(), key=lambda it: abs(it[1]))
         sort_correl.reverse()
         for name, val in sort_correl:


### PR DESCRIPTION
When correlation between parameters are NaN `fit_report` prints them. For example the output of [this script](https://gist.github.com/tritemio/35854ac8f0a9a6be234b) is: 

```
[[Variables]]
     ampl:         6884.602 +/- nan (nan%) initial =  7000
     baseline:     22.57765 +/- 1.745224 (7.73%) initial =  24
     offset:       2.753906 +/- nan (nan%) initial =  2.8
     tau:          2.766161 +/- 0.02408554 (0.87%) initial =  2.8
[[Correlations]] (unreported correlations are <  0.100)
    C(ampl, tau)                 =  nan 
    C(ampl, baseline)            =  nan 
    C(baseline, tau)             = -0.419 
    C(ampl, offset)              =  nan 
    C(baseline, offset)          =  nan 
    C(offset, tau)               =  nan 
```

Make sense to print only the meaningful correlations. With the present PR, `fit_report` will skip all the correlations that are NaN. In the previous example the output becomes:

```
[[Variables]]
     ampl:         6884.602 +/- nan (nan%) initial =  7000
     baseline:     22.57765 +/- 1.745224 (7.73%) initial =  24
     offset:       2.753906 +/- nan (nan%) initial =  2.8
     tau:          2.766161 +/- 0.02408554 (0.87%) initial =  2.8
[[Correlations]] (unreported correlations are <  0.100)
    C(baseline, tau)             = -0.419 
```
