### PR TITLE
Fix log -> np.log

### DIFF
--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -276,7 +276,7 @@ class PowerLawModel(Model):
 
     def guess(self, data, x=None, **kwargs):
         try:
-            expon, amp = np.polyfit(log(x+1.e-14), log(data+1.e-14), 1)
+            expon, amp = np.polyfit(np.log(x+1.e-14), np.log(data+1.e-14), 1)
         except:
             expon, amp = 1, np.log(abs(max(data)+1.e-9))
 


### PR DESCRIPTION
Sorry for not catching this in the previous PR.

Anyway I now checked all the files, no more errors detected by Spyder. Only a warning about `logistic` and `skewed_voigt` being imported but not used in `models.py`.
