### PR TITLE
Model noparams

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -217,6 +217,9 @@ class Model(object):
         """create and return a Parameters object for a Model.
         This applies any default values
         """
+        verbose = False
+        if 'verbose' in kwargs:
+            verbose = kwargs['verbose']
         params = Parameters()
         if not self.is_composite():
             # base model: build Parameters from scratch
@@ -268,6 +271,7 @@ class Model(object):
                         setattr(par, item, hint[item])
                 # Add the new parameter to the self.param_names
                 self.param_names.add(name)
+                if verbose: print ' - Adding parameter "%s"' % name
         return params
 
     def guess(self, data=None, **kws):
@@ -347,7 +351,7 @@ class Model(object):
         return result
 
     def fit(self, data, params=None, weights=None, method='leastsq',
-            iter_cb=None, scale_covar=True, **kwargs):
+            iter_cb=None, scale_covar=True, verbose=True, **kwargs):
         """Fit the model to the data.
 
         Parameters
@@ -359,6 +363,8 @@ class Model(object):
         method: fitting method to use (default = 'leastsq')
         iter_cb:  None or callable  callback function to call at each iteration.
         scale_covar:  bool (default True) whether to auto-scale covariance matrix
+        verbose: bool (default True) print a message when a new parameter is
+            added because of a hint.
         keyword arguments: optional, named like the arguments of the
             model function, will override params. See examples below.
 
@@ -387,7 +393,7 @@ class Model(object):
 
         """
         if params is None:
-            params = self.make_params()
+            params = self.make_params(verbose=verbose)
         else:
             params = deepcopy(params)
 


### PR DESCRIPTION
This branch implements composite models through a list of sub-models in `Model.components`.

Composite models have these properties:
1. `Model.func = None`
2. The list `Model.param_names` contains all the parameter names from sub-models and any additional parameter added through a hint
3. The list `Model.independent_vars` is set from the first base model and it is assumed that all the base models have same independent variables names
4. Hints from sub-models are applied. Hints from the composite model can override hints from sub-models
5. Hints on the composite models must use the full parameter name (i.e. with prefix).
6. Setting a hint on a parameter not in `Model.param_names` results in the silent creation of a new parameter when calling `.make_params()`. A `verbose` flag can be used to print a message when this happens.
5. By accessing the sub-models in `.components` is possible to evaluate (and plot) all the base models individually
6. The name of a composite model is obtained by default by joining the names of the base models. A new name can be assigned by assigning to `Model.name`

The branch has been manually tested on a few examples but not with unit-tests. 

**EDITED typos**
