### PR TITLE
FIX: Flatten components when adding two composite models.

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -483,9 +483,13 @@ class Model(object):
             collision = colliding_param_names.pop()
             raise NameError(self._names_collide % collision)
 
-        if len(self.components) > 0:
+        if self.is_composite:
             # If the model is already composite just add other as component
-            self.components.append(other)
+            if not other.is_composite:
+                self.components.append(other)
+            else:
+                self.components.extend(other.components)
+                self.param_hints.update(other.param_hints)
             return self
         else:
             # make new composite Model, add self and other as components


### PR DESCRIPTION
This patch flattens the components when summing composite models.

When adding 2 composite models, if the prefixes are the same (for example empty), `__add__()` makes sure there is no parameter name conflict and all the parameters and hints are preserved in the composition.

There are some corner cases when adding two composite models **with different prefixes**. In this case one prefix is lost, and a parameter defined via an hint **may** change name. This case may be addressed in the future if it turns out to be a real-world problem.
