### PR TITLE
MAINT: lmfit.minimize, deprecating lmfit.minimize.Minimize.lbfgs.

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -14,7 +14,7 @@ function-to-be-minimized (residual function) in terms of these Parameters.
 from copy import deepcopy
 import numpy as np
 from numpy import (dot, eye, ndarray, ones_like,
-                   sqrt, take, transpose, triu)
+                   sqrt, take, transpose, triu, deprecate)
 from numpy.dual import inv
 from numpy.linalg import LinAlgError
 
@@ -333,6 +333,8 @@ or set  leastsq_kws['maxfev']  to increase this maximum."""
             if hasattr(par, 'ast'):
                 delattr(par, 'ast')
 
+    @deprecate(message='    Deprecated in lmfit 0.8.2, use scalar_minimize '
+                       'and method=\'L-BFGS-B\' instead')
     def lbfgsb(self, **kws):
         """
         use l-bfgs-b minimization
@@ -358,6 +360,8 @@ or set  leastsq_kws['maxfev']  to increase this maximum."""
         self.unprepare_fit()
         return
 
+    @deprecate(message='    Deprecated in lmfit 0.8.2, use scalar_minimize '
+                       'and method=\'Nelder-Mead\' instead')
     def fmin(self, **kws):
         """
         use nelder-mead (simplex) minimization


### PR DESCRIPTION
scipy.optimize.minimize was added in scipy v0.11.  The minimum scipy version for lmfit is now 0.13.  This PR used a numpy deprecation warning to say that the minimize.Minimize.lbfgs and fmin method will be removed in the future.  This was originally discussed in #65.
Before merging the version number needs to be checked.
