### PR TITLE
MAINT: lmfit.printfuncs.fit_report, using alphanumeric sort

### DIFF
--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -66,7 +66,8 @@ def gformat(val, length=11):
 
 CORREL_HEAD = '[[Correlations]] (unreported correlations are < % .3f)'
 
-def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1):
+def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
+               sort_pars=False):
     """return text of a report for fitted params best-fit values,
     uncertainties and correlations
 
@@ -76,16 +77,28 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1):
        modelpars    Optional Known Model Parameters [None]
        show_correl  whether to show list of sorted correlations [True]
        min_correl   smallest correlation absolute value to show [0.1]
-
+       sort_pars    If True, then fit_report will show parameter names
+                    sorted in alphanumerical order.  If False, then the
+                    parameters will be listed in the order they were added to
+                    the Parameters dictionary. If sort_pars is callable, then
+                    this (one argument) function is used to extract a
+                    comparison key from each list element.
     """
     if isinstance(inpars, Parameters):
         result, params = None, inpars
     if hasattr(inpars, 'params'):
         result = inpars
         params = inpars.params
+    
+    if sort_pars:
+        if callable(sort_pars):
+            key = sort_pars
+        else:
+            key = natural_sort_key
+        parnames = sorted(params, key=key)
+    else:
+        parnames = params.keys()
 
-    parnames = sorted(params, key=natural_sort_key)
-    parnames = sorted(params, key=natural_sort_key)
     buff = []
     add = buff.append
     if result is not None:

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 from .parameter import Parameters
 import re
 
-def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
+def alphanumeric_sort(s, _nsre=re.compile('([0-9]+)')):
     return [int(text) if text.isdigit() else text.lower()
             for text in re.split(_nsre, s)]
 
@@ -94,7 +94,7 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
         if callable(sort_pars):
             key = sort_pars
         else:
-            key = natural_sort_key
+            key = alphanumeric_sort
         parnames = sorted(params, key=key)
     else:
         # dict.keys() returns a KeysView in py3, and they're indexed further

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -97,7 +97,9 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
             key = natural_sort_key
         parnames = sorted(params, key=key)
     else:
-        parnames = params.keys()
+        # dict.keys() returns a KeysView in py3, and they're indexed further
+        # down
+        parnames = list(params.keys())
 
     buff = []
     add = buff.append

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -19,6 +19,11 @@ Changes:
 
 from __future__ import print_function
 from .parameter import Parameters
+import re
+
+def natural_sort_key(s, _nsre=re.compile('([0-9]+)')):
+    return [int(text) if text.isdigit() else text.lower()
+            for text in re.split(_nsre, s)]
 
 def getfloat_attr(obj, attr, fmt='%.3f'):
     "format an attribute of an object for printing"
@@ -79,8 +84,8 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1):
         result = inpars
         params = inpars.params
 
-    parnames = sorted(params)
-    parnames = sorted(params)
+    parnames = sorted(params, key=natural_sort_key)
+    parnames = sorted(params, key=natural_sort_key)
     buff = []
     add = buff.append
     if result is not None:


### PR DESCRIPTION
lmfit.printfuncs.fit_report is a nice way of print the results of a fit.  However, it sorts the dictionary before printing (line83):

parnames = sorted(params)

At the moment I am using parameter names ['p0', 'p1', ...., 'p10', 'p11', ...]
Consequently fit_report prints them in the order

p0
p1
p10
p11
p2

I would much rather we have an alphanumeric sort, or for the dictionary to remain ordered in the way they first got inserted in the dictionary

p0
p1
p2
p3
...
p10
p11

Is there a reason for this sorting?  Shouldn't we keep the natural ordering of the lmfit.parameters.Parameters object, or at least use alphanumeric ordering?

This PR uses alphanumeric sorting.