### PR TITLE
propagate param_hints from components to CompositeModel

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -567,6 +567,11 @@ class CompositeModel(Model):
         def _tmp(self, *args, **kws): pass
         Model.__init__(self, _tmp, **kws)
 
+        for side in (left, right):
+            prefix = side.prefix
+            for basename, hint in side.param_hints.items():
+                self.param_hints["%s%s" % (prefix, basename)] = hint
+
     def _parse_params(self):
         self._func_haskeywords = (self.left._func_haskeywords or
                                   self.right._func_haskeywords)


### PR DESCRIPTION
This is meant to address issue #172 and to propagate parameter hints from component models when making a composite model.  The fix simply copies the parameter hints from `left` and `right`, and assumes (that is, does not explicitly check) that `prefix` is used to avoid collisions of parameter names, but it happens after the check for name collisions.
