### PR TITLE
ENH: Minimizer, adding mcmc sampler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
     - conda update --yes conda
 
 install:
-    - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy pandas matplotlib dateutil nose
+    - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy pandas matplotlib dateutil nose pymc
     - python setup.py install
 
 script:

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -339,6 +339,7 @@ The Minimizer object has a few public methods:
 
 .. method:: lbfgsb(**kws)
 
+
    perform fit with L-BFGS-B algorithm.  Keywords will be passed directly to
    :func:`scipy.optimize.fmin_l_bfgs_b`.
 
@@ -353,6 +354,10 @@ The Minimizer object has a few public methods:
     +------------------+----------------+------------------------------------------------------------+
     |   maxfun         | 2000*(nvar+1)  | maximum number of function calls (nvar= # of variables)    |
     +------------------+----------------+------------------------------------------------------------+
+
+.. warning::
+
+  :meth:`lbfgsb` is deprecated.  Use :meth:`minimize` with ``method='lbfgsb'``.
 
 .. method:: fmin(**kws)
 
@@ -369,6 +374,10 @@ The Minimizer object has a few public methods:
     +------------------+----------------+------------------------------------------------------------+
     |   maxfun         | 5000*(nvar+1)  | maximum number of function calls (nvar= # of variables)    |
     +------------------+----------------+------------------------------------------------------------+
+
+.. warning::
+
+  :meth:`fmin` is deprecated.  Use :meth:`minimize` with ``method='nelder'``.
 
 
 .. method:: scalar_minimize(method='Nelder-Mead', hess=None, tol=None, **kws)
@@ -449,5 +458,3 @@ which would write out::
     [[Correlations]] (unreported correlations are <  0.100)
         C(period, shift)             =  0.797
         C(amp, decay)                =  0.582
-
-

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -524,7 +524,7 @@ class Minimizer(object):
             parameter.from_internal = lambda val: val        
             self.vars.append(p[i].value)
 
-        self.__fun_evals = 0
+        self._fun_evals = 0
 
         @pm.observed
         def likelihood(value=self.__residual(self.vars), p=p):
@@ -533,7 +533,7 @@ class Minimizer(object):
             normal_like because we expect the residuals to be normally
             distributed around zero.
             """
-            self.__fun_evals += 1
+            self._fun_evals += 1
                 
             residuals = self.__residual(p)
             zero = np.zeros_like(residuals)
@@ -565,10 +565,9 @@ class Minimizer(object):
 
         residuals = self.__residual(self.vars)
         self.ndata = residuals.size
-        self.nfev = self.__fun_evals
+        self.nfev = self._fun_evals
         self.chisqr = np.sum(residuals ** 2)
         self.redchi = self.chisqr / (self.ndata - self.nvarys)
-        del(self.__fun_evals)
         self.MDL = MDL
         self.unprepare_fit()
         

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -93,10 +93,10 @@ class test_mcmc(unittest.TestCase):
         self.objective = fcn2min
         # create a set of Parameters
         params = Parameters()
-        params.add('amp',   value= 10,  min=0, max=10)
-        params.add('decay', value= 0.1, min = 0, max=0.105)
-        params.add('shift', value= 0.0, min=-np.pi/2., max=np.pi/2)
-        params.add('omega', value= 3.0, min=1., max=3.)
+        params.add('amp',   value=10.,  min=0., max=10.)
+        params.add('decay', value=0.105, min=0., max=0.105)
+        params.add('shift', value=0.0, min=-np.pi/2., max=np.pi/2)
+        params.add('omega', value=2.99, min=1., max=3.)
         self.params = params
 
         self.mini = Minimizer(self.objective, self.params,
@@ -105,12 +105,18 @@ class test_mcmc(unittest.TestCase):
     def test_mcmc(self):
         if not HAS_PYMC:
             return True
+                
+        params = self.mini.params
         np.random.seed(123456)
         self.mini.mcmc(samples=5000, burn=1000, thin=10)
         mc_fit_params = self.mini.params
-        # test that fitted parameters are within tolerance.
+        # test that fitted parameters are within tolerance of the lM values
         values = mc_fit_params.valuesdict().values()
-        assert_allclose(values, [4.97, 0.025, -0.1, 2.0], atol=0.01)
+
+        self.mini.minimize()
+        LM_fit_params = self.mini.params
+        LM_values = LM_fit_params.valuesdict().values()
+        assert_allclose(values, LM_values, atol=0.06)
         
         # test that stderrors are similar to those obtained from LM.
         self.mini.minimize()
@@ -118,7 +124,7 @@ class test_mcmc(unittest.TestCase):
         
         for par in mc_fit_params:
             assert_allclose(mc_fit_params[par].stderr,
-                            LM_fit_params[par].stderr, atol=0.01)
+                            LM_fit_params[par].stderr, atol=0.02)
 
 def test_lbfgsb():
     p_true = Parameters()

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -9,6 +9,11 @@ from numpy import pi
 import unittest
 import nose
 from nose import SkipTest
+try:
+    import pymc as pm
+    HAS_PYMC = True
+except ImportError:
+    HAS_PYMC = False
 
 def check(para, real_val, sig=3):
     err = abs(para.value - real_val)
@@ -95,6 +100,8 @@ class test_mcmc(unittest.TestCase):
                               fcn_args=(self.x, self.data))
 
     def test_mcmc(self):
+        if not HAS_PYMC:
+            return True
         np.random.seed(123456)
         self.mini.mcmc(samples=5000, burn=1000, thin=10)
         mc_fit_params = self.mini.params


### PR DESCRIPTION
My attempt at adding an MCMC sampler to lmfit.Minimizer.  MCMC is a way of sampling the posterior distribution for a parameter set.    Once the sampler finishes running the Minimizer.params attribute is updated using the statistics of the MCMC samples.  The mean of a parameter trace gives the 'fitted value' and the SD gives the parameter uncertainty.  You can work out the correlations as well.  The mcmc method returns the sampler instance, from which you can get a lot of extra information.  It's worth reading up from: http://pymc-devs.github.io/pymc/ to learn what kind of information you can extract from the sampler.