### PR TITLE
Minimizer.params is always the same instance as the params used to construct the Minimizer, closes #174.

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -392,7 +392,6 @@ class Minimizer(object):
         removes ast compilations of constraint expressions
         """
         self.__prepared = False
-        self.params = deepcopy(self.params)
         for par in self.params.values():
             if hasattr(par, 'ast'):
                 delattr(par, 'ast')
@@ -814,4 +813,8 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     fitter = Minimizer(fcn, params, fcn_args=args, fcn_kws=kws,
                        iter_cb=iter_cb, scale_covar=scale_covar, **fit_kws)
     fitter.minimize(method=method)
+
+    params_copy = deepcopy(fitter.params)
+    fitter.params = params_copy
     return fitter
+

--- a/tests/test_copy_params.py
+++ b/tests/test_copy_params.py
@@ -22,7 +22,7 @@ class test_copy_params(unittest.TestCase):
         return (data - model)
 
     def params_values(self, params):
-        return params.valuesdict().values()
+        return np.asfarray(params.valuesdict().values())
 
     def test_copy_params(self):
         # checking output for gh-#56

--- a/tests/test_copy_params.py
+++ b/tests/test_copy_params.py
@@ -22,7 +22,7 @@ class test_copy_params(unittest.TestCase):
         return (data - model)
 
     def params_values(self, params):
-        return np.asfarray(params.valuesdict().values())
+        return list(params.valuesdict().values())
 
     def test_copy_params(self):
         # checking output for gh-#56

--- a/tests/test_copy_params.py
+++ b/tests/test_copy_params.py
@@ -1,36 +1,80 @@
+"""
+Originally added for gh-#56
+"""
 import numpy as np
-from lmfit import Parameters, minimize, report_fit
+from lmfit import Parameters, minimize, report_fit, Minimizer
+import unittest
+from numpy.testing import assert_, assert_equal
 
-def get_data():
-    x = np.arange(0, 1, 0.01)
-    y1 = 1.5*np.exp(0.9*x) + np.random.normal(scale=0.001, size=len(x))
-    y2 = 2.0 + x + 1/2.*x**2 +1/3.*x**3
-    y2 = y2 + np.random.normal(scale=0.001, size=len(x))
-    return x, y1, y2
+class test_copy_params(unittest.TestCase):
+    def setUp(self):
 
-def residual(params, x, data):
-    a = params['a'].value
-    b = params['b'].value
+        self.x = np.arange(0, 1, 0.01)
+        self.y1 = 1.5 * np.exp(0.9 * self.x) + np.random.normal(scale=0.001, size=len(self.x))
+        self.y2 = 2.0 + self.x + 1/2. * self.x**2 +1/3. * self.x**3
+        self.y2 = self.y2 + np.random.normal(scale=0.001, size=len(self.x))
 
-    model = a*np.exp(b*x)
-    return (data-model)
+    def residual(self, params, x, data):
+        a = params['a'].value
+        b = params['b'].value
 
-def test_copy_params():
-    x, y1, y2 = get_data()
+        model = a * np.exp(b * x)
+        return (data - model)
 
-    params = Parameters()
-    params.add('a', value = 2.0)
-    params.add('b', value = 2.0)
+    def params_values(self, params):
+        return params.valuesdict().values()
 
-    # fit to first data set
-    out1 = minimize(residual, params, args=(x, y1))
+    def test_copy_params(self):
+        # checking output for gh-#56
+        # 1. the output.params is a different instance to the supplied params
+        # instance
+        # 2. the supplied params instance changes its values after the fit.
 
-    # fit to second data set
-    out2 = minimize(residual, params, args=(x, y2))
+        params = Parameters()
+        params.add('a', value = 2.0)
+        params.add('b', value = 2.0)
 
-    adiff = out1.params['a'].value - out2.params['a'].value
-    bdiff = out1.params['b'].value - out2.params['b'].value
+        # fit to first data set
+        out1 = minimize(self.residual, params, args=(self.x, self.y1))
 
-    assert(abs(adiff) > 1.e-2)
-    assert(abs(bdiff) > 1.e-2)
+        assert_equal(self.params_values(params),
+                     self.params_values(out1.params))
+        assert_(not params is out1)
 
+        # fit to second data set
+        out2 = minimize(self.residual, params, args=(self.x, self.y2))
+
+        assert_equal(self.params_values(params),
+                     self.params_values(out2.params))
+        assert_(not params is out2)
+        assert_(not out1 is out2)
+
+        adiff = out1.params['a'].value - out2.params['a'].value
+        bdiff = out1.params['b'].value - out2.params['b'].value
+
+        assert(abs(adiff) > 1.e-2)
+        assert(abs(bdiff) > 1.e-2)
+
+    def test_copy_params_Minimizer(self):
+        # check that the params instance supplied to construct the Minimizer
+        # object is present as Minimizer.params for the lifetime of the object
+
+        params = Parameters()
+        params.add('a', value = 2.0)
+        params.add('b', value = 2.0)
+
+        fitter = Minimizer(self.residual, params, fcn_args=(self.x, self.y1))
+
+        #checks that fitter.params is the same instance as params
+        assert_equal(self.params_values(params),
+                     self.params_values(fitter.params))
+
+        assert_(params is fitter.params)
+
+        fitter.minimize()
+
+        # checks that fitter.params is the same instance as params, after a fit.
+        # Checking that the values are the same is almost redundant.
+        assert_equal(self.params_values(params),
+                     self.params_values(fitter.params))
+        assert_(params is fitter.params)


### PR DESCRIPTION
@danielballan to kick this PR off, I've modified the test_copy_params.py file, which was added to test #56.
I've added an extra test `test_copy_params_Minimizer`, that checks if the `Minimizer.params` attribute is the same instance as the `params` object used to construct the `Minimizer` in the first place.

Without the "fix" I get the following error:

======================================================================
FAIL: test_copy_params_Minimizer (test_copy_params.test_copy_params)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/anz/Documents/Andy/programming/lmfit-py/tests/test_copy_params.py", line 80, in test_copy_params_Minimizer
    assert_(params is fitter.params)
  File "/Users/anz/Documents/Andy/programming/dev2/lib/python2.7/site-packages/numpy/testing/utils.py", line 53, in assert_
    raise AssertionError(smsg)
AssertionError

----------------------------------------------------------------------
