### PR TITLE
fixes MPLFitter NameError when ipython is installed but matplotlib isn't

### DIFF
--- a/lmfit/ui/__init__.py
+++ b/lmfit/ui/__init__.py
@@ -36,7 +36,7 @@ if has_matplotlib:
 
 if has_ipython:
     from .ipy_fitter import NotebookFitter
+    from .basefitter import MPLFitter
     BaseFitter = BaseFitter
     MPLFitter = MPLFitter
     Fitter = NotebookFitter
-


### PR DESCRIPTION
Got the following error when trying to use lmfit in an ipython session.
```
/.../venv/lib/python2.7/site-packages/lmfit/__init__.py in <module>()
     47 from .uncertainties import ufloat, correlated_values
     48
---> 49 from .ui import Fitter
     50
     51 ## versioneer code

/.../venv/lib/python2.7/site-packages/lmfit/ui/__init__.py in <module>()
     38     from .ipy_fitter import NotebookFitter
     39     BaseFitter = BaseFitter
---> 40     MPLFitter = MPLFitter
     41     Fitter = NotebookFitter
     42

NameError: name 'MPLFitter' is not defined
```