### PR TITLE
Model selection methods for ModelFit

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -7,10 +7,10 @@ A list of common questions.
 How can I fit multi-dimensional data?
 ========================================
 
-The fitting routines except data arrays that are 1 dimensional and double
+The fitting routines expect data arrays that are 1 dimensional and double
 precision.  So you need to convert the data and model (or the value
-returned by the objective function) to be one dimensional by using
-numpy's :meth:`numpy.ndarray.flatten`, for example::
+returned by the objective function) to be one dimensional.  A simple way to 
+do this is to use numpy's :meth:`numpy.ndarray.flatten`, for example::
 
     def residual(params, x, data=None):
         ....
@@ -22,8 +22,8 @@ How can I fit complex data?
 ===================================
 
 As with working with multidimensional data, you need to convert your data
-and model (or the value returned by the objective function) to be real.
-One way to do this would be to use a function like this::
+and model (or the value returned by the objective function) to be double precision
+floating point numbers. One way to do this would be to use a function like this::
 
     def realimag(array):
         return np.array([(x.real, x.imag) for x in array]).flatten()
@@ -45,3 +45,5 @@ Basically, no.  None of the minimizers in lmfit support integer
 programming.  They all (I think) assume that they can make a very small
 change to a floating point value for a parameters value and see a change in
 the value to be minimized.
+
+

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -640,6 +640,10 @@ model while the :class:`ModelFit` is the messier, more complex (but perhaps
 more useful) object that represents a fit with a set of parameters to data
 with a model.
 
+A :class:`ModelFit` object also includes basic methods for **model selection**:
+`aic`, `bic` and `lik_ratio` (see below).
+
+
 A :class:`ModelFit` has several attributes holding values for fit results,
 and several methods for working with fits.
 
@@ -687,7 +691,52 @@ These methods are all inherited from :class:`Minimize` or from
    :param show_correl:  whether to show list of sorted correlations [``True``]
    :param min_correl:   smallest correlation absolute value to show [0.1]
 
+.. method:: ModelFit.aic()
 
+    Calculate the `Akaike Information Criterion <http://en.wikipedia.org/wiki/Akaike_information_criterion>`_ (AIC) of the model fit.
+    AIC measures the relative quality of a statistical model for a given set of data.
+    AIC balances between the fit of the model to the data and the complexity of the model;
+    it can be used to prevent `overfitting <http://en.wikipedia.org/wiki/Overfitting>`_.
+    
+    AIC is computed by `AIC = n * log(rss/n) + 2k`, where `n` is the number of data points, `rss` is the sum of residuals squares, and `k` in the number of varying parameters.
+
+    AIC is used for model selection by selecting the model with the *lowest* AIC.
+    It is a relative measure and as such can only be used to compare models.
+    Compared to `BIC <http://en.wikipedia.org/wiki/Bayesian_information_criterion>`_, AIC can be considered
+    less conservative, giving less weight to model simplicity (number of parameters) than BIC.
+
+.. method:: ModelFit.bic()
+
+    Calculate the `Bayesian Information Criterion <http://en.wikipedia.org/wiki/Bayesian_information_criterion>`_ (BIC) of the model fit.
+    BIC measures the relative quality of a statistical model for a given set of data.
+    BIC balances between the fit of the model to the data and the complexity of the model;
+    it can be used to prevent `overfitting <http://en.wikipedia.org/wiki/Overfitting>`_.
+
+    BIC is computed by `BIC = n * log(rss/n) + log(n) k`, where `n` is the number of data points, `rss` is the sum of residuals squares, and `k` in the number of varying parameters.
+
+    BIC is used for model selection by selecting the model with the *lowest* BIC.
+    BIC is a relative measure and as such can only be used to compare models.
+    Compared to `AIC <http://en.wikipedia.org/wiki/Akaike_information_criterion>`_, BIC can be considered
+    more conservative, giving more weight to model simplicity (number of parameters) than AIC.
+
+.. method:: ModelFit.lik_ratio(other)
+
+    Calculate a `likelihood ratio test <http://en.wikipedia.org/wiki/Likelihood-ratio_test>`_ for two model fits.
+
+    The likelihood ratio test is performed on two nested models 
+    (`self` is nested in `other`; that is, some of the parameters of `other` are fixed in `self`).
+
+    The null hypothesis of the test is that the nested model is true. 
+    The method returns the p-value of the test - 
+    the likelihood of getting the model fits we got, given the null hypothesis and the data.
+
+    The test calculates the statistic `D = -2 log(lik0/lik1)`.
+    `lik0` and `lik1` are the likelihoods of the nested and the nesting models,
+    which are calculated as the reciprocal of the residual sum of squares.
+
+    By Wilks's theorem, `D` is approximately `chi-square distributed <http://en.wikipedia.org/wiki/Chi-squared_distribution>`_ with `df` degrees of freedom, 
+    where `df` is the difference in number of parameters between the models; 
+    this allows the approximation of the p-value.  
 
 
 :class:`ModelFit` attributes

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -698,7 +698,7 @@ These methods are all inherited from :class:`Minimize` or from
     AIC balances between the fit of the model to the data and the complexity of the model;
     it can be used to prevent `overfitting <http://en.wikipedia.org/wiki/Overfitting>`_.
     
-    AIC is computed by `AIC = n * log(rss/n) + 2k`, where `n` is the number of data points, `rss` is the sum of residuals squares, and `k` in the number of varying parameters.
+    AIC is computed by `AIC = n * log(rss/n) + 2k`, where `n` is the number of data points, `rss` is the sum of residuals squares, and `k` in the number of estimated parameters.
 
     AIC is used for model selection by selecting the model with the *lowest* AIC.
     It is a relative measure and as such can only be used to compare models.
@@ -712,7 +712,7 @@ These methods are all inherited from :class:`Minimize` or from
     BIC balances between the fit of the model to the data and the complexity of the model;
     it can be used to prevent `overfitting <http://en.wikipedia.org/wiki/Overfitting>`_.
 
-    BIC is computed by `BIC = n * log(rss/n) + log(n) k`, where `n` is the number of data points, `rss` is the sum of residuals squares, and `k` in the number of varying parameters.
+    BIC is computed by `BIC = n * log(rss/n) + log(n) k`, where `n` is the number of data points, `rss` is the sum of residuals squares, and `k` in the number of estimated parameters.
 
     BIC is used for model selection by selecting the model with the *lowest* BIC.
     BIC is a relative measure and as such can only be used to compare models.
@@ -724,7 +724,8 @@ These methods are all inherited from :class:`Minimize` or from
     Calculate a `likelihood ratio test <http://en.wikipedia.org/wiki/Likelihood-ratio_test>`_ for two model fits.
 
     The likelihood ratio test is performed on two nested models 
-    (`self` is nested in `other`; that is, some of the parameters of `other` are fixed in `self`).
+    (`self` is nested in `other`; that is, some of the parameters of `other` are fixed in `self` --
+    the estimated paramters of `self` are a subset of the estimated parameters of `other`).
 
     The null hypothesis of the test is that the nested model is true. 
     The method returns the p-value of the test - 
@@ -734,7 +735,7 @@ These methods are all inherited from :class:`Minimize` or from
     `lik0` and `lik1` are the likelihoods of the nested and the nesting models,
     which are calculated as the reciprocal of the residual sum of squares.
 
-    By Wilks's theorem, `D` is approximately `chi-square distributed <http://en.wikipedia.org/wiki/Chi-squared_distribution>`_ with `df` degrees of freedom, 
+    By Wilks's theorem, `D` is asymptotically `chi-square distributed <http://en.wikipedia.org/wiki/Chi-squared_distribution>`_ with `df` degrees of freedom, 
     where `df` is the difference in number of parameters between the models; 
     this allows the approximation of the p-value.  
 

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -995,10 +995,18 @@ class ModelFit(Minimizer):
         return fig
 
     def aic(self):
-        """calculate and return the AIC for a ModelFit.
+        """Calculate and return the AIC for a ModelFit.
         AIC is Akaike information criterion, a measure of the relative quality of a statistical model for a given set of data.
         It is computed as `n * log(rss/n) + 2k`, where `n` is the number of data points, `rss` is the sum of residuals squares, 
         and k in the number of varying parameters.
+        
+        Returns
+        -------
+        aic : float
+
+        See also
+        --------
+        http://en.wikipedia.org/wiki/Akaike_information_criterion
         """
         rss = self.chisqr
         n = self.ndata
@@ -1006,11 +1014,19 @@ class ModelFit(Minimizer):
         return n * np.log(rss / n) + 2 * k
 
     def bic(self):
-        """calculate and return the BIC for a ModelFit.
+        """Calculate and return the BIC for a ModelFit.
         BIC is Bayesian information criterion, a measure of the relative quality of a statistical model for a given set of data.
         It is computed as `n * log(rss/n) + log(n) k`, where `n` is the number of data points, `rss` is the sum of residuals squares, 
         and k in the number of varying parameters. 
         It is closely related to AIC but gives a larger penalty to the number of paramters in the model.
+
+        Returns
+        -------
+        bic : float
+
+        See also
+        --------
+        http://en.wikipedia.org/wiki/Bayesian_information_criterion
         """
         rss = self.chisqr
         n = self.ndata
@@ -1018,8 +1034,8 @@ class ModelFit(Minimizer):
         return n * np.log(rss / n) + np.log(n) * k
 
 
-    def likelihood_ratio_test(self, other):
-        """calculate a likelihood ratio test for two model fits (self and other).
+    def lik_ratio(self, other):
+        """Calculate a likelihood ratio test for two model fits (self and other).
 
         The likelihood ratio test is performed on two nested models 
         (self is nested in other; that is, some of the parameters of other are fixed in self).

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1004,3 +1004,15 @@ class ModelFit(Minimizer):
         n = self.ndata
         k = self.nvarys
         return n * np.log(rss / n) + 2 * k
+
+    def bic(self):
+        """calculate and return the BIC for a ModelFit.
+        BIC is Bayesian information criterion, a measure of the relative quality of a statistical model for a given set of data.
+        It is computed as `n * log(rss/n) + log(n) k`, where `n` is the number of data points, `rss` is the sum of residuals squares, 
+        and k in the number of varying parameters. 
+        It is closely related to AIC but gives a larger penalty to the number of paramters in the model.
+        """
+        rss = np.float((self.residual**2).sum())
+        n = self.ndata
+        k = self.nvarys
+        return n * np.log(rss / n) + np.log(n) * k

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -993,3 +993,14 @@ class ModelFit(Minimizer):
                             fit_kws=fit_kws, ax_kws=ax_res_kws)
 
         return fig
+
+    def aic(self):
+        """calculate and return the AIC for a ModelFit.
+        AIC is Akaike information criterion, a measure of the relative quality of a statistical model for a given set of data.
+        It is computed as `n * log(rss/n) + 2k`, where `n` is the number of data points, `rss` is the sum of residuals squares, 
+        and k in the number of varying parameters.
+        """
+        rss = np.float((self.residual**2).sum())
+        n = self.ndata
+        k = self.nvarys
+        return n * np.log(rss / n) + 2 * k

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1000,7 +1000,7 @@ class ModelFit(Minimizer):
         It is computed as `n * log(rss/n) + 2k`, where `n` is the number of data points, `rss` is the sum of residuals squares, 
         and k in the number of varying parameters.
         """
-        rss = np.float((self.residual**2).sum())
+        rss = self.chisqr
         n = self.ndata
         k = self.nvarys
         return n * np.log(rss / n) + 2 * k
@@ -1012,7 +1012,63 @@ class ModelFit(Minimizer):
         and k in the number of varying parameters. 
         It is closely related to AIC but gives a larger penalty to the number of paramters in the model.
         """
-        rss = np.float((self.residual**2).sum())
+        rss = self.chisqr
         n = self.ndata
         k = self.nvarys
         return n * np.log(rss / n) + np.log(n) * k
+
+
+    def likelihood_ratio_test(self, other):
+        """calculate a likelihood ratio test for two model fits (self and other).
+
+        The likelihood ratio test is performed on two nested models 
+        (self is nested in other; that is, some of the parameters of other are fixed in self).
+        The test is used to calculate the probability that, given the null hypothesis that the nested model is true,
+        fitting both models to the same data produces the model fits given in the input to this function.
+        
+        The test uses the formula:
+        `D = -2 log(lik0/lik1)` 
+        where `D` is approximately chisquare distributed with `df` degrees of freedom, where `df` is the difference 
+        in number of parameters between the models. This approximation is due to Wilks's theorem and depends on the 
+        number of data points.
+
+
+        Parameters
+        ----------
+        self, other : lmfit.ModelFit
+            ModelFit instances. self is the nested /restricted / null model.
+
+        Returns
+        -------
+        pvalue : float
+            The pvalue of the test, specifying the probability of getting the specified input given the data.
+        D: float
+            The test statistic, chisquare distributed with df degrees of freedom when the number of data points is large.
+        df: int
+            The respective degrees of freedom, calculated as the difference in number of paramaters of the input models.
+        
+        Notes
+        -----
+        Model likelihood is calculated as the reciprocal of the residual sum of squares of the model.
+        Therefore the formula used is
+        `D = -2 log(rss1/rss0)`
+
+        See Also
+        --------
+        http://en.wikipedia.org/wiki/Likelihood-ratio_test
+
+        """
+        n0 = self.ndata
+        k0 = self.nvarys
+        chisqr0 = self.chisqr # residual sum square - see minimizer.py
+        assert chisqr0 > 0
+        n1 = other.ndata 
+        k1 = other.nvarys
+        chisqr1 = other.chisqr
+        assert chisqr1 > 0
+
+        lam = chisqr1 / chisqr0 # chisqr ~ 1/lik
+        assert 0 <= lam <= 1
+        D = -2 * np.log(lam)
+        df = k1 - k0
+        return stats.chi2.sf(D, df), D, df

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -160,6 +160,22 @@ class CommonTests(object):
         # to be overridden for models that do not accept indep vars
         pass
 
+    def test_aic(self):
+        model = self.model
+
+        # Pass Parameters object.
+        params = model.make_params(**self.guess())
+        result = model.fit(self.data, params, x=self.x)
+        aic    = result.aic()
+        self.assertTrue(aic < 0) # aic must be negative
+
+        # Pass extra unused Parameter.
+        params.add("unused_param", value=1.0, vary=True)
+        result    = model.fit(self.data, params, x=self.x)
+        aic_extra = result.aic()
+        self.assertTrue(aic_extra < 0)   # aic must be negative
+        self.assertTrue(aic < aic_extra) # the extra param should lower the aic
+
 
 class TestUserDefiniedModel(CommonTests, unittest.TestCase):
     # mainly aimed at checking that the API does what it says it does

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -166,12 +166,12 @@ class CommonTests(object):
         # Pass Parameters object.
         params = model.make_params(**self.guess())
         result = model.fit(self.data, params, x=self.x)
-        aic    = result.aic()
+        aic = result.aic()
         self.assertTrue(aic < 0) # aic must be negative
 
         # Pass extra unused Parameter.
         params.add("unused_param", value=1.0, vary=True)
-        result    = model.fit(self.data, params, x=self.x)
+        result = model.fit(self.data, params, x=self.x)
         aic_extra = result.aic()
         self.assertTrue(aic_extra < 0)   # aic must be negative
         self.assertTrue(aic < aic_extra) # the extra param should lower the aic

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -177,6 +177,29 @@ class CommonTests(object):
         self.assertTrue(aic < aic_extra) # the extra param should lower the aic
 
 
+    def test_bic(self):
+        model = self.model
+
+        # Pass Parameters object.
+        params = model.make_params(**self.guess())
+        result = model.fit(self.data, params, x=self.x)
+        bic = result.bic()
+        self.assertTrue(bic < 0) # aic must be negative
+
+        # Compare to AIC
+        aic = result.aic()
+        self.assertTrue(aic < bic) # aic should be lower than bic
+
+        # Pass extra unused Parameter.
+        params.add("unused_param", value=1.0, vary=True)
+        result = model.fit(self.data, params, x=self.x)
+        bic_extra = result.bic()
+        self.assertTrue(bic_extra < 0)   # bic must be negative
+        self.assertTrue(bic < bic_extra) # the extra param should lower the bic
+
+
+
+
 class TestUserDefiniedModel(CommonTests, unittest.TestCase):
     # mainly aimed at checking that the API does what it says it does
     # and raises the right exceptions or warnings when things are not right


### PR DESCRIPTION
I added a method called `aic` to `ModelFit`.
The method calculates and returns the AIC of a model fit based on the formula:
```
n log(rss/n) + 2k
```
where n is the number of data points, rss is the sum squares of the residuals and k is the number of varying parameters.
I included a simple test (`test_aic` in `test_model.py`). 
I ran the tests with `nosetests` and got `OK (SKIP=2)`.