### PR TITLE
Added __division __ to lineshapes, fixes a bug with expgaussian.

### DIFF
--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -2,6 +2,7 @@
 """
 basic model line shapes and distribution functions
 """
+from __future__ import division
 from numpy import (pi, log, exp, sqrt, arctan, cos, where)
 from numpy.testing import assert_allclose
 


### PR DESCRIPTION
One could also change the `/2` to `/2.`, but this is better for py3.