### PR TITLE
Limit deepcopy

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -45,7 +45,11 @@ class Parameters(OrderedDict):
     def __deepcopy__(self, memo):
         _pars = Parameters()
         for key, val in self._asteval.symtable.items():
-            _pars._asteval.symtable[key] = deepcopy(val)
+            if key not in self._asteval.no_deepcopy:
+                try:
+                    _pars._asteval.symtable[key] = deepcopy(val, memo)
+                except TypeError:
+                    pass
         for key, par in self.items():
             if isinstance(par, Parameter):
                 name = par.name

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -46,10 +46,7 @@ class Parameters(OrderedDict):
         _pars = Parameters()
         for key, val in self._asteval.symtable.items():
             if key not in self._asteval.no_deepcopy:
-                try:
-                    _pars._asteval.symtable[key] = deepcopy(val, memo)
-                except TypeError:
-                    pass
+                _pars._asteval.symtable[key] = deepcopy(val, memo)
         for key, par in self.items():
             if isinstance(par, Parameter):
                 name = par.name


### PR DESCRIPTION
This *should* address #221, but I think it will need careful testing.

In this approach, asteval keeps a list of items to *not* try to deepcopy() (stuff it will be able to import from Python or numpy later), and Parameters.__deepcopy__() uses this list.
