### PR TITLE
Parameter set() fixes

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -330,6 +330,8 @@ class Parameter(object):
             Mathematical expression used to constrain the value during the fit.
             To remove a constraint you must supply an empty string.
         """
+
+        self.__set_expression(expr)
         if value is not None:
             self._val = value
         if vary is not None:
@@ -338,8 +340,6 @@ class Parameter(object):
             self.min = min
         if max is not None:
             self.max = max
-        if expr is not None:
-            self.expr = expr
 
     def _init_bounds(self):
         """make sure initial bounds are self-consistent"""
@@ -442,8 +442,10 @@ class Parameter(object):
                 pass
         if not self.vary and self._expr is None:
             return self._val
-        if not hasattr(self, '_expr_eval'):  self._expr_eval = None
-        if not hasattr(self, '_expr_ast'):   self._expr_ast = None
+        if not hasattr(self, '_expr_eval'):
+            self._expr_eval = None
+        if not hasattr(self, '_expr_ast'):
+            self._expr_ast = None
         if self._expr_ast is not None and self._expr_eval is not None:
             self._val = self._expr_eval(self._expr_ast)
             check_ast_errors(self._expr_eval)
@@ -496,12 +498,16 @@ class Parameter(object):
         The mathematical expression used to constrain the value during the fit.
         To remove a constraint you must supply an empty string.
         """
+        self.__set_expression(val)
+
+    def __set_expression(self, val):
         if val == '':
             val = None
         self._expr = val
         if val is not None:
             self.vary = False
         if not hasattr(self, '_expr_eval'):  self._expr_eval = None
+        if val is None: self._expr_ast = None
         if val is not None and self._expr_eval is not None:
             self._expr_ast = self._expr_eval.parse(val)
             check_ast_errors(self._expr_eval)

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -364,6 +364,9 @@ class Parameter(object):
         """set state for pickle"""
         (self.name, self.value, self.vary, self.expr, self.min,
          self.max, self.stderr, self.correl, self.init_value) = state
+        self._expr_ast = None
+        self._expr_eval = None
+        self._expr_deps = []
         self._init_bounds()
 
     def __repr__(self):

--- a/tests/test_params_set.py
+++ b/tests/test_params_set.py
@@ -1,0 +1,41 @@
+import numpy as np
+from numpy.testing import assert_allclose
+from lmfit import Parameters, minimize, report_fit
+from lmfit.lineshapes import gaussian
+from lmfit.models import VoigtModel
+
+def test_param_set():
+    np.random.seed(2015)
+    x = np.arange(0, 20, 0.05)
+    y = gaussian(x, amplitude=15.43, center=4.5, sigma=2.13)
+    y = y + 0.05 - 0.01*x + np.random.normal(scale=0.03, size=len(x))
+
+    model  = VoigtModel()
+    params = model.guess(y, x=x)
+
+    # test #1:  gamma is constrained to equal sigma
+    sigval = params['gamma'].value
+    assert(params['gamma'].expr == 'sigma')
+    assert_allclose(params['gamma'].value, sigval, 1e-4, 1e-4, '', True)
+
+    # test #2: explicitly setting a param value should work, even when
+    #          it had been an expression.  The value will be left as fixed
+    gamval = 0.87543
+    params['gamma'].set(value=gamval)
+    assert(params['gamma'].expr is None)
+    assert(not params['gamma'].vary)
+    assert_allclose(params['gamma'].value, gamval, 1e-4, 1e-4, '', True)
+
+    # test #3: explicitly setting an expression should work
+    params['gamma'].set(expr='sigma/2.0')
+    assert(params['gamma'].expr is not None)
+    assert(not params['gamma'].vary)
+    assert_allclose(params['gamma'].value, sigval/2.0, 1e-4, 1e-4, '', True)
+
+    # test #4: explicitly setting a param value WITH vary=True
+    #          will set it to be variable
+    gamval = 0.7777
+    params['gamma'].set(value=gamval, vary=True)
+    assert(params['gamma'].expr is None)
+    assert(params['gamma'].vary)
+    assert_allclose(params['gamma'].value, gamval, 1e-4, 1e-4, '', True)


### PR DESCRIPTION
This addresses issue #242, so that `Parameter.set()` works to set parameter attributes, even when already defined to have an `expr`.   It works in preliminary tests, but actual nose tests should be added.

It also adds the explicit setting of `_expr_ast=None` etc in order to address a problem with pickling and IPython uses, Issue #237  