### PR TITLE
fix pseudo-voigt definition as per github issue #229

### DIFF
--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -65,8 +65,8 @@ parameter ``fwhm`` is included.
   f(x; A, \mu, \sigma) = \frac{A}{\sigma\sqrt{2\pi}} e^{[{-{(x-\mu)^2}/{{2\sigma}^2}}]}
 
 where the parameter ``amplitude`` corresponds to :math:`A`, ``center`` to
-:math:`\mu`, and ``sigma`` to :math:`\sigma`.  The Full-Width at
-Half-Maximum is :math:`2\sigma\sqrt{2\ln{2}}`, approximately
+:math:`\mu`, and ``sigma`` to :math:`\sigma`.  The full width at
+half maximum is :math:`2\sigma\sqrt{2\ln{2}}`, approximately
 :math:`2.3548\sigma`
 
 
@@ -85,8 +85,8 @@ parameter ``fwhm`` is included.
   f(x; A, \mu, \sigma) = \frac{A}{\pi} \big[\frac{\sigma}{(x - \mu)^2 + \sigma^2}\big]
 
 where the parameter ``amplitude`` corresponds to :math:`A`, ``center`` to
-:math:`\mu`, and ``sigma`` to :math:`\sigma`.  The Full-Width at
-Half-Maximum is :math:`2\sigma`.
+:math:`\mu`, and ``sigma`` to :math:`\sigma`.  The full width at
+half maximum is :math:`2\sigma`.
 
 
 :class:`VoigtModel`
@@ -132,18 +132,20 @@ the full width at half maximum is approximately :math:`3.6013\sigma`.
 a model based on a `pseudo-Voigt distribution function
 <http://en.wikipedia.org/wiki/Voigt_profile#Pseudo-Voigt_Approximation>`_,
 which is a weighted sum of a Gaussian and Lorentzian distribution functions
-with the same values for ``amplitude`` (:math:`A`), ``center`` (:math:`\mu`)
-and ``sigma`` (:math:`\sigma`), and a parameter ``fraction`` (:math:`\alpha`)
-in
+with that share values for ``amplitude`` (:math:`A`), ``center`` (:math:`\mu`)
+and full width at half maximum (and so have  constrained values of
+``sigma`` (:math:`\sigma`).  A parameter ``fraction`` (:math:`\alpha`)
+controls the relative weight of the Gaussian and Lorentzian components,
+giving the full definition of
 
 .. math::
 
-  f(x; A, \mu, \sigma, \alpha) = (1-\alpha)\frac{A}{\pi}
-  \big[\frac{\sigma}{(x - \mu)^2 + \sigma^2}\big] + \frac{\alpha A}{\pi} \big[\frac{\sigma}{(x - \mu)^2 + \sigma^2}\big]
+  f(x; A, \mu, \sigma, \alpha) = \frac{(1-\alpha)A}{\sigma_g\sqrt{2\pi}} e^{[{-{(x-\mu)^2}/{{2\sigma_g}^2}}]}
+ + \frac{\alpha A}{\pi} \big[\frac{\sigma}{(x - \mu)^2 + \sigma^2}\big]
 
-
-The :meth:`guess` function always gives a starting
-value for ``fraction`` of 0.5
+where :math:`\sigma_g = {\sigma}/{\sqrt{2\ln{2}}}` so that the full width
+at half maximum of each component and of the sum is :math:`2\sigma`. The
+:meth:`guess` function always sets the starting value for ``fraction`` at 0.5.
 
 :class:`Pearson7Model`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -45,10 +45,18 @@ def voigt(x, amplitude=1.0, center=0.0, sigma=1.0, gamma=None):
 def pvoigt(x, amplitude=1.0, center=0.0, sigma=1.0, fraction=0.5):
     """1 dimensional pseudo-voigt:
     pvoigt(x, amplitude, center, sigma, fraction)
-       = amplitude*(1-fraction)*gaussion(x, center,sigma) +
+       = amplitude*(1-fraction)*gaussion(x, center, sigma_g) +
          amplitude*fraction*lorentzian(x, center, sigma)
+
+    where sigma_g (the sigma for the Gaussian component) is
+
+        sigma_g = sigma / sqrt(2*log(2)) ~= sigma / 1.17741
+
+    so that the Gaussian and Lorentzian components have the
+    same FWHM of 2*sigma.
     """
-    return ((1-fraction)*gaussian(x, amplitude, center, sigma) +
+    sigma_g = sigma / sqrt(2*log2)
+    return ((1-fraction)*gaussian(x, amplitude, center, sigma_g) +
                fraction*lorentzian(x, amplitude, center, sigma))
 
 def pearson7(x, amplitude=1.0, center=0.0, sigma=1.0, expon=1.0):

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -192,9 +192,11 @@ class VoigtModel(Model):
 
 class PseudoVoigtModel(Model):
     __doc__ = pvoigt.__doc__ + COMMON_DOC if pvoigt.__doc__ else ""
+    fwhm_factor = 2.0
     def __init__(self, *args, **kwargs):
         super(PseudoVoigtModel, self).__init__(pvoigt, *args, **kwargs)
         self.set_param_hint('fraction', value=0.5)
+        self.set_param_hint('fwhm',  expr=fwhm_expr(self))
 
     def guess(self, data, x=None, negative=False, **kwargs):
         pars = guess_from_peak(self, data, x, negative, ampscale=1.25)


### PR DESCRIPTION
simple change to pseudo-voigt definition as per #229, so that the FWHM of the Gaussian and Lorentzian lineshapes are equal.  The `sigma` parameter is used un-altered for the Lorentzian, but altered for the Gaussian component.  The resulting FWHM of the sum is `2*sigma`.
