### PR TITLE
 allow iteration callback iter_cb to abort fit

### DIFF
--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -38,7 +38,7 @@ details on writing the objective.
    :type  method:  string (default ``leastsq``)
    :param scale_covar:  whether to automatically scale covariance matrix (``leastsq`` only)
    :type  scale_covar:  bool (default ``True``)
-   :param iter_cb:  function to be called at each fit iteration
+   :param iter_cb:  function to be called at each fit iteration. See :ref:`fit-itercb-label` for details.
    :type  iter_cb:  callable or ``None``
    :param fit_kws:  dictionary to pass to :func:`scipy.optimize.leastsq` or :func:`scipy.optimize.minimize`.
    :type  fit_kws:  dict
@@ -51,11 +51,6 @@ details on writing the objective.
    contained in the returned :class:`MinimizerResult`.  See
    :ref:`fit-results-label` for further details.
 
-   If provided, the ``iter_cb`` function should take arguments of ``params,
-   iter, resid, *args, **kws``, where ``params`` will have the current
-   parameter values, ``iter`` the iteration, ``resid`` the current residual
-   array, and ``*args`` and ``**kws`` as passed to the objective function.
-
    For clarity, it should be emphasized that this function is simply a
    wrapper around :class:`Minimizer` that runs a single fit, implemented as::
 
@@ -65,7 +60,6 @@ details on writing the objective.
 
 
 ..  _fit-func-label:
-
 
 
 Writing a Fitting Function
@@ -418,6 +412,40 @@ Akaike information criterion, and/or Bayesian information criterion.
 Generally, the Bayesian information criterion is considered themost
 conservative of these statistics.
 
+..  _fit-itercb-label:
+
+
+Using a Iteration Callback Function
+====================================
+
+An iteration callback function is a function to be called at each
+iteration, just after the objective function is called.  The iteration
+callback allows user-supplied code to be run at each iteration, and can be
+used to abort a fit.
+
+.. function:: iter_cb(params, iter, resid, *args, **kws):
+
+   user-supplied function to be run at each iteration
+
+   :param params: parameters.
+   :type  params: :class:`Parameters`.
+   :param iter:   iteration number
+   :type  iter:   integer
+   :param resid:  residual array.
+   :type  resid:  ndarray
+   :param args:  positional arguments.  Must match ``args`` argument to :func:`minimize`
+   :param kws:   keyword arguments.  Must match ``kws`` argument to :func:`minimize`
+   :return:      residual array (generally data-model) to be minimized in the least-squares sense.
+   :rtype:    ``None`` for normal behavior, any value like ``True`` to abort fit.
+
+
+Normally, the iteration callback would have no return value or return
+``None``.  To abort a fit, have this function return a value that is
+``True`` (including any non-zero integer).  The fit will also abort if any
+exception is raised in the iteration callback. When a fit is aborted this
+way, the parameters will have the values from the last iteration.  The fit
+statistics are not likely to be meaningful, and uncertainties will not be computed.
+
 
 .. module:: Minimizer
 
@@ -443,7 +471,7 @@ For full control of the fitting process, you'll want to create a
    :type  fcn_args: tuple
    :param fcn_kws:  dictionary to pass to the residual function as keyword arguments.
    :type  fcn_kws:  dict
-   :param iter_cb:  function to be called at each fit iteration
+   :param iter_cb:  function to be called at each fit iteration.  See :ref:`fit-itercb-label` for details.
    :type  iter_cb:  callable or ``None``
    :param scale_covar:  flag for automatically scaling covariance matrix and uncertainties to reduced chi-square (``leastsq`` only)
    :type  scale_cover:  bool (default ``True``).

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -257,7 +257,7 @@ specifying one or more independent variables.
    :type  method:  string (default ``leastsq``)
    :param scale_covar:  whether to automatically scale covariance matrix (``leastsq`` only)
    :type  scale_covar:  bool (default ``True``)
-   :param iter_cb:  function to be called at each fit iteration
+   :param iter_cb:  function to be called at each fit iteration. See :ref:`fit-itercb-label` for details.
    :type  iter_cb:  callable or ``None``
    :param verbose:  print a message when a new parameter is created due to a *hint*
    :type  verbose:  bool (default ``True``)
@@ -865,7 +865,7 @@ These methods are all inherited from :class:`Minimize` or from
    must take take arguments of ``params, iter, resid, *args, **kws``, where
    ``params`` will have the current parameter values, ``iter`` the
    iteration, ``resid`` the current residual array, and ``*args`` and
-   ``**kws`` as passed to the objective function.
+   ``**kws`` as passed to the objective function.  See :ref:`fit-itercb-label`.
 
 .. attribute:: jacfcn
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -256,12 +256,9 @@ class Minimizer(object):
 
         out = self.userfcn(params, *self.userargs, **self.userkws)
         if callable(self.iter_cb):
-            try:
-                abort = self.iter_cb(params, self.result.nfev, out,
-                                     *self.userargs, **self.userkws)
-            except:
-                abort = True
-        self._abort = self._abort or abort
+            abort = self.iter_cb(params, self.result.nfev, out,
+                                 *self.userargs, **self.userkws)
+            self._abort = self._abort or abort
         if not self._abort:
             return np.asarray(out).ravel()
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -214,6 +214,7 @@ class Minimizer(object):
         self.nfree = 0
         self.ndata = 0
         self.ier = 0
+        self._abort = False
         self.success = True
         self.errorbars = False
         self.message = None
@@ -246,6 +247,8 @@ class Minimizer(object):
         calculate the residual.
         """
         # set parameter values
+        if self._abort:
+            return None
         params = self.result.params
         for name, val in zip(self.result.var_names, fvars):
             params[name].value = params[name].from_internal(val)
@@ -253,9 +256,14 @@ class Minimizer(object):
 
         out = self.userfcn(params, *self.userargs, **self.userkws)
         if callable(self.iter_cb):
-            self.iter_cb(params, self.result.nfev, out,
-                         *self.userargs, **self.userkws)
-        return np.asarray(out).ravel()
+            try:
+                abort = self.iter_cb(params, self.result.nfev, out,
+                                     *self.userargs, **self.userkws)
+            except:
+                abort = True
+        self._abort = self._abort or abort
+        if not self._abort:
+            return np.asarray(out).ravel()
 
     def __jacobian(self, fvars):
         """
@@ -332,7 +340,7 @@ class Minimizer(object):
         result.params.update_constraints()
         result.nfev = 0
         result.errorbars = False
-
+        result.aborted = False
         for name, par in self.result.params.items():
             par.stderr = None
             par.correl = None
@@ -472,6 +480,9 @@ class Minimizer(object):
         else:
             ret = scipy_minimize(self.penalty, vars, **fmin_kws)
 
+        result.aborted = self._abort
+        self._abort = False
+
         for attr in dir(ret):
             if not attr.startswith('_'):
                 setattr(result, attr, getattr(ret, attr))
@@ -537,14 +548,18 @@ class Minimizer(object):
 
         lsout = scipy_leastsq(self.__residual, vars, **lskws)
         _best, _cov, infodict, errmsg, ier = lsout
+        result.aborted = self._abort
+        self._abort = False
 
         result.residual = resid = infodict['fvec']
         result.ier = ier
         result.lmdif_message = errmsg
         result.message = 'Fit succeeded.'
         result.success = ier in [1, 2, 3, 4]
-
-        if ier == 0:
+        if result.aborted:
+            result.message = 'Fit aborted by user callback.'
+            result.success = False
+        elif ier == 0:
             result.message = 'Invalid Input Parameters.'
         elif ier == 5:
             result.message = self.err_maxfev % lskws['maxfev']
@@ -596,8 +611,9 @@ class Minimizer(object):
             has_expr = has_expr or par.expr is not None
 
         # self.errorbars = error bars were successfully estimated
-        result.errorbars = result.covar is not None
-
+        result.errorbars = (result.covar is not None)
+        if result.aborted:
+            result.errorbars = False
         if result.errorbars:
             if self.scale_covar:
                 result.covar *= result.redchi

--- a/tests/test_itercb.py
+++ b/tests/test_itercb.py
@@ -1,0 +1,29 @@
+import numpy as np
+from lmfit import Parameters, minimize, report_fit
+from lmfit.models import LinearModel, GaussianModel
+from lmfit.lineshapes import gaussian
+
+def per_iteration(pars, iter, resid, *args, **kws):
+    """iteration callback, will abort at iteration 23
+    """
+    # print( iter, ', '.join(["%s=%.4f" % (p.name, p.value) for p in pars.values()]))
+    return iter == 23
+
+def test_itercb():
+    x = np.linspace(0, 20, 401)
+    y = gaussian(x, amplitude=24.56, center=7.6543, sigma=1.23)
+    y = y  - .20*x + 3.333 + np.random.normal(scale=0.23,  size=len(x))
+    mod = GaussianModel(prefix='peak_') + LinearModel(prefix='bkg_')
+
+    pars = mod.make_params(peak_amplitude=21.0,
+                           peak_center=7.0,
+                           peak_sigma=2.0,
+                           bkg_intercept=2,
+                           bkg_slope=0.0)
+
+    out = mod.fit(y, pars, x=x, iter_cb=per_iteration)
+
+    assert(out.nfev == 23)
+    assert(out.aborted)
+    assert(not out.errorbars)
+    assert(not out.success)


### PR DESCRIPTION
This allows an iteration callback to return `True` (or any true value) in order to immediately abort a fit, addressing #241.  Results will be returned with the latest values for the parameters.  The fit success will be `False`, no error bars will be calculated, an `aborted` boolean attribute of the `MinimizerResult` will be set to `True`, and many fit statistics will have invalid (possibly `NaN`) values. That is, it should be darn obvious when a fit is aborted. 

Docs are updated to have a section on iteration callbacks, documenting this behavior, and a test has been added to ensure that aborting from  iteration callback works. 
