### PR TITLE
Added moffat function MoffatModel and appropriate documentation.

### DIFF
--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -147,6 +147,26 @@ where :math:`\sigma_g = {\sigma}/{\sqrt{2\ln{2}}}` so that the full width
 at half maximum of each component and of the sum is :math:`2\sigma`. The
 :meth:`guess` function always sets the starting value for ``fraction`` at 0.5.
 
+
+:class:`MoffatModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. class:: MoffatModel(missing=None[, prefix=''[, name=None[, **kws]]])
+
+a model based on a `Moffat distribution function
+<https://en.wikipedia.org/wiki/Moffat_distribution>`_, the parameters are
+``amplitude`` (:math:`A`), ``center`` (:math:`\mu`),
+a width parameter ``sigma`` (:math:`\sigma`) and an exponent ``beta`` (:math:`\beta`).
+For (:math:`\beta=1`) the Moffat has a Lorentzian shape.
+
+.. math::
+
+  f(x; A, \mu, \sigma, \beta) = A \big[(\frac{x-\mu}{\sigma})^2+1\big]^{-\beta}
+
+the full width have maximum is :math:`\sigma 2 \sqrt{2^{1/\beta}}-1`.
+:meth:`guess` function always sets the starting value for ``beta`` to 1.
+
+
 :class:`Pearson7Model`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -163,7 +163,7 @@ For (:math:`\beta=1`) the Moffat has a Lorentzian shape.
 
   f(x; A, \mu, \sigma, \beta) = A \big[(\frac{x-\mu}{\sigma})^2+1\big]^{-\beta}
 
-the full width have maximum is :math:`\sigma 2 \sqrt{2^{1/\beta}}-1`.
+the full width have maximum is :math:`\sigma 2 \sqrt{2^{1/\beta}-1}`.
 :meth:`guess` function always sets the starting value for ``beta`` to 1.
 
 

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -14,7 +14,7 @@ s2pi = sqrt(2*pi)
 spi  = sqrt(pi)
 s2   = sqrt(2.0)
 
-functions = ('gaussian', 'lorentzian', 'voigt', 'pvoigt', 'pearson7',
+functions = ('gaussian', 'lorentzian', 'voigt', 'pvoigt', 'moffat', 'pearson7',
              'breit_wigner', 'damped_oscillator', 'logistic', 'lognormal',
              'students_t', 'expgaussian', 'donaich', 'skewed_gaussian',
              'skewed_voigt', 'step', 'rectangle', 'erf', 'erfc', 'wofz',
@@ -58,6 +58,13 @@ def pvoigt(x, amplitude=1.0, center=0.0, sigma=1.0, fraction=0.5):
     sigma_g = sigma / sqrt(2*log2)
     return ((1-fraction)*gaussian(x, amplitude, center, sigma_g) +
                fraction*lorentzian(x, amplitude, center, sigma))
+
+def moffat(x, amplitude=1, center=0., sigma=1, beta=1.):
+    """ 1 dimensional moffat function:
+
+    moffat(amplitude, center, sigma, beta) = amplitude / (((x - center)/sigma)**2 + 1)**beta
+    """
+    return amplitude / (((x - center)/sigma)**2 + 1)**beta
 
 def pearson7(x, amplitude=1.0, center=0.0, sigma=1.0, expon=1.0):
     """pearson7 lineshape, using the wikipedia definition:

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -208,7 +208,7 @@ class MoffatModel(Model):
     __doc__ = moffat.__doc__ + COMMON_DOC if moffat.__doc__ else ""
     def __init__(self, *args, **kwargs):
         super(MoffatModel, self).__init__(moffat, *args, **kwargs)
-        # self.set_param_hint('fwhm', expr=fwhm_expr(self))
+        self.set_param_hint('fwhm', expr="2*%ssigma*sqrt(2**(1.0/%sbeta)-1)" % (self.prefix, self.prefix))
 
     def guess(self, data, x=None, negative=False, **kwargs):
         pars = guess_from_peak(self, data, x, negative, ampscale=0.5, sigscale=1.)

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1,7 +1,7 @@
 import numpy as np
 from .model import Model
 
-from .lineshapes import (gaussian, lorentzian, voigt, pvoigt, pearson7,
+from .lineshapes import (gaussian, lorentzian, voigt, pvoigt, moffat, pearson7,
                          step, rectangle, breit_wigner, logistic,
                          students_t, lognormal, damped_oscillator,
                          expgaussian, skewed_gaussian, donaich,
@@ -201,6 +201,17 @@ class PseudoVoigtModel(Model):
     def guess(self, data, x=None, negative=False, **kwargs):
         pars = guess_from_peak(self, data, x, negative, ampscale=1.25)
         pars['%sfraction' % self.prefix].set(value=0.5)
+        return update_param_vals(pars, self.prefix, **kwargs)
+
+
+class MoffatModel(Model):
+    __doc__ = moffat.__doc__ + COMMON_DOC if moffat.__doc__ else ""
+    def __init__(self, *args, **kwargs):
+        super(MoffatModel, self).__init__(moffat, *args, **kwargs)
+        # self.set_param_hint('fwhm', expr=fwhm_expr(self))
+
+    def guess(self, data, x=None, negative=False, **kwargs):
+        pars = guess_from_peak(self, data, x, negative, ampscale=0.5, sigscale=1.)
         return update_param_vals(pars, self.prefix, **kwargs)
 
 


### PR DESCRIPTION
A Moffat is commonly used in astronomy to describe point spread functions. However, the profile is generally useful for lines that have larger wings than a Lorentzian.

Not yet implemented: Better guess parameters.
FWHM expression in the Model.

I coudln't find out how to correctly add the FWHM expression in this case. As written in the documentation it is \sigma 2 \sqrt{2^{1/\beta}}-1.

It's the first time I use github, sorry if I did something wrong.