### PR TITLE
Model conf_interval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
     - 3.4
 
 before_install:
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux_x86_64.sh -O miniconda.sh
+    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/minicoda
     - export PATH=$HOME/miniconda/bin:$PATH
     - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Config file for automatic testing at travis-ci.org
 
 language: python
+sudo: false
 
 python:
     - 2.7
@@ -8,7 +9,7 @@ python:
     - 3.4
 
 before_install:
-    - wget http://repo.continuum.io/miniconda/Miniconda-latest-x86_64.sh -O miniconda.sh
+    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux_x86_64.sh -O miniconda.sh
     - bash miniconda.sh -b -p $HOME/minicoda
     - export PATH=$HOME/miniconda/bin:$PATH
     - hash -r

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,17 @@ python:
     - 3.4
 
 before_install:
-    - wget http://repo.continuum.io/miniconda/Miniconda3-3.5.5-Linux-x86_64.sh -O miniconda.sh
-    - chmod +x miniconda.sh
-    - ./miniconda.sh -b
-    - export PATH=/home/travis/miniconda3/bin:$PATH
-    - conda config --add channels https://conda.binstar.org/dan_blanchard
-    - conda update --yes conda
+    - wget http://repo.continuum.io/miniconda/Miniconda-latest-x86_64.sh -O miniconda.sh
+    - bash miniconda.sh -b -p $HOME/minicoda
+    - export PATH=$HOME/miniconda/bin:$PATH
+    - hash -r
+    - conda config --set always_yes yws --set changeps1 no
+    - conda update -q conda
+    - conda info -a
 
 install:
-    - conda install --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy pandas matplotlib dateutil nose
+    - conda create test_env --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy pandas matplotlib dateutil nose
+    - source activate test_env
     - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ python:
 
 before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-    - bash miniconda.sh -b -p $HOME/minicoda
-    - export PATH=$HOME/miniconda/bin:$PATH
+    - bash miniconda.sh -b -p $HOME/miniconda
+    - export PATH="$HOME/miniconda/bin:$PATH"
     - hash -r
-    - conda config --set always_yes yws --set changeps1 no
+    - conda config --set always_yes yes --set changeps1 no
     - conda update -q conda
     - conda info -a
 
 install:
-    - conda create test_env --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy pandas matplotlib dateutil nose
+    - conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy pandas matplotlib dateutil nose
     - source activate test_env
     - python setup.py install
 

--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -163,7 +163,7 @@ For (:math:`\beta=1`) the Moffat has a Lorentzian shape.
 
   f(x; A, \mu, \sigma, \beta) = A \big[(\frac{x-\mu}{\sigma})^2+1\big]^{-\beta}
 
-the full width have maximum is :math:`\sigma 2 \sqrt{2^{1/\beta}-1}`.
+the full width have maximum is :math:`2\sigma\sqrt{2^{1/\beta}-1}`.
 :meth:`guess` function always sets the starting value for ``beta`` to 1.
 
 
@@ -755,15 +755,15 @@ for simple problems.  The example is included in the ``doc_peakmodels.py``
 file in the examples directory.
 
 
-
 Example 2: Fit data to a Composite Model with pre-defined models
 ------------------------------------------------------------------
 
-Here, we repeat the point made at the end of the last chapter that instances
-of :class:`model.Model` class can be added them together to make a *composite
-model*.  But using the large number of built-in models available, this is
-very simple.  An example of a simple fit to a noisy step function plus a
-constant:
+Here, we repeat the point made at the end of the last chapter that
+instances of :class:`model.Model` class can be added together to make a
+*composite model*.  By using the large number of built-in models available,
+it is therefore very simple to build models that contain multiple peaks and
+various backgrounds.  An example of a simple fit to a noisy step function
+plus a constant:
 
 .. literalinclude:: ../examples/doc_stepmodel.py
 

--- a/doc/confidence.rst
+++ b/doc/confidence.rst
@@ -1,3 +1,5 @@
+.. _confidence_chapter:
+
 Calculation of confidence intervals
 ====================================
 
@@ -164,8 +166,12 @@ which shows the trace of values:
    :width: 50%
 
 
-Documentation of methods
-------------------------
+
+Confidence Interval Functions
+----------------------------------
 
 .. autofunction:: lmfit.conf_interval
+
 .. autofunction:: lmfit.conf_interval2d
+
+.. autofunction:: lmfit.ci_report

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -141,7 +141,7 @@ Putting everything together, the script to do such a fit (included in the
 .. literalinclude:: ../examples/doc_model1.py
 
 which is pretty compact and to the point.  The returned ``result`` will be
-a :class:`ModelFit` object.  As we will see below, this has many
+a :class:`ModelResult` object.  As we will see below, this has many
 components, including a :meth:`fit_report` method, which will show::
 
     [[Model]]
@@ -262,7 +262,7 @@ specifying one or more independent variables.
    :param verbose:  print a message when a new parameter is created due to a *hint*
    :type  verbose:  bool (default ``True``)
    :param kws:      additional keyword arguments to pass to model function.
-   :return:         :class:`ModelFit` object.
+   :return:         :class:`ModelResult` object.
 
    If ``params`` is ``None``, the internal ``params`` will be used. If it
    is supplied, these will replace the internal ones.   If supplied,
@@ -624,50 +624,51 @@ at half maximum of a Gaussian model, one could use a parameter hint of::
 
 
 
-The :class:`ModelFit` class
+The :class:`ModelResult` class
 =======================================
 
-A :class:`ModelFit` is the object returned by :meth:`Model.fit`.  It is a
-subclass of :class:`Minimizer`, and so contains many of the fit results.
-Of course, it knows the :class:`Model` and the set of :class:`Parameters`
-used in the fit, and it has methods to evaluate the model, to fit the data
-(or re-fit the data with changes to the parameters, or fit with different
-or modified data) and to print out a report for that fit.
+A :class:`ModelResult` (which had been called `ModelFit` prior to version
+0.9) is the object returned by :meth:`Model.fit`.  It is a subclass of
+:class:`Minimizer`, and so contains many of the fit results.  Of course, it
+knows the :class:`Model` and the set of :class:`Parameters` used in the
+fit, and it has methods to evaluate the model, to fit the data (or re-fit
+the data with changes to the parameters, or fit with different or modified
+data) and to print out a report for that fit.
 
 While a :class:`Model` encapsulates your model function, it is fairly
 abstract and does not contain the parameters or data used in a particular
-fit.  A :class:`ModelFit` *does* contain parameters and data as well as
+fit.  A :class:`ModelResult` *does* contain parameters and data as well as
 methods to alter and re-do fits.  Thus the :class:`Model` is the idealized
-model while the :class:`ModelFit` is the messier, more complex (but perhaps
+model while the :class:`ModelResult` is the messier, more complex (but perhaps
 more useful) object that represents a fit with a set of parameters to data
 with a model.
 
 
-A :class:`ModelFit` has several attributes holding values for fit results,
+A :class:`ModelResult` has several attributes holding values for fit results,
 and several methods for working with fits.  These include statistics
 inherited from :class:`Minimizer` useful for comparing different models,
 includind `chisqr`, `redchi`, `aic`, and `bic`.
 
-.. class:: ModelFit()
+.. class:: ModelResult()
 
     Model fit is intended to be created and returned by :meth:`Model.fit`.
 
 
 
-:class:`ModelFit` methods
+:class:`ModelResult` methods
 ---------------------------------
 
 These methods are all inherited from :class:`Minimize` or from
 :class:`Model`.
 
-.. method:: ModelFit.eval(**kwargs)
+.. method:: ModelResult.eval(**kwargs)
 
    evaluate the model using the best-fit parameters and supplied
    independent variables.  The ``**kwargs`` arguments can be used to update
    parameter values and/or independent variables.
 
 
-.. method:: ModelFit.eval_components(**kwargs)
+.. method:: ModelResult.eval_components(**kwargs)
 
    evaluate each component of a :class:`CompositeModel`, returning an
    ordered dictionary of with the values for each component model.  The
@@ -675,7 +676,7 @@ These methods are all inherited from :class:`Minimize` or from
    is given), the model name.  The ``**kwargs`` arguments can be used to
    update parameter values and/or independent variables.
 
-.. method:: ModelFit.fit(data=None[, params=None[, weights=None[, method=None[, **kwargs]]]])
+.. method:: ModelResult.fit(data=None[, params=None[, weights=None[, method=None[, **kwargs]]]])
 
    fit (or re-fit), optionally changing ``data``, ``params``, ``weights``,
    or ``method``, or changing the independent variable(s) with the
@@ -683,7 +684,7 @@ These methods are all inherited from :class:`Minimize` or from
    descriptions, and note that any value of ``None`` defaults to the last
    used value.
 
-.. method:: ModelFit.fit_report(modelpars=None[, show_correl=True[,`< min_correl=0.1]])
+.. method:: ModelResult.fit_report(modelpars=None[, show_correl=True[,`< min_correl=0.1]])
 
    return a printable fit report for the fit with fit statistics, best-fit
    values with uncertainties and correlations.  As with :func:`fit_report`.
@@ -693,7 +694,20 @@ These methods are all inherited from :class:`Minimize` or from
    :param min_correl:   smallest correlation absolute value to show [0.1]
 
 
-.. method:: ModelFit.plot(datafmt='o', fitfmt='-', initfmt='--', yerr=None, numpoints=None, fig=None, data_kws=None, fit_kws=None, init_kws=None, ax_res_kws=None, ax_fit_kws=None, fig_kws=None)
+.. method:: ModelResult.conf_interval(**kwargs)
+
+   calculate the confidence intervals for the variable parameters using
+   :func:`confidence.conf_interval() <lmfit.conf_interval>`.  All keyword
+   arguments are passed to that function.  The result is stored in
+   :attr:`ci_out`, and so can be accessed without recalculating them.
+
+.. method:: ModelResult.ci_report(with_offset=True)
+
+   return a nicely formatted text report of the confidence intervals, as
+   from :func:`ci_report() <lmfit.ci_report>`.
+
+
+.. method:: ModelResult.plot(datafmt='o', fitfmt='-', initfmt='--', yerr=None, numpoints=None, fig=None, data_kws=None, fit_kws=None, init_kws=None, ax_res_kws=None, ax_fit_kws=None, fig_kws=None)
 
    Plot the fit results and residuals using matplotlib, if available.  The
    plot will include two panels, one showing the fit residual, and the
@@ -727,7 +741,7 @@ These methods are all inherited from :class:`Minimize` or from
    :type fig_kws: ``None`` or dictionary
    :returns:     matplotlib.figure.Figure
 
-   This combines :meth:`ModelFit.plot_fit` and :meth:`ModelFit.plot_residual`.
+   This combines :meth:`ModelResult.plot_fit` and :meth:`ModelResult.plot_residual`.
 
    If ``yerr`` is specified or if the fit model included weights, then
    matplotlib.axes.Axes.errorbar is used to plot the data.  If ``yerr`` is
@@ -735,7 +749,7 @@ These methods are all inherited from :class:`Minimize` or from
 
    If ``fig`` is None then ``matplotlib.pyplot.figure(**fig_kws)`` is called.
 
-.. method:: ModelFit.plot_fit(ax=None, datafmt='o', fitfmt='-', initfmt='--', yerr=None, numpoints=None,  data_kws=None, fit_kws=None, init_kws=None, ax_kws=None)
+.. method:: ModelResult.plot_fit(ax=None, datafmt='o', fitfmt='-', initfmt='--', yerr=None, numpoints=None,  data_kws=None, fit_kws=None, init_kws=None, ax_kws=None)
 
    Plot the fit results using matplotlib, if available.  The plot will include
    the data points, the initial fit curve, and the best-fit curve. If the fit
@@ -773,7 +787,7 @@ These methods are all inherited from :class:`Minimize` or from
 
    If ``ax`` is None then ``matplotlib.pyplot.gca(**ax_kws)`` is called.
 
-.. method:: ModelFit.plot_residuals(ax=None, datafmt='o', yerr=None, data_kws=None, fit_kws=None, ax_kws=None)
+.. method:: ModelResult.plot_residuals(ax=None, datafmt='o', yerr=None, data_kws=None, fit_kws=None, ax_kws=None)
 
   Plot the fit residuals (data - fit) using matplotlib.  If ``yerr`` is
   supplied or if the model included weights, errorbars will also be plotted.
@@ -806,7 +820,7 @@ These methods are all inherited from :class:`Minimize` or from
 
 
 
-:class:`ModelFit` attributes
+:class:`ModelResult` attributes
 ---------------------------------
 
 .. attribute:: aic
@@ -829,6 +843,11 @@ These methods are all inherited from :class:`Minimize` or from
 .. attribute:: chisqr
 
    floating point best-fit chi-square statistic (see :ref:`fit-results-label`).
+
+.. attribute:: ci_out
+
+   confidence interval data (see :ref:`confidence_chapter`) or `None`  if
+   the confidence intervals have not been calculated.
 
 .. attribute:: covar
 
@@ -1015,14 +1034,14 @@ red line, and the initial fit is shown as a black dashed line.  In the
 figure on the right, the data is again shown in blue dots, and the Gaussian
 component shown as a black dashed line, and the linear component shown as a
 red dashed line.  These components were generated after the fit using the
-Models :meth:`ModelFit.eval_components` method of the `result`::
+Models :meth:`ModelResult.eval_components` method of the `result`::
 
     comps = result.eval_components()
 
 which returns a dictionary of the components, using keys of the model name
 (or `prefix` if that is set).  This will use the parameter values in
 ``result.params`` and the independent variables (``x``) used during the
-fit.  Note that while the :class:`ModelFit` held in `result` does store the
+fit.  Note that while the :class:`ModelResult` held in `result` does store the
 best parameters and the best estimate of the model in ``result.best_fit``,
 the original model and parameters in ``pars`` are left unaltered.
 

--- a/lmfit/confidence.py
+++ b/lmfit/confidence.py
@@ -10,6 +10,11 @@ from scipy.stats import f
 from scipy.optimize import brentq
 from .minimizer import MinimizerException
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
+
 CONF_ERR_GEN    = 'Cannot determine Confidence Intervals'
 CONF_ERR_STDERR = '%s without sensible uncertainty estimates' % CONF_ERR_GEN
 CONF_ERR_NVARS  = '%s with < 2 variables' % CONF_ERR_GEN
@@ -190,7 +195,7 @@ class ConfidenceInterval(object):
         """
         Calculates all cis.
         """
-        out = {}
+        out = OrderedDict()
 
         for p in self.p_names:
             out[p] = (self.calc_ci(p, -1)[::-1] +

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -296,10 +296,9 @@ class Model(object):
             if name in kwargs:
                 # kw parameter names with prefix
                 par.value = kwargs[name]
-            if par not in params:
-                params.add(par)
-                if verbose:
-                    print( ' - Adding parameter "%s"' % name)
+            params.add(par)
+            if verbose:
+                print( ' - Adding parameter "%s"' % name)
 
         for p in params.values():
             p._delay_asteval = False

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -261,8 +261,7 @@ class Model(object):
                 par = params[name]
             else:
                 par = Parameter(name=name)
-            par._allow_asteval_errors = True
-            # print(" HINT ", name, hint, par)
+            par._delay_asteval = True
             for item in self._hint_names:
                 if item in  hint:
                     setattr(par, item, hint[item])
@@ -272,16 +271,15 @@ class Model(object):
             params.add(par)
             if verbose:
                 print( ' - Adding parameter for hint "%s"' % name)
-                    
+
         # next, make sure that all named parameters are included
         for name in self.param_names:
             if name in params:
                 par = params[name]
             else:
                 par = Parameter(name=name)
-            par._allow_asteval_errors = True
+            par._delay_asteval = True
             basename = name[len(self._prefix):]
-            # print(" PAR  ", name, par)
             # apply defaults from model function definition
             if basename in self.def_vals:
                 par.value = self.def_vals[basename]
@@ -298,11 +296,13 @@ class Model(object):
             if name in kwargs:
                 # kw parameter names with prefix
                 par.value = kwargs[name]
-            params.add(par)
-            if verbose:
-                print( ' - Adding parameter "%s"' % name)
+            if par not in params:
+                params.add(par)
+                if verbose:
+                    print( ' - Adding parameter "%s"' % name)
 
-        for p in params.values(): p._allow_asteval_errors = False
+        for p in params.values():
+            p._delay_asteval = False
         return params
 
     def guess(self, data=None, **kws):

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -8,7 +8,8 @@ import operator
 from copy import deepcopy
 import numpy as np
 from . import Parameters, Parameter, Minimizer
-from .printfuncs import fit_report
+from .printfuncs import fit_report, ci_report
+from .confidence import conf_interval
 
 from collections import MutableSet
 
@@ -761,6 +762,7 @@ class ModelResult(Minimizer):
         self.data = data
         self.weights = weights
         self.method = method
+        self.ci_out = None
         self.init_params = deepcopy(params)
         Minimizer.__init__(self, model._residual, params, fcn_args=fcn_args,
                            fcn_kws=fcn_kws, iter_cb=iter_cb,
@@ -776,6 +778,7 @@ class ModelResult(Minimizer):
             self.weights = weights
         if method is not None:
             self.method = method
+        self.ci_out = None
         self.userargs = (self.data, self.weights)
         self.userkws.update(kwargs)
         self.init_fit    = self.model.eval(params=self.params, **self.userkws)
@@ -800,6 +803,16 @@ class ModelResult(Minimizer):
     def eval_components(self, **kwargs):
         self.userkws.update(kwargs)
         return self.model.eval_components(params=self.params, **self.userkws)
+
+    def conf_interval(self, **kwargs):
+        """return explicitly calculated confidence intervals"""
+        if self.ci_out is None:
+            self.ci_out = conf_interval(self, self, **kwargs)
+        return self.ci_out
+
+    def ci_report(self, **kwargs):
+        """return nicely formatted report about confidence intervals"""
+        return ci_report(self.conf_interval(**kwargs))
 
     def fit_report(self,  **kwargs):
         "return fit report"

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -141,11 +141,6 @@ class Model(object):
     def prefix(self):
         return self._prefix
 
-    @prefix.setter
-    def prefix(self, value):
-        self._prefix = value
-        self._parse_params()
-
     @property
     def param_names(self):
         return self._param_names
@@ -153,18 +148,9 @@ class Model(object):
     def __repr__(self):
         return "<lmfit.Model: %s>" % (self.name)
 
-    def copy(self, prefix=None):
-        """Return a completely independent copy of the whole model.
-
-        Parameters
-        ----------
-        prefix: string or None. If not None new model's prefix is
-            changed to the passed value.
-        """
-        new = deepcopy(self)
-        if prefix is not None:
-            new.prefix = prefix
-        return new
+    def copy(self, **kwargs):
+        """DOES NOT WORK"""
+        raise NotImplementedError("Model.copy does not work. Make a new Model")
 
     def _parse_params(self):
         "build params from function arguments"

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -810,9 +810,10 @@ class ModelResult(Minimizer):
             self.ci_out = conf_interval(self, self, **kwargs)
         return self.ci_out
 
-    def ci_report(self, **kwargs):
+    def ci_report(self, with_offset=True, ndigits=5, **kwargs):
         """return nicely formatted report about confidence intervals"""
-        return ci_report(self.conf_interval(**kwargs))
+        return ci_report(self.conf_interval(**kwargs),
+                         with_offset=with_offset, ndigits=ndigits)
 
     def fit_report(self,  **kwargs):
         "return fit report"

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -375,6 +375,7 @@ class Parameter(object):
         self._expr_ast = None
         self._expr_eval = None
         self._expr_deps = []
+        self._allow_asteval_errors = False
         self.stderr = None
         self.correl = None
         self.from_internal = lambda val: val
@@ -528,9 +529,9 @@ class Parameter(object):
             self.__set_expression(self._expr)
 
         if self._expr_ast is not None and self._expr_eval is not None:
-            self.value = self._expr_eval(self._expr_ast)
-            check_ast_errors(self._expr_eval)
-
+            if not self._allow_asteval_errors:    
+                self.value = self._expr_eval(self._expr_ast)
+                check_ast_errors(self._expr_eval)
         if self.min is None:
             self.min = -inf
         if self.max is None:

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -436,6 +436,7 @@ class Parameter(object):
         self._expr_ast = None
         self._expr_eval = None
         self._expr_deps = []
+        self._allow_asteval_errors = False
         self._init_bounds()
 
     def __repr__(self):

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -527,6 +527,9 @@ class Parameter(object):
             self._expr_eval = None
         if not hasattr(self, '_expr_ast'):
             self._expr_ast = None
+        if self._expr_ast is None and self._expr is not None:
+            self.__set_expression(self._expr)
+
         if self._expr_ast is not None and self._expr_eval is not None:
             self.value = self._expr_eval(self._expr_ast)
             check_ast_errors(self._expr_eval)

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -196,8 +196,11 @@ class Parameters(OrderedDict):
         is equivalent to:
         p[name] = Parameter(name=name, value=XX, ....
         """
-        self.__setitem__(name, Parameter(value=value, name=name, vary=vary,
-                                         min=min, max=max, expr=expr))
+        if isinstance(name, Parameter):
+            self.__setitem__(name.name, name)
+        else:
+            self.__setitem__(name, Parameter(value=value, name=name, vary=vary,
+                                             min=min, max=max, expr=expr))
 
     def add_many(self, *parlist):
         """

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -375,7 +375,7 @@ class Parameter(object):
         self._expr_ast = None
         self._expr_eval = None
         self._expr_deps = []
-        self._allow_asteval_errors = False
+        self._delay_asteval = False
         self.stderr = None
         self.correl = None
         self.from_internal = lambda val: val
@@ -436,7 +436,7 @@ class Parameter(object):
         self._expr_ast = None
         self._expr_eval = None
         self._expr_deps = []
-        self._allow_asteval_errors = False
+        self._delay_asteval = False
         self._init_bounds()
 
     def __repr__(self):
@@ -530,9 +530,10 @@ class Parameter(object):
             self.__set_expression(self._expr)
 
         if self._expr_ast is not None and self._expr_eval is not None:
-            if not self._allow_asteval_errors:    
+            if not self._delay_asteval:
                 self.value = self._expr_eval(self._expr_ast)
                 check_ast_errors(self._expr_eval)
+
         if self.min is None:
             self.min = -inf
         if self.max is None:

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -141,10 +141,7 @@ class Parameters(OrderedDict):
         Update all constrained parameters, checking that dependencies are
         evaluated as needed.
         """
-        _updated = []
-        for name, par in self.items():
-            if par._expr is None:
-                _updated.append(name)
+        _updated = [name for name,par in self.items() if par._expr is None]
 
         def _update_param(name):
             """

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -41,11 +41,6 @@ class Parameters(OrderedDict):
         super(Parameters, self).__init__(self)
         self._asteval = asteval
 
-        # a flag to temporarily pause updating constraints when lots of
-        # parameters are being added. This is mainly used during the deepcopy
-        # operation. Do not forget to switch back on.
-        self._dont_update_constraints = False
-
         if asteval is None:
             self._asteval = Interpreter()
         self.update(*args, **kwds)
@@ -147,6 +142,10 @@ class Parameters(OrderedDict):
         evaluated as needed.
         """
         _updated = []
+        for name, par in self.items():
+            if par._expr is None:
+                _updated.append(name)
+
         def _update_param(name):
             """
             Update a parameter value, including setting bounds.
@@ -170,7 +169,8 @@ class Parameters(OrderedDict):
             _updated.append(name)
 
         for name in self.keys():
-            _update_param(name)
+            if name not in _updated:
+                _update_param(name)
 
     def pretty_repr(self, oneline=False):
         if oneline:

--- a/tests/test_manypeaks_speed.py
+++ b/tests/test_manypeaks_speed.py
@@ -1,0 +1,37 @@
+#
+# test speed of building complex model
+#
+import time
+import sys
+import numpy as np
+from lmfit import Model
+from lmfit.lineshapes import gaussian
+from copy import deepcopy
+
+
+sys.setrecursionlimit(2000)
+
+def test_manypeaks_speed():
+    x  = np.linspace( -5, 5, 251)
+    model = None
+    t0 = time.time()
+    for i in np.arange(500):
+        g = Model(gaussian, prefix='g%i_' % i)
+        if model is None:
+            model = g
+        else:
+            model += g
+    t1 = time.time()
+    pars = model.make_params()
+    t2 = time.time()
+    cpars = deepcopy(pars)
+    t3 = time.time()
+
+    # these are very conservative tests that 
+    # should be satisfied on nearly any machine
+    assert((t3-t2) < 0.5)
+    assert((t2-t1) < 0.5)
+    assert((t1-t0) < 5.0)
+
+if __name__ == '__main__':
+    test_manypeaks_speed()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -301,15 +301,18 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         self.assertTrue('bsigma' in pars)
 
     def test_change_prefix(self):
+        "should fail"
         mod = models.GaussianModel(prefix='b')
-        mod.prefix = 'c'
+        set_prefix_failed = None
         try:
-            params = mod.make_params()
-            names = params.keys()
-            all_begin_with_c = all([n.startswith('c') for n in names])
-            self.assertTrue(all_begin_with_c)
-        except NameError:
-            warnings.warn("test_change_prefix is a known fail")
+            mod.prefix = 'c'
+            set_prefix_failed = False
+        except AttributeError:
+            set_prefix_failed = True
+        except:
+            set_prefix_failed = None
+        self.assertTrue(set_prefix_failed)
+
 
     def test_sum_of_two_gaussians(self):
         # two user-defined gaussians


### PR DESCRIPTION
This started as a PR to add  `Model.conf_interval` to address #263, but sort of morphed into a general PR for 0.9.2, trying to address #262, better deal with #265, and even do some cleanup related to #261.

Features of this PR include

 * `Model.conf_interval()` and `Model.ci_report()` added.
 * `ci_report()` (for all confidence intervals) now shows differences from best-fit value by default, 
and has options of `with_offset=True, ndigits=5` to control whether the best-fit value is offset from other interval values, and how many digits to show.  It's also now in the documentation.
 * make `Model.prefix` immutable,  make `Model.copy()` raise `NotImplemented`.
 * `Model._param_names` is now a plain list (was `OrderedSet`, then `set`), which even further improves the performance of @licode #259 example.
 * `Parameters.add()` can take an existing `Parameter`.

Sorry, it is kind of a disjointed set of ideas, and so is totally fair to comment on these individually.

Anyway, I think this would make 0.9.2.    Comments, complaints, suggestions greatly appreciated!



