### PR TITLE
scalar_minimize() fixes using scipy OptimizeResult

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -486,7 +486,8 @@ class Minimizer(object):
                 if not attr.startswith('_'):
                     setattr(result, attr, getattr(ret, attr))
 
-        result.chisqr = result.residual = self.__residual(ret.x)
+        result.x = np.atleast_1d(result.x)
+        result.chisqr = result.residual = self.__residual(result.x)
         result.nvarys = len(vars)
         result.ndata = 1
         result.nfree = 1

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -478,10 +478,13 @@ class Minimizer(object):
 
         result.aborted = self._abort
         self._abort = False
-
-        for attr in dir(ret):
-            if not attr.startswith('_'):
-                setattr(result, attr, getattr(ret, attr))
+        if isinstance(ret, dict):
+            for attr, value in ret.items():
+                setattr(result, attr, value)
+        else:
+            for attr in dir(ret):
+                if not attr.startswith('_'):
+                    setattr(result, attr, getattr(ret, attr))
 
         result.chisqr = result.residual = self.__residual(ret.x)
         result.nvarys = len(vars)


### PR DESCRIPTION
This addresses #285 and #292 

scipy's OptimizeResult is (now? since when?) dictionary-like, so this checks for that and copies data into MinimizerResult.

This also fixes scalar_minimize() for the case of using a single variable, and makes sure that is a 1-element array. 