### PR TITLE
MAINT: improve Parameters pickling support

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -162,17 +162,24 @@ class Parameters(OrderedDict):
 
         Parameters
         ----------
-        state : list
-            state[0] is a dictionary containing symbols that need to be
-            injected into _asteval.symtable
-            state[1:] are the Parameter instances to be added
-         is list of parameters
+        state : dict
+            state['unique_symbols'] is a dictionary containing symbols that
+            need to be injected into _asteval.symtable
+            state['params'] is a list of Parameter instances to be added
         """
-        # first add all the parameters
+        # first update the Interpreter symbol table. This needs to be done
+        # first because Parameter's early in the list may depend on later
+        # Parameter's. This leads to problems because add_many eventually leads
+        # to a Parameter value being retrieved with _getval, which, if the
+        # dependent value hasn't already been added to the symtable, leads to
+        # an Error. Another way of doing this would be to remove all the expr
+        # from the Parameter instances before they get added, then to restore
+        # them.
+        self._asteval.symtable.update(state['unique_symbols'])
+
+        # then add all the parameters
         self.add_many(*state['params'])
 
-        # now update the Interpreter symbol table
-        self._asteval.symtable.update(state['unique_symbols'])
 
     def update_constraints(self):
         """

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -106,6 +106,17 @@ class TestParameters(unittest.TestCase):
         # now test if the asteval machinery survived
         assert_(q._asteval.symtable['abc'] == '2 * 3.142')
 
+        # check that unpickling of Parameters is not affected by expr that
+        # refer to Parameter that are added later on. In the following
+        # example var_0.expr refers to var_1, which is a Parameter later
+        # on in the Parameters OrderedDict.
+        p = Parameters()
+        p.add('var_0', value=1)
+        p.add('var_1', value=2)
+        p['var_0'].expr = 'var_1'
+        pkl = pickle.dumps(p)
+        q = pickle.loads(pkl)
+
     def test_isclose(self):
         assert_(isclose(1., 1+1e-5, atol=1e-4, rtol=0))
         assert_(not isclose(1., 1+1e-5, atol=1e-6, rtol=0))


### PR DESCRIPTION
Peter Metz reports a problem with unpickling a `Parameters` instance. The problem can be reproduced with:

    import lmfit
    import pickle
    p = lmfit.Parameters()
    p.add('var_0', value=1)
    p.add('var_1', value=2)
    p['var_0'].expr = 'var_1'
    pkl = pickle.dumps(p)
    q = pickle.loads(pkl)

The Error arises because `var_0` has an expr that depends on `var_1`. When `p` is unpickled the unpickling process tries to retrive the value of `var_1` from the symtable, but it doesn't yet been added to the symtable.
Solution: add the symbols to the symtable first, then add the parameters.