### PR TITLE
Change the order of arguments in the signature of Parameters.__init__()

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -73,7 +73,7 @@ class Parameters(OrderedDict):
     dumps() / dump()
     loads() / load()
     """
-    def __init__(self, asteval=None, *args, **kwds):
+    def __init__(self, *args, asteval=None, **kwds):
         super(Parameters, self).__init__(self)
         self._asteval = asteval
 


### PR DESCRIPTION
**Abstract:** This pull request switches the order of the arguments in `Parameters.__init__()`, ensuring that `asteval=None` is interpreted as a keyword argument.

**Reason:** The following code results in an AttributeError:
```
from lmfit import Parameters
p1 = Parameters()
p2 = p1.copy()
p2.add('foo')
```
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/usr/local/lib/python3.4/dist-packages/lmfit/parameter.py in _getval(self)
    546         try:
--> 547             self.value = max(self.min, min(self._val, self.max))
    548         except(TypeError, ValueError):

TypeError: unorderable types: float() < NoneType()

During handling of the above exception, another exception occurred:

AttributeError                            Traceback (most recent call last)
<ipython-input-5-b0051757b071> in <module>()
----> 1 p2.add('foo')

/usr/local/lib/python3.4/dist-packages/lmfit/parameter.py in add(self, name, value, vary, min, max, expr)
    198         else:
    199             self.__setitem__(name, Parameter(value=value, name=name, vary=vary,
--> 200                                              min=min, max=max, expr=expr))
    201 
    202     def add_many(self, *parlist):

/usr/local/lib/python3.4/dist-packages/lmfit/parameter.py in __setitem__(self, key, par)
     83         par.name = key
     84         par._expr_eval = self._asteval
---> 85         self._asteval.symtable[key] = par.value
     86 
     87     def __add__(self, other):

/usr/local/lib/python3.4/dist-packages/lmfit/parameter.py in value(self)
    557     def value(self):
    558         "The numerical value of the Parameter, with bounds applied"
--> 559         return self._getval()
    560 
    561     @value.setter

/usr/local/lib/python3.4/dist-packages/lmfit/parameter.py in _getval(self)
    547             self.value = max(self.min, min(self._val, self.max))
    548         except(TypeError, ValueError):
--> 549             self.value = nan
    550         return self._val
    551 

/usr/local/lib/python3.4/dist-packages/lmfit/parameter.py in value(self, val)
    565         if not hasattr(self, '_expr_eval'):  self._expr_eval = None
    566         if self._expr_eval is not None:
--> 567             self._expr_eval.symtable[self.name] = val
    568 
    569     @property

AttributeError: 'Parameters' object has no attribute 'symtable'
```

Interestingly, the old parameters object has ended up in `p2._asteval`:
```
p2._asteval.add('foo')
print(p2._asteval)
    Parameters([('foo', <Parameter 'foo', -inf, bounds=[-inf:inf]>)])
```
The error seems to be caused by the definition of `Parameters.__init__()`:
```
    def __init__(self, asteval=None, *args, **kwds):
        super(Parameters, self).__init__(self)
        self._asteval = asteval

        if asteval is None:
            self._asteval = Interpreter()
        self.update(*args, **kwds)
```
The keyword argument `asteval=None` is being interpreted as a positional argument, so that when an existing Parameters object is passed to the constructor as the first argument, it is seen as the `asteval` parameter. This is indeed what the .copy() method does.
```
[/usr/lib/python3.4/collections/__init__.py:211]

    def copy(self):
        'od.copy() -> a shallow copy of od'
        return self.__class__(self)
```