### PR TITLE
Copy params

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -81,8 +81,14 @@ class Parameters(OrderedDict):
             self._asteval = Interpreter()
         self.update(*args, **kwds)
 
+    def copy(self):
+        return self.__deepcopy__(None)
+
+    def __copy__(self, memo):
+        self.__deepcopy__(memo)
+
     def __deepcopy__(self, memo):
-        _pars = Parameters()
+        _pars = Parameters(asteval=None)
 
         # find the symbols that were added by users, not during construction
         sym_unique = self._asteval.user_defined_symbols()

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -82,12 +82,17 @@ class Parameters(OrderedDict):
         self.update(*args, **kwds)
 
     def copy(self):
+        """Parameters.copy() should always be a deepcopy"""
         return self.__deepcopy__(None)
 
     def __copy__(self, memo):
+        """Parameters.copy() should always be a deepcopy"""
         self.__deepcopy__(memo)
 
     def __deepcopy__(self, memo):
+        """Parameters deepcopy needs to make sure that
+        asteval is available and that all individula
+        parameter objects are copied"""
         _pars = Parameters(asteval=None)
 
         # find the symbols that were added by users, not during construction

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -21,6 +21,27 @@ class TestParameters(unittest.TestCase):
         assert_almost_equal(self.params['c'].value,
                             2 * self.params['a'].value)
 
+    def test_copy(self):
+        # check simple Parameters.copy() does not fail
+        # on non-trivial Parameters
+        p1 = Parameters()
+        p1.add('t', 2.0, min=0.0, max=5.0)
+        p1.add('x', 10.0)
+        p1.add('y', expr='x*t + sqrt(t)/3.0')
+
+        p2 = p1.copy()
+        assert(isinstance(p2, Parameters))
+        assert('t' in p2)
+        assert('y' in p2)
+        assert(p2['t'].max < 6.0)
+        assert(np.isinf(p2['x'].max) and p2['x'].max > 0)
+        assert(np.isinf(p2['x'].min) and p2['x'].min < 0)
+        assert('sqrt(t)' in p2['y'].expr )
+        assert(p2._asteval is not None)
+        assert(p2._asteval.symtable is not None)
+        assert((p2['y'].value > 20) and (p2['y'].value < 21))
+
+
     def test_deepcopy(self):
         # check that a simple copy works
         b = deepcopy(self.params)


### PR DESCRIPTION
This adds a `copy()` method to Parameters, which makes an explicit deep copy.    This addresses issue #298.   The added test includes a parameter with a non-trivial constraint expression that is checked to ensure that the expression is evaluated correctly in the copy.
