### PR TITLE
add check that fit cannot abort too early

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -291,6 +291,7 @@ class Minimizer(object):
             abort = self.iter_cb(params, self.result.nfev, out,
                                  *self.userargs, **self.userkws)
             self._abort = self._abort or abort
+        self._abort = self._abort and self.result.nfev > len(fvars)
         if not self._abort:
             return np.asarray(out).ravel()
 


### PR DESCRIPTION
addresses #301 by preventing a fit from aborting (from a user's iteration-callback) until at least len(fvars) (the number of variables parameters) iterations. 

