### PR TITLE
MAINT: pip+emcee for asv

### DIFF
--- a/asv_benchmarking/asv.conf.json
+++ b/asv_benchmarking/asv.conf.json
@@ -42,9 +42,9 @@
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)
     // version.
-    // "matrix": {
-    //      "scipy": ["0.16", "0.17"]
-    // },
+     "matrix": {
+          "pip+emcee": [],
+     },
 
     // The directory (relative to the current directory) that benchmarks are
     // stored in.  If not provided, defaults to "benchmarks"


### PR DESCRIPTION
The master branch of [asv](https://github.com/spacetelescope/asv) now allows you to install dependencies via pip, even if the `environment_type` is conda. This is relevant to lmfit because emcee is an optional dependency that is not installed via setup.py. This PR allows emcee benchmarking using asv (master branch 63b5fb and later)
