### PR TITLE
refactor Model.set_param_hint()

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -235,13 +235,10 @@ class Model(object):
         if npref > 0 and name.startswith(self._prefix):
             name = name[npref:]
 
-        thishint = {}
-        if name in self.param_hints:
-            thishint = self.param_hints.pop(name)
-        thishint.update(kwargs)
+        if name not in self.param_hints:
+            self.param_hints[name] = OrderedDict()
 
-        self.param_hints[name] = OrderedDict()
-        for key, val in thishint.items():
+        for key, val in kwargs.items():
             if key in self._hint_names:
                 self.param_hints[name][key] = val
             else:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -433,6 +433,24 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         self.assertEqual(param_values['p1_amplitude'], 1)
         self.assertEqual(param_values['p2_amplitude'], 2)
 
+    def test_weird_param_hints(self):
+        # tests Github Issue 312, a very weird way to access param_hints
+        def func(x, amp):
+            return amp*x
+
+        m = Model(func)
+        models = {}
+        for i in range(2):
+            m.set_param_hint('amp', value=1)
+            m.set_param_hint('amp', value=25)
+
+            models[i] = Model(func, prefix='mod%i_' % i)
+            models[i].param_hints['amp'] = m.param_hints['amp']
+
+        self.assertEqual(models[0].param_hints['amp'],
+                         models[1].param_hints['amp'])
+
+
     def test_composite_model_with_expr_constrains(self):
         """Smoke test for composite model fitting with expr constraints.
         """


### PR DESCRIPTION
This appears to address #314 with a fairly simple rewrite and simplification of `Model.set_param_hint()`.  To be honest, I'm not sure I completely understand what the problem was.... but the problem seems fixed and the code more readable.


