### PR TITLE
Improve pretty printing of Parameters

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -229,8 +229,26 @@ class Parameters(OrderedDict):
         s += "    })\n"
         return s
 
-    def pretty_print(self, oneline=False):
-        print(self.pretty_repr(oneline=oneline))
+    def pretty_print(self, oneline=False, spacing=8):
+        """Pretty-print parameters data.
+
+        Argument `spacing` is column width except for first and last columns.
+        """
+        if oneline:
+            print(self.pretty_repr(oneline=oneline))
+            return
+
+        name_len = max(len(s) for s in self)
+        print('{:{name_len}}  {:>{n}} {:>{n}} {:>{n}} {:>{n}}    {:{n}}'
+              .format('Name', 'Value', 'Min', 'Max', 'Vary', 'Expr',
+                      name_len=name_len, n=spacing))
+        line = ('{name:<{name_len}}  {value:{n}g} {min:{n}g} {max:{n}g} '
+                '{vary!s:>{n}}    {expr}')
+        for name, values in sorted(self.items()):
+            pvalues = {k: getattr(values, k)
+                       for k in ('value', 'min', 'max', 'vary', 'expr')}
+            pvalues['name'] = name
+            print(line.format(name_len=name_len, n=spacing, **pvalues))
 
     def add(self, name, value=None, vary=True, min=-inf, max=inf, expr=None):
         """

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -253,14 +253,13 @@ class Parameters(OrderedDict):
             return
 
         name_len = max(len(s) for s in self)
-        allcols = [s.capitalize() for s in (['name'] + columns)]
+        allcols = ['name'] + columns
         title = '{:{name_len}} ' + len(columns) * ' {:>{n}}'
-        print(title.format(*allcols, name_len=name_len, n=colwidth))
+        print(title.format(*allcols, name_len=name_len, n=colwidth).title())
         numstyle = '{%s:>{n}.{p}{f}}'  # format for numeric columns
         otherstyles = dict(name='{name:<{name_len}} ', stderr='{stderr!s:>{n}}',
                            vary='{vary!s:>{n}}', expr='{expr!s:>{n}}')
-        line = ' '.join([otherstyles.get(k.lower(), numstyle % k.lower())
-                         for k in allcols])
+        line = ' '.join([otherstyles.get(k, numstyle % k) for k in allcols])
         for name, values in sorted(self.items()):
             pvalues = {k: getattr(values, k) for k in columns}
             pvalues['name'] = name

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -236,16 +236,16 @@ class Parameters(OrderedDict):
         Parameters
         ----------
         oneline : boolean
-            If True print a one-line parameters representation. Default False.
+            If True prints a one-line parameters representation. Default False.
         colwidth : int
             column width for all except the first (i.e. name) column.
         columns : list of strings
-            list of columns names to print. All values must be a valid
+            list of columns names to print. All values must be valid
             :class:`Parameter` attributes.
         precision : int
-            number of digits after floating point to be printed.
+            number of digits to be printed after floating point.
         format : string
-            single-char numeric formatter type. Valid values: 'f' floating point,
+            single-char numeric formatter. Valid values: 'f' floating point,
             'g' floating point and exponential, 'e' exponential.
         """
         if oneline:


### PR DESCRIPTION
Similar to #318.

`Parameters` has a `pretty_print()` which prints with the following style:

```
Parameters({
    'p1_sigma': <Parameter 'p1_sigma', 0.03, bounds=[0.01:0.2]>, 
    'p1_fwhm': <Parameter 'p1_fwhm', 0.0706446, bounds=[-inf:inf], expr='2.3548200*p1_sigma'>, 
    'p2_sigma': <Parameter 'p2_sigma', 0.03, bounds=[0.01:0.2]>, 
    'p2_fwhm': <Parameter 'p2_fwhm', 0.0706446, bounds=[-inf:inf], expr='2.3548200*p2_sigma'>, 
    'p1_center': <Parameter 'p1_center', 0.3, bounds=[-0.1:0.7]>, 
    'p2_center': <Parameter 'p2_center', 0.85, bounds=[0.5:1.1]>, 
    'p1_amplitude': <Parameter 'p1_amplitude', 1, bounds=[0.01:inf]>, 
    'p2_amplitude': <Parameter 'p2_amplitude', 1, bounds=[0.01:inf]>, 
    'br_amplitude': <Parameter 'br_amplitude', 0.0001, bounds=[0:inf]>, 
    'br_center1': <Parameter 'br_center1', 0.3, bounds=[0:inf], expr='p1_center'>, 
    'br_center2': <Parameter 'br_center2', 0.85, bounds=[0:inf], expr='p2_center'>, 
    'br_sigma1': <Parameter 'br_sigma1', 0.03, bounds=[0:inf], expr='p1_sigma'>, 
    'br_sigma2': <Parameter 'br_sigma2', 0.03, bounds=[0:inf], expr='p2_sigma'>, 
    })
```

This follows a style typical for object representations in python (`__repr__`) but is hard to read for a user.

This PR modifies `pretty_print()` in backward-compatible way  (not removing arguments) in order to produce the following output:

```
Name               Value        Min        Max       Vary    Expr      
br_amplitude      0.0001          0        inf       True    None
br_center1           0.3          0        inf      False    p1_center
br_center2          0.85          0        inf      False    p2_center
br_sigma1           0.03          0        inf      False    p1_sigma
br_sigma2           0.03          0        inf      False    p2_sigma
p1_amplitude           1       0.01        inf       True    None
p1_center            0.3       -0.1        0.7       True    None
p1_fwhm        0.0706446       -inf        inf      False    2.3548200*p1_sigma
p1_sigma            0.03       0.01        0.2       True    None
p2_amplitude           1       0.01        inf       True    None
p2_center           0.85        0.5        1.1       True    None
p2_fwhm        0.0706446       -inf        inf      False    2.3548200*p2_sigma
p2_sigma            0.03       0.01        0.2       True    None
```