### PR TITLE
Add future as dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
     - conda info -a
 
 install:
-    - conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy pandas matplotlib nose
+    - conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy pandas matplotlib nose future
     - source activate test_env
     - pip install emcee
     - python setup.py install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.5
 scipy>=0.13
+future

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name = 'lmfit',
       author_email = 'matt.newville@gmail.com',
       url          = 'http://lmfit.github.io/lmfit-py/',
       download_url = 'http://lmfit.github.io//lmfit-py/',
-      install_requires = ['numpy', 'scipy'],
+      install_requires = ['numpy', 'scipy', 'future'],
       license = 'BSD',
       description = "Least-Squares Minimization with Bounds and Constraints",
       long_description = long_desc,
@@ -51,4 +51,3 @@ setup(name = 'lmfit',
       package_dir = {'lmfit': 'lmfit'},
       packages = ['lmfit', 'lmfit.ui', 'lmfit.uncertainties'],
       )
-


### PR DESCRIPTION
This PR adds [`future`](http://python-future.org/) as a dependency. 

The `future` package provides a few importables: 
-  `builtins` (only on python2, which provides python3-style objects)
- `past`
- `future`

See:
- http://python-future.org/compatible_idioms.html

For the ints issue #319 (and #321) see:
- http://python-future.org/compatible_idioms.html#long-integers