### PR TITLE
Docs fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ sandbox/
 .idea/
 .DS_Store
 .ipynb_checkpoints/
+doc/html

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,6 +65,7 @@ copyright = u'2014, Matthew Newville, The University of Chicago,  Till Stensitzk
 # built documents.
 #
 # The short X.Y version.
+sys.path.insert(0, os.path.abspath('../'))
 try:
     import lmfit
     release = lmfit.__version__

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,13 +24,18 @@ sys.path.append(os.path.abspath(os.path.join('.')))
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 from extensions import extensions
 
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.mathjax',
+    ]
+
 try:
     import IPython.sphinxext.ipython_directive
     extensions.extend(['IPython.sphinxext.ipython_directive',
                        'IPython.sphinxext.ipython_console_highlighting'])
 except ImportError:
     pass
-
 
 intersphinx_mapping = {'py': ('http://docs.python.org/2', None),
                        'numpy': ('http://docs.scipy.org/doc/numpy/', None),
@@ -173,4 +178,3 @@ latex_documents = [
    'Non-Linear Least-Squares Minimization and Curve-Fitting for Python',
    'Matthew Newville, Till Stensitzki, and others', 'manual'),
 ]
-

--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -145,74 +145,74 @@ The :class:`Parameters` class
    Two methods are provided for convenient initialization of a :class:`Parameters`,
    and one for extracting :class:`Parameter` values into a plain dictionary.
 
-.. method:: add(name[, value=None[, vary=True[, min=None[, max=None[, expr=None]]]]])
+    .. method:: add(name[, value=None[, vary=True[, min=None[, max=None[, expr=None]]]]])
 
-   add a named parameter.  This creates a :class:`Parameter`
-   object associated with the key `name`, with optional arguments
-   passed to :class:`Parameter`::
+       add a named parameter.  This creates a :class:`Parameter`
+       object associated with the key `name`, with optional arguments
+       passed to :class:`Parameter`::
 
-     p = Parameters()
-     p.add('myvar', value=1, vary=True)
+         p = Parameters()
+         p.add('myvar', value=1, vary=True)
 
-.. method:: add_many(self, paramlist)
+    .. method:: add_many(self, paramlist)
 
-   add a list of named parameters.  Each entry must be a tuple
-   with the following entries::
+       add a list of named parameters.  Each entry must be a tuple
+       with the following entries::
 
-        name, value, vary, min, max, expr
+            name, value, vary, min, max, expr
 
-   This method is somewhat rigid and verbose (no default values), but can
-   be useful when initially defining a parameter list so that it looks
-   table-like::
+       This method is somewhat rigid and verbose (no default values), but can
+       be useful when initially defining a parameter list so that it looks
+       table-like::
 
-     p = Parameters()
-     #           (Name,  Value,  Vary,   Min,  Max,  Expr)
-     p.add_many(('amp1',    10,  True, None, None,  None),
-                ('cen1',   1.2,  True,  0.5,  2.0,  None),
-                ('wid1',   0.8,  True,  0.1, None,  None),
-                ('amp2',   7.5,  True, None, None,  None),
-                ('cen2',   1.9,  True,  1.0,  3.0,  None),
-                ('wid2',  None, False, None, None, '2*wid1/3'))
+         p = Parameters()
+         #           (Name,  Value,  Vary,   Min,  Max,  Expr)
+         p.add_many(('amp1',    10,  True, None, None,  None),
+                    ('cen1',   1.2,  True,  0.5,  2.0,  None),
+                    ('wid1',   0.8,  True,  0.1, None,  None),
+                    ('amp2',   7.5,  True, None, None,  None),
+                    ('cen2',   1.9,  True,  1.0,  3.0,  None),
+                    ('wid2',  None, False, None, None, '2*wid1/3'))
 
 
-.. automethod:: Parameters.pretty_print
+    .. automethod:: Parameters.pretty_print
 
-.. method:: valuesdict()
+    .. method:: valuesdict()
 
-   return an ordered dictionary of name:value pairs with the
-   Paramater name as the key and Parameter value as value.
+       return an ordered dictionary of name:value pairs with the
+       Paramater name as the key and Parameter value as value.
 
-   This is distinct from the :class:`Parameters` itself, as the dictionary
-   values are not :class:`Parameter` objects, just the :attr:`value`.
-   Using :meth:`valuesdict` can be a very convenient way to get updated
-   values in a objective function.
+       This is distinct from the :class:`Parameters` itself, as the dictionary
+       values are not :class:`Parameter` objects, just the :attr:`value`.
+       Using :meth:`valuesdict` can be a very convenient way to get updated
+       values in a objective function.
 
-.. method:: dumps(**kws):
+    .. method:: dumps(**kws)
 
-   return a JSON string representation of the :class:`Parameter` object.
-   This can be saved or used to re-create or re-set parameters, using the
-   :meth:`loads` method.
+       return a JSON string representation of the :class:`Parameter` object.
+       This can be saved or used to re-create or re-set parameters, using the
+       :meth:`loads` method.
 
-   Optional keywords are sent :py:func:`json.dumps`.
+       Optional keywords are sent :py:func:`json.dumps`.
 
-.. method:: dump(file, **kws):
+    .. method:: dump(file, **kws)
 
-   write a JSON representation of the :class:`Parameter` object to a file
-   or file-like object in `file` -- really any object with a :meth:`write`
-   method.  Optional keywords are sent :py:func:`json.dumps`.
+       write a JSON representation of the :class:`Parameter` object to a file
+       or file-like object in `file` -- really any object with a :meth:`write`
+       method.  Optional keywords are sent :py:func:`json.dumps`.
 
-.. method:: loads(sval, **kws):
+    .. method:: loads(sval, **kws)
 
-   use a JSON string representation of the :class:`Parameter` object in
-   `sval` to set all parameter settins. Optional keywords are sent
-   :py:func:`json.loads`.
+       use a JSON string representation of the :class:`Parameter` object in
+       `sval` to set all parameter settins. Optional keywords are sent
+       :py:func:`json.loads`.
 
-.. method:: load(file, **kws):
+    .. method:: load(file, **kws)
 
-   read and use a JSON string representation of the :class:`Parameter`
-   object from a file or file-like object in `file` -- really any object
-   with a :meth:`read` method.  Optional keywords are sent
-   :py:func:`json.loads`.
+       read and use a JSON string representation of the :class:`Parameter`
+       object from a file or file-like object in `file` -- really any object
+       with a :meth:`read` method.  Optional keywords are sent
+       :py:func:`json.loads`.
 
 
 Simple Example

--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -129,6 +129,8 @@ update some Parameter attribute without affecting others, for example::
 The :class:`Parameters` class
 ========================================
 
+.. currentmodule:: lmfit.parameter
+
 .. class:: Parameters()
 
    create a Parameters object.  This is little more than a fancy ordered
@@ -140,8 +142,7 @@ The :class:`Parameters` class
 
    2. values must be valid :class:`Parameter` objects.
 
-
-   Two methods are for provided for convenient initialization of a :class:`Parameters`,
+   Two methods are provided for convenient initialization of a :class:`Parameters`,
    and one for extracting :class:`Parameter` values into a plain dictionary.
 
 .. method:: add(name[, value=None[, vary=True[, min=None[, max=None[, expr=None]]]]])
@@ -174,10 +175,7 @@ The :class:`Parameters` class
                 ('wid2',  None, False, None, None, '2*wid1/3'))
 
 
-.. method:: pretty_print(oneline=False)
-
-   prints a clean representation on the Parameters. If `oneline` is
-   `True`, the result will be printed to a single (long) line.
+.. automethod:: Parameters.pretty_print
 
 .. method:: valuesdict()
 
@@ -186,7 +184,7 @@ The :class:`Parameters` class
 
    This is distinct from the :class:`Parameters` itself, as the dictionary
    values are not :class:`Parameter` objects, just the :attr:`value`.
-   Using :method:`valuesdict` can be a very convenient way to get updated
+   Using :meth:`valuesdict` can be a very convenient way to get updated
    values in a objective function.
 
 .. method:: dumps(**kws):

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -77,21 +77,21 @@ Discussion
 
 The main goal for making this change were to
 
-   1. give a better return value to :func:`minimize` and
-      :meth:`Minimizer.minimize` that can hold all of the information
-      about a fit.  By having the return value be an instance of the
-      :class:`MinimizerResult` class, it can hold an arbitrary amount of
-      information that is easily accessed by attribute name, and even
-      be given methods.  Using objects is good!
+1. give a better return value to :func:`minimize` and
+   :meth:`Minimizer.minimize` that can hold all of the information
+   about a fit.  By having the return value be an instance of the
+   :class:`MinimizerResult` class, it can hold an arbitrary amount of
+   information that is easily accessed by attribute name, and even
+   be given methods.  Using objects is good!
 
-   2. To limit or even elimate the amount of "state information" a
-      :class:`Minimizer` holds.  By state information, we mean how much of
-      the previous fit is remembered after a fit is done.  Keeping (and
-      especially using) such information about a previous fit means that
-      a :class:`Minimizer` might give different results even for the same
-      problem if run a second time.  While it's desirable to be able to
-      adjust a set of :class:`Parameters` re-run a fit to get an improved
-      result, doing this by changing an *internal attribute
-      (:attr:`Minimizer.params`) has the undesirable side-effect of not
-      being able to "go back", and makes it somewhat cumbersome to keep
-      track of changes made while adjusting parameters and re-running fits.
+2. To limit or even eliminate the amount of "state information" a
+   :class:`Minimizer` holds.  By state information, we mean how much of
+   the previous fit is remembered after a fit is done.  Keeping (and
+   especially using) such information about a previous fit means that
+   a :class:`Minimizer` might give different results even for the same
+   problem if run a second time.  While it's desirable to be able to
+   adjust a set of :class:`Parameters` re-run a fit to get an improved
+   result, doing this by changing an internal attribute
+   (:attr:`Minimizer.params`) has the undesirable side-effect of not
+   being able to "go back", and makes it somewhat cumbersome to keep
+   track of changes made while adjusting parameters and re-running fits.

--- a/lmfit/confidence.py
+++ b/lmfit/confidence.py
@@ -48,7 +48,7 @@ def restore_vals(tmp_params, params):
 
 def conf_interval(minimizer, result, p_names=None, sigmas=(0.674, 0.95, 0.997),
                   trace=False, maxiter=200, verbose=False, prob_func=None):
-    r"""Calculates the confidence interval for parameters
+    """Calculates the confidence interval for parameters
     from the given a MinimizerResult, output from minimize.
 
     The parameter for which the ci is calculated will be varied, while
@@ -80,7 +80,7 @@ def conf_interval(minimizer, result, p_names=None, sigmas=(0.674, 0.95, 0.997),
         A dict, which contains a list of (sigma, vals)-tuples for each name.
     trace_dict : dict
         Only if trace is set true. Is a dict, the key is the parameter which
-        was fixed.The values are again a dict with the names as keys, but with
+        was fixed. The values are again a dict with the names as keys, but with
         an additional key 'prob'. Each contains an array of the corresponding
         values.
 
@@ -96,7 +96,7 @@ def conf_interval(minimizer, result, p_names=None, sigmas=(0.674, 0.95, 0.997),
         Function to calculate the probability from the optimized chi-square.
         Default (``None``) uses built-in f_compare (F test).
     verbose: bool
-        print extra debuggin information. Default is ``False``.
+        print extra debuging information. Default is ``False``.
 
 
     Examples
@@ -120,6 +120,7 @@ def conf_interval(minimizer, result, p_names=None, sigmas=(0.674, 0.95, 0.997),
     >>> prob = trace['para1']['prob']
 
     This makes it possible to plot the dependence between free and fixed.
+    
     """
     ci = ConfidenceInterval(minimizer, result, p_names, prob_func, sigmas,
                             trace, verbose, maxiter)


### PR DESCRIPTION
This PR enables autodoc, napoleaon and mathjax sphinx extension and fix all warnings during build.

Seems like all the docs are correctly generated, so this can be a good starting point for a gradual switch to autodoc generated API docs.