### PR TITLE
Docs: add Model.print_param_hints to the sphinx docs

### DIFF
--- a/doc/model.rst
+++ b/doc/model.rst
@@ -324,6 +324,9 @@ specifying one or more independent variables.
    See :ref:`model_param_hints_section`.
 
 
+.. automethod:: lmfit.model.Model.print_param_hints
+
+
 :class:`Model` class Attributes
 ---------------------------------
 

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -243,9 +243,10 @@ class Model(object):
                 warnings.warn(self._invalid_hint % (key, name))
 
     def print_param_hints(self, colwidth=8):
-        """Pretty-print parameters hints.
+        """Prints a nicely aligned text-table of parameters hints.
 
-        Argument `colwidth` is column width except for first and last columns.
+        The argument `colwidth` is the width of each column,
+        except for first and last columns.
         """
         name_len = max(len(s) for s in self.param_hints)
         print('{:{name_len}}  {:>{n}} {:>{n}} {:>{n}} {:>{n}}    {:{n}}'


### PR DESCRIPTION
This PR adds docs entry for `Model.print_param_hints`.
