### PR TITLE
Fix eval errors with `Model.make_params()` and constraint expressions

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -265,27 +265,8 @@ class Model(object):
         This applies any default values
         """
         params = Parameters()
-        # first build parameters defined in param_hints
-        # note that composites may define their own additional
-        # convenience parameters here
-        for basename, hint in self.param_hints.items():
-            name = "%s%s" % (self._prefix, basename)
-            if name in params:
-                par = params[name]
-            else:
-                par = Parameter(name=name)
-            par._delay_asteval = True
-            for item in self._hint_names:
-                if item in  hint:
-                    setattr(par, item, hint[item])
-            # Add the new parameter to self._param_names
-            if name not in self._param_names:
-                self._param_names.append(name)
-            params.add(par)
-            if verbose:
-                print( ' - Adding parameter for hint "%s"' % name)
 
-        # next, make sure that all named parameters are included
+        # make sure that all named parameters are in params
         for name in self.param_names:
             if name in params:
                 par = params[name]
@@ -312,6 +293,26 @@ class Model(object):
             params.add(par)
             if verbose:
                 print( ' - Adding parameter "%s"' % name)
+
+        # next build parameters defined in param_hints
+        # note that composites may define their own additional
+        # convenience parameters here
+        for basename, hint in self.param_hints.items():
+            name = "%s%s" % (self._prefix, basename)
+            if name in params:
+                par = params[name]
+            else:
+                par = Parameter(name=name)
+                params.add(par)
+                if verbose:
+                    print( ' - Adding parameter for hint "%s"' % name)
+            par._delay_asteval = True
+            for item in self._hint_names:
+                if item in  hint:
+                    setattr(par, item, hint[item])
+            # Add the new parameter to self._param_names
+            if name not in self._param_names:
+                self._param_names.append(name)
 
         for p in params.values():
             p._delay_asteval = False

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -449,9 +449,8 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         m = m1 + m2
 
         param_values = {name: p.value for name, p in params.items()}
-        self.assertEqual(param_values['m1_amplitude'], 1)
         self.assertTrue(param_values['m1_intercept'] < -0.0)
-
+        self.assertEqual(param_values['m2_amplitude'], 1)
 
     def test_weird_param_hints(self):
         # tests Github Issue 312, a very weird way to access param_hints

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -433,6 +433,26 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         self.assertEqual(param_values['p1_amplitude'], 1)
         self.assertEqual(param_values['p2_amplitude'], 2)
 
+    def test_hints_for_peakmodels(self):
+        # test that height/fwhm do not cause asteval errors.
+
+        x = np.linspace(-10, 10, 101)
+        y = np.sin(x / 3)  + x /100.
+
+        m1 = models.LinearModel(prefix='m1_')
+
+        params = m1.guess(y, x=x)
+
+        m2 = models.GaussianModel(prefix='m2_')
+        params.update(m2.make_params())
+
+        m = m1 + m2
+
+        param_values = {name: p.value for name, p in params.items()}
+        self.assertEqual(param_values['m1_amplitude'], 1)
+        self.assertTrue(param_values['m1_intercept'] < -0.0)
+
+
     def test_weird_param_hints(self):
         # tests Github Issue 312, a very weird way to access param_hints
         def func(x, amp):
@@ -531,7 +551,6 @@ class TestPolynomialOrder3(CommonTests, unittest.TestCase):
 
 
 class TestConstant(CommonTests, unittest.TestCase):
-
     def setUp(self):
         self.true_values = lambda: dict(c=5)
         self.guess = lambda: dict(c=2)
@@ -542,7 +561,6 @@ class TestConstant(CommonTests, unittest.TestCase):
         raise nose.SkipTest("ConstantModel has not independent_vars.")
 
 class TestPowerlaw(CommonTests, unittest.TestCase):
-
     def setUp(self):
         self.true_values = lambda: dict(amplitude=5, exponent=3)
         self.guess = lambda: dict(amplitude=2, exponent=8)
@@ -551,7 +569,6 @@ class TestPowerlaw(CommonTests, unittest.TestCase):
 
 
 class TestExponential(CommonTests, unittest.TestCase):
-
     def setUp(self):
         self.true_values = lambda: dict(amplitude=5, decay=3)
         self.guess = lambda: dict(amplitude=2, decay=8)
@@ -565,3 +582,5 @@ class TestComplexConstant(CommonTests, unittest.TestCase):
         self.guess = lambda: dict(re=2,im=2)
         self.model_constructor = models.ComplexConstantModel
         super(TestComplexConstant, self).setUp()
+
+#


### PR DESCRIPTION
This fixes #328.    The essential change is to add the constraint expressions from model hints *after* the main model parameters have been added.  This avoids NameError exceptions that can arise if accessing a models parameters right after creation (and before the namespace is fully populated).  This is pretty similar to the situation that led to `param._delay_asteval`, but is now outside a single model (say, when making a composite).  

A test is added for this particular problem.  I'm not sure it's a completely general solution, and can believe other NameErrors when building models is still possible.

 