### PR TITLE
Minor fix for lmfit.ui.basefitter.BaseFitter in the case that model does not implement guess

### DIFF
--- a/lmfit/ui/basefitter.py
+++ b/lmfit/ui/basefitter.py
@@ -149,7 +149,7 @@ class BaseFitter(object):
                 val = self.kwargs[key]
                 d = {key: val}
                 guess = self.model.guess(self._data, **d)
-                self.current_params = guess
+            self.current_params = guess
         except NotImplementedError:
             guessing_successful = False
         return guessing_successful

--- a/lmfit/ui/basefitter.py
+++ b/lmfit/ui/basefitter.py
@@ -149,9 +149,9 @@ class BaseFitter(object):
                 val = self.kwargs[key]
                 d = {key: val}
                 guess = self.model.guess(self._data, **d)
+                self.current_params = guess
         except NotImplementedError:
             guessing_successful = False
-        self.current_params = guess
         return guessing_successful
 
     def __assign_deps(self, params):


### PR DESCRIPTION
This fixes a simple error in lmfit.ui.basefitter.BaseFitter.guess.
Currently, if you try to use a model that does not implement a guess method, the code detects the NotImplmentedError and indicates guessing failed, but it also tries to update self.current_params = guess which raises an UnboundLocalError since guess never successfully got defined.

This can easily happen by simply creating a CompositeModel and not defining a guess method for it.

This pull request simply moves the assignment of self.current_params = guess such that it only happens if "guess" is defined. If guess fails, self.current_params shouldn't be updated anyway.