### PR TITLE
MAINT: de shouldn't need bounds if not varying

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -496,10 +496,13 @@ class Minimizer(object):
 
         if method == 'differential_evolution':
             fmin_kws['method'] = _differential_evolution
-            bounds = [(par.min, par.max) for par in params.values()]
-            if not np.all(np.isfinite(bounds)):
+            bounds = np.asarray([(par.min, par.max)
+                                 for par in params.values()])
+            varying = np.asarray([par.vary for par in params.values()])
+
+            if not np.all(np.isfinite(bounds[varying])):
                 raise ValueError('With differential evolution finite bounds '
-                                 'are required for each parameter')
+                                 'are required for each varying parameter')
             bounds = [(-np.pi / 2., np.pi / 2.)] * len(vars)
             fmin_kws['bounds'] = bounds
 

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -361,8 +361,13 @@ class CommonMinimizerTest(unittest.TestCase):
         # You need finite (min, max) for each parameter if you're using
         # differential_evolution.
         self.fit_params['decay'].min = -np.inf
+        self.fit_params['decay'].vary = True
         self.minimizer = 'differential_evolution'
         np.testing.assert_raises(ValueError, self.scalar_minimizer)
+
+        # but only if a parameter is not fixed
+        self.fit_params['decay'].vary = False
+        self.mini.scalar_minimize(method='differential_evolution', maxiter=1)
 
     def test_scalar_minimizers(self):
         # test all the scalar minimizers


### PR DESCRIPTION
Currently the `differential_evolution` option in `scalar_minimize` requires finite upper and lower bounds for all parameters. This PR removes that requirement. Instead finite upper and lower bounds are only required for those parameters that vary.
