### PR TITLE
FIX: Changed dict comprehensions to style compatible with py26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 sudo: false
 
 python:
+    - 2.6
     - 2.7
     - 3.3
     - 3.4

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,9 @@ Non-Linear Least-Square Minimization and Curve-Fitting for Python
 
   Upgrading scripts from version 0.8.3 to 0.9.0?  See  :ref:`whatsnew_090_label`
 
+.. warning::
+
+  Support for Python 2.6.x will be officially dropped following version 0.9.4 (in 0.9.5)
 
 Lmfit provides a high-level interface to non-linear optimization and curve
 fitting problems for Python. Lmfit builds on and extends many of the

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -13,11 +13,11 @@ Prerequisites
 The lmfit package requires Python, Numpy, and Scipy.  Scipy version 0.13 or
 higher is recommended, but extensive testing on compatibility with various
 versions of scipy has not been done.  Lmfit works with Python 2.7, 3.3 and
-3.4.  No testing has been done with Python 3.5, but as the package is pure
-Python, relying only on scipy and numpy, no significant troubles are
-expected.  The `nose`_ framework is required for running the test suite,
-and IPython and matplotib are recommended.  If Pandas is available, it will
-be used in portions of lmfit.
+3.4.  Lmfit works with Python 2.6 only for versions <= 0.9.4. No testing has
+been done with Python 3.5, but as the package is pure Python, relying only on
+scipy and numpy, no significant troubles are expected.  The `nose`_ framework
+is required for running the test suite, and IPython and matplotib are
+recommended. If Pandas is available, it will be used in portions of lmfit.
 
 
 Downloads

--- a/lmfit/__init__.py
+++ b/lmfit/__init__.py
@@ -33,6 +33,8 @@ from scipy.optimize.  It has a number of useful enhancements, including:
              Daniel B. Allen, Johns Hopkins University
              Antonino Ingargiola, University of California, Los Angeles
 """
+import warnings
+import sys
 
 from .minimizer import minimize, Minimizer, MinimizerException
 from .parameter import Parameter, Parameters
@@ -49,5 +51,10 @@ from .uncertainties import ufloat, correlated_values
 
 ## versioneer code
 from ._version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions
+
+# PY26 Depreciation Warning
+if sys.version_info[:2] == (2, 6):
+    warnings.warn('Support for Python 2.6.x is depreciated in Lmfit 0.9.4 and will be dropped in 0.9.5', DeprecationWarning)

--- a/lmfit/asteval.py
+++ b/lmfit/asteval.py
@@ -86,28 +86,28 @@ class Interpreter:
         symtable['print'] = self._printer
 
         # add python symbols
-        py_symtable = {sym: __builtins__[sym] for sym in FROM_PY
-                              if sym in __builtins__}
+        py_symtable = dict((sym, __builtins__[sym]) for sym in FROM_PY
+                              if sym in __builtins__)
         symtable.update(py_symtable)
 
         # add local symbols
-        local_symtable = {sym: obj for (sym, obj) in LOCALFUNCS.items()}
+        local_symtable = dict((sym, obj) for (sym, obj) in LOCALFUNCS.items())
         symtable.update(local_symtable)
 
         # add math symbols
-        math_symtable = {sym: getattr(math, sym) for sym in FROM_MATH
-                              if hasattr(math, sym)}
+        math_symtable = dict((sym, getattr(math, sym)) for sym in FROM_MATH
+                              if hasattr(math, sym))
         symtable.update(math_symtable)
 
         # add numpy symbols
         if self.use_numpy:
-            numpy_symtable = {sym: getattr(numpy, sym) for sym in FROM_NUMPY
-                              if hasattr(numpy, sym)}
+            numpy_symtable = dict((sym, getattr(numpy, sym)) for sym in FROM_NUMPY
+                              if hasattr(numpy, sym))
             symtable.update(numpy_symtable)
 
-            npy_rename_symtable = {name: getattr(numpy, sym) for name, sym
+            npy_rename_symtable = dict((name, getattr(numpy, sym)) for name, sym
                                    in NUMPY_RENAMES.items()
-                                   if hasattr(numpy, sym)}
+                                   if hasattr(numpy, sym))
             symtable.update(npy_rename_symtable)
 
         self.node_handlers = dict(((node, getattr(self, "on_%s" % node))

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -97,8 +97,8 @@ class Parameters(OrderedDict):
 
         # find the symbols that were added by users, not during construction
         sym_unique = self._asteval.user_defined_symbols()
-        unique_symbols = {key: deepcopy(self._asteval.symtable[key], memo)
-                          for key in sym_unique}
+        unique_symbols = dict((key, deepcopy(self._asteval.symtable[key], memo))
+                          for key in sym_unique)
         _pars._asteval.symtable.update(unique_symbols)
 
         # we're just about to add a lot of Parameter objects to the newly
@@ -161,8 +161,8 @@ class Parameters(OrderedDict):
 
         # find the symbols from _asteval.symtable, that need to be remembered.
         sym_unique = self._asteval.user_defined_symbols()
-        unique_symbols = {key: deepcopy(self._asteval.symtable[key])
-                          for key in sym_unique}
+        unique_symbols = dict((key, deepcopy(self._asteval.symtable[key]))
+                          for key in sym_unique)
 
         return self.__class__, (), {'unique_symbols': unique_symbols,
                                     'params': params}
@@ -197,8 +197,8 @@ class Parameters(OrderedDict):
         Update all constrained parameters, checking that dependencies are
         evaluated as needed.
         """
-        requires_update = {name for name, par in self.items()
-                           if par._expr is not None}
+        requires_update = set(name for name, par in self.items()
+                           if par._expr is not None)
         updated_tracker = set(requires_update)
 
         def _update_param(name):
@@ -261,7 +261,7 @@ class Parameters(OrderedDict):
                            vary='{vary!s:>{n}}', expr='{expr!s:>{n}}')
         line = ' '.join([otherstyles.get(k, numstyle % k) for k in allcols])
         for name, values in sorted(self.items()):
-            pvalues = {k: getattr(values, k) for k in columns}
+            pvalues = dict((k, getattr(values, k)) for k in columns)
             pvalues['name'] = name
             # stderr is a special case: it is either numeric or None (i.e. str)
             if 'stderr' in columns and pvalues['stderr'] is not None:

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -43,9 +43,9 @@ def gformat(val, length=11):
     and have at least length-6 significant digits
     """
     length = max(length, 7)
-    fmt = '{: .%ig}' % (length-6)
+    fmt = '{0: .%ig}' % (length-6)
     if isinstance(val, int):
-        out = ('{: .%ig}' % (length-2)).format(val)
+        out = ('{0: .%ig}' % (length-2)).format(val)
         if len(out) > length:
             out = fmt.format(val)
     else:
@@ -57,7 +57,7 @@ def gformat(val, length=11):
                 out = out[:ie] + '.' + out[ie:]
             out = out.replace('e', '0'*(length-len(out))+'e')
         else:
-            fmt = '{: .%ig}' % (length-1)
+            fmt = '{0: .%ig}' % (length-1)
             out = fmt.format(val)[:length]
             if len(out) < length:
                 pad = '0' if '.' in  out else ' '
@@ -133,7 +133,7 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
             serr = gformat(par.stderr, length=9)
 
             try:
-                spercent = '({:.2%})'.format(abs(par.stderr/par.value))
+                spercent = '({0:.2%})'.format(abs(par.stderr/par.value))
             except ZeroDivisionError:
                 spercent = ''
             sval = '%s +/-%s %s' % (sval, serr, spercent)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -57,12 +57,12 @@ class CommonTests(object):
         assert_results_close(result.values, self.true_values())
 
         # Pass inidividual Parameter objects as kwargs.
-        kwargs = {name: p for name, p in params.items()}
+        kwargs = dict((name, p) for name, p in params.items())
         result = self.model.fit(self.data, x=self.x, **kwargs)
         assert_results_close(result.values, self.true_values())
 
         # Pass guess values (not Parameter objects) as kwargs.
-        kwargs = {name: p.value for name, p in params.items()}
+        kwargs = dict((name, p.value) for name, p in params.items())
         result = self.model.fit(self.data, x=self.x, **kwargs)
         assert_results_close(result.values, self.true_values())
 
@@ -429,7 +429,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
 
         mx = (m1 + m2)
         params = mx.make_params()
-        param_values = {name: p.value for name, p in params.items()}
+        param_values = dict((name, p.value) for name, p in params.items())
         self.assertEqual(param_values['p1_amplitude'], 1)
         self.assertEqual(param_values['p2_amplitude'], 2)
 
@@ -448,7 +448,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
 
         m = m1 + m2
 
-        param_values = {name: p.value for name, p in params.items()}
+        param_values = dict((name, p.value) for name, p in params.items())
         self.assertTrue(param_values['m1_intercept'] < -0.0)
         self.assertEqual(param_values['m2_amplitude'], 1)
 


### PR DESCRIPTION
This PR addresses Issue #334 

Dictionary comprehensions are changed to a style compatible with Python 2.6, i.e. `dict((key, value) for key in list)`. This should continue to maintain basic py26 compatibility for now, even if it is not officially supported. No additional tests should be required.