### PR TITLE
ENH: raise error if userfcn returns non-finite number

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -25,3 +25,37 @@ The LMFIT-py code is distribution under the following license:
   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
   DEALINGS IN THIS SOFTWARE.
+
+-----------------------------------------
+Some code sections have been taken from the scipy library whose licence is below.
+
+Copyright (c) 2001, 2002 Enthought, Inc.
+All rights reserved.
+
+Copyright (c) 2003-2016 SciPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  a. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  b. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  c. Neither the name of Enthought nor the names of the SciPy Developers
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -484,12 +484,12 @@ For full control of the fitting process, you'll want to create a
    :type  iter_cb:  callable or ``None``
    :param scale_covar:  flag for automatically scaling covariance matrix and uncertainties to reduced chi-square (``leastsq`` only)
    :type  scale_covar:  bool (default ``True``).
-   :param mask_non_finite:  if ``userfcn`` returns non-finite values then a
-                            ``ValueError`` is raised. However, if
-                            ``mask_non_finite`` is set to ``True`` then those
-                            non-finite values are ignored, allowing the fit to
-                            proceed with the finite values.
-   :type  mask_non_finite: bool (default ``False``)
+   :param nan_policy: Specifies action if `userfcn` (or a Jacobian) returns nan
+            values. One of:
+                'raise' - a `ValueError` is raised
+                'propagate' - the values returned from `userfcn` are un-altered
+                'omit' - the non-finite values are filtered.
+   :type  nan_policy: str (default 'raise')
    :param kws:      dictionary to pass as keywords to the underlying :mod:`scipy.optimize` method.
    :type  kws:      dict
 

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -466,7 +466,7 @@ Using the :class:`Minimizer` class
 For full control of the fitting process, you'll want to create a
 :class:`Minimizer` object.
 
-.. class:: Minimizer(function, params, fcn_args=None, fcn_kws=None, iter_cb=None, scale_covar=True, **kws)
+.. class:: Minimizer(function, params, fcn_args=None, fcn_kws=None, iter_cb=None, scale_covar=True, mask_non_finite=False, **kws)
 
    creates a Minimizer, for more detailed access to fitting methods and attributes.
 
@@ -484,6 +484,12 @@ For full control of the fitting process, you'll want to create a
    :type  iter_cb:  callable or ``None``
    :param scale_covar:  flag for automatically scaling covariance matrix and uncertainties to reduced chi-square (``leastsq`` only)
    :type  scale_covar:  bool (default ``True``).
+   :param mask_non_finite:  if ``userfcn`` returns non-finite values then a
+                            ``ValueError`` is raised. However, if
+                            ``mask_non_finite`` is set to ``True`` then those
+                            non-finite values are ignored, allowing the fit to
+                            proceed with the finite values.
+   :type  mask_non_finite: bool (default ``False``)
    :param kws:      dictionary to pass as keywords to the underlying :mod:`scipy.optimize` method.
    :type  kws:      dict
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1326,9 +1326,6 @@ def _nan_policy(a, nan_policy='raise', handle_inf=True):
     """
 
     policies = ['propagate', 'raise', 'omit']
-    if nan_policy not in policies:
-        raise ValueError("nan_policy must be one of {%s}" %
-                         ', '.join("'%s'" % s for s in policies))
 
     if handle_inf:
         handler_func =  lambda a: ~np.isfinite(a)
@@ -1360,6 +1357,9 @@ def _nan_policy(a, nan_policy='raise', handle_inf=True):
         # nans are filtered
         mask = handler_func(a)
         return a[~mask]
+    else:
+        raise ValueError("nan_policy must be one of {%s}" %
+                         ', '.join("'%s'" % s for s in policies))
 
 
 def minimize(fcn, params, method='leastsq', args=None, kws=None,

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1254,10 +1254,9 @@ def _lnpost(theta, userfcn, params, var_names, bounds, userargs=(),
     # or filter them.
     mask = np.isnan(out)
     if mask_non_finite:
-        out = out[mask]
-    elif not np.all(mask):
-        raise ValueError("The userfcn supplied to Minimizer returned a"
-                         " non-finite value")
+        out = out[~mask]
+    elif np.any(mask):
+        raise ValueError("The userfcn supplied to Minimizer returned NaN")
 
     lnprob = np.asarray(out).ravel()
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1320,6 +1320,10 @@ def _nan_policy(a, nan_policy='raise', handle_inf=True):
     -------
     filtered_array : array_like
     """
+    """
+    This function is copied, then modified, from
+    scipy/stats/stats.py/_contains_nan
+    """
 
     policies = ['propagate', 'raise', 'omit']
     if nan_policy not in policies:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,7 @@
 import unittest
 import warnings
 import nose
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_raises
 from numpy.testing.decorators import knownfailureif
 import numpy as np
 
@@ -218,7 +218,11 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
     def test_lists_become_arrays(self):
         # smoke test
         self.model.fit([1, 2, 3], x=[1, 2, 3], **self.guess())
-        self.model.fit([1, 2, None, 3], x=[1, 2, 3, 4], **self.guess())
+        assert_raises(ValueError,
+                      self.model.fit,
+                      [1, 2, None, 3],
+                      x=[1, 2, 3, 4],
+                      **self.guess())
 
     def test_missing_param_raises_error(self):
 

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 from lmfit import minimize, Parameters, Parameter, report_fit, Minimizer
 from lmfit.minimizer import (SCALAR_METHODS, HAS_EMCEE,
-                             MinimizerResult, _lnpost)
+                             MinimizerResult, _lnpost, _nan_policy)
 from lmfit.lineshapes import gaussian
 import numpy as np
 from numpy import pi
@@ -391,8 +391,8 @@ class CommonMinimizerTest(unittest.TestCase):
                                    self.p_true.values()):
             check_wo_stderr(para, true_para.value, sig=sig)
 
-    def test_mask_non_finite(self):
-        # check that an error is raised if there are non-finite points in
+    def test_nan_policy(self):
+        # check that an error is raised if there are nan in
         # the data returned by userfcn
         self.data[0] = np.nan
 
@@ -403,14 +403,26 @@ class CommonMinimizerTest(unittest.TestCase):
 
         assert_raises(ValueError, self.mini.minimize)
 
-        # now check that the fit proceeds if mask_non_finite is True
-        self.mini.mask_non_finite = True
+        # now check that the fit proceeds if nan_policy is 'omit'
+        self.mini.nan_policy = 'omit'
         res = self.mini.minimize()
         assert_equal(res.ndata, np.size(self.data, 0) - 1)
 
         for para, true_para in zip(res.params.values(),
                                    self.p_true.values()):
             check_wo_stderr(para, true_para.value, sig=0.15)
+
+    def test_nan_policy_function(self):
+        a = np.array([0, 1, 2, 3, np.nan])
+        assert_raises(ValueError, _nan_policy, a)
+        assert_(np.isnan(_nan_policy(a, nan_policy='propagate')[-1]))
+        assert_equal(_nan_policy(a, nan_policy='omit'), [0, 1, 2, 3])
+
+        a[-1] = np.inf
+        assert_raises(ValueError, _nan_policy, a)
+        assert_(np.isposinf(_nan_policy(a, nan_policy='propagate')[-1]))
+        assert_equal(_nan_policy(a, nan_policy='omit'), [0, 1, 2, 3])
+        assert_equal(_nan_policy(a, handle_inf=False), a)
 
     @decorators.slow
     def test_emcee(self):


### PR DESCRIPTION
As discussed on ML, raise a `ValueError` if `userfcn` returns a non-finite number. This is because all of the scipy optimizers do not work in such a situation. However, the failure is insidious: the fit success is still `True` and the optimized parameters are just the initial guesses. Thus, the fit appears to work, when it is in fact not doing anything at all.
It was discussed on ML whether to raise an Error or a warning. My preference is for Error because I consider it to be an Error state. With a warning you might suspect that the situation isn't as bad as it really is.

