### PR TITLE
Add support for least_squares, deleted deprecated methods.

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -52,6 +52,14 @@ try:
 except ImportError:
     pass
 
+# check for scipy.opitimize.least_squares
+HAS_NEW_LEAST_SQUARES_MIN = False
+try:
+    from scipy.optimize import least_squares
+    HAS_NEW_LEAST_SQUARES_MIN = True
+except ImportError:
+    pass
+
 from .parameter import Parameter, Parameters
 
 # use locally modified version of uncertainties package
@@ -270,7 +278,7 @@ class Minimizer(object):
 
         return dict([(name, p.value) for name, p in self.result.params.items()])
 
-    def __residual(self, fvars):
+    def __residual(self, fvars, apply_scaling=True):
         """
         Residual function used for least-squares fit.
         With the new, candidate values of fvars (the fitting variables), this
@@ -282,11 +290,16 @@ class Minimizer(object):
         if self._abort:
             return None
         params = self.result.params
-        for name, val in zip(self.result.var_names, fvars):
-            params[name].value = params[name].from_internal(val)
+
+        if apply_scaling:
+            for name, val in zip(self.result.var_names, fvars):
+                params[name].value = params[name].from_internal(val)
+                params.update_constraints()
+        else:
+            for name, val in zip(self.result.var_names, fvars):
+                params[name].value = val
         self.result.nfev += 1
 
-        params.update_constraints()
         out = self.userfcn(params, *self.userargs, **self.userkws)
         if callable(self.iter_cb):
             abort = self.iter_cb(params, self.result.nfev, out,
@@ -348,7 +361,8 @@ class Minimizer(object):
         """
         # determine which parameters are actually variables
         # and which are defined expressions.
-        result = self.result = MinimizerResult()
+        self.result = MinimizerResult()
+        result = self.result
         if params is not None:
             self.params = params
         if isinstance(self.params, Parameters):
@@ -396,33 +410,7 @@ class Minimizer(object):
         """
         pass
 
-    @deprecate(message='    Deprecated in lmfit 0.8.2, use scalar_minimize '
-                       'and method=\'L-BFGS-B\' instead')
-    def lbfgsb(self, **kws):
-        """
-        Use l-bfgs-b minimization
 
-        Parameters
-        ----------
-        kws : dict
-            Minimizer options to pass to the
-            scipy.optimize.lbfgsb.fmin_l_bfgs_b function.
-
-        """
-        raise NotImplementedError("use scalar_minimize(method='L-BFGS-B')")
-
-    @deprecate(message='    Deprecated in lmfit 0.8.2, use scalar_minimize '
-                       'and method=\'Nelder-Mead\' instead')
-    def fmin(self, **kws):
-        """
-        Use Nelder-Mead (simplex) minimization
-
-        Parameters
-        ----------
-        kws : dict
-            Minimizer options to pass to the scipy.optimize.fmin minimizer.
-        """
-        raise NotImplementedError("use scalar_minimize(method='Nelder-Mead')")
 
     def scalar_minimize(self, method='Nelder-Mead', params=None, **kws):
         """
@@ -885,6 +873,61 @@ class Minimizer(object):
         if auto_pool is not None:
             auto_pool.terminate()
 
+        return result
+
+    def least_squares(self, params=None, **kws):
+        """
+        Use the least_squares (new in scipy 0.17) function to perform a fit.
+        This assumes that ModelParameters have been stored, and a function to
+        minimize has been properly set up. This method doesn't support
+        parameter.constraints.
+
+        This wraps scipy.optimize.least_squares, which has in build support
+        for bounds and robust loss functions.
+
+        Parameters
+        ----------
+        params : Parameters, optional
+           Parameters to use as starting points.
+        kws : dict, optional
+            Minimizer options to pass to scipy.optimize.least_squares.
+
+        """
+
+        if not HAS_NEW_LEAST_SQUARES_MIN:
+            raise NotImplementedError("Scipy with a Version higher than 0.17 "
+                                      "is need for this method.")
+
+        result = self.prepare_fit(params)
+
+        replace_none = lambda x, sign: sign*np.inf if x is None else x
+        upper_bounds = [replace_none(i.max, 1) for i in self.params.values()]
+        lower_bounds = [replace_none(i.min, -1) for i in self.params.values()]
+        start_vals = [i.value for i in self.params.values()]
+
+        ret = least_squares(self.__residual,
+                            start_vals,
+                            bounds=(lower_bounds, upper_bounds),
+                            args=(False,),  # don't use scaling for bounds.
+                            **kws
+                            )
+
+        for attr in ret:
+            setattr(result, attr, ret[attr])
+
+        result.x = np.atleast_1d(result.x)
+        result.chisqr = result.residual = self.__residual(result.x, False)
+        result.nvarys = len(start_vals)
+        result.ndata = 1
+        result.nfree = 1
+        if isinstance(result.residual, ndarray):
+            result.chisqr = (result.chisqr**2).sum()
+            result.ndata = len(result.residual)
+            result.nfree = result.ndata - result.nvarys
+        result.redchi = result.chisqr / result.nfree
+        _log_likelihood = result.ndata * np.log(result.redchi)
+        result.aic = _log_likelihood + 2 * result.nvarys
+        result.bic = _log_likelihood + np.log(result.ndata) * result.nvarys
         return result
 
     def leastsq(self, params=None, **kws):

--- a/tests/test_least_squares.py
+++ b/tests/test_least_squares.py
@@ -1,0 +1,54 @@
+from lmfit import Parameters, minimize, fit_report, Minimizer
+from lmfit_testutils import assert_paramval, assert_paramattr
+
+from numpy import linspace, zeros, sin, exp, random, pi, sign
+
+def test_bounds():
+    p_true = Parameters()
+    p_true.add('amp', value=14.0)
+    p_true.add('period', value=5.4321)
+    p_true.add('shift', value=0.12345)
+    p_true.add('decay', value=0.01000)
+
+    def residual(pars, x, data=None):
+        amp = pars['amp']
+        per = pars['period']
+        shift = pars['shift']
+        decay = pars['decay']
+
+        if abs(shift) > pi/2:
+            shift = shift - sign(shift)*pi
+
+        model = amp*sin(shift + x/per) * exp(-x*x*decay*decay)
+        if data is None:
+            return model
+        return (model - data)
+
+    n = 1500
+    xmin = 0.
+    xmax = 250.0
+    random.seed(0)
+    noise = random.normal(scale=2.80, size=n)
+    x     = linspace(xmin, xmax, n)
+    data  = residual(p_true, x) + noise
+
+    fit_params = Parameters()
+    fit_params.add('amp', value=13.0, max=20, min=0.0)
+    fit_params.add('period', value=2, max=10)
+    fit_params.add('shift', value=0.0, max=pi/2., min=-pi/2.)
+    fit_params.add('decay', value=0.02, max=0.10, min=0.00)
+
+    min = Minimizer(residual, fit_params, (x, data))
+    out = min.least_squares()
+
+
+    assert(out.nfev  > 10)
+    assert(out.nfree > 50)
+    assert(out.chisqr > 1.0)
+
+    print(fit_report(out, show_correl=True, modelpars=p_true))
+    assert_paramval(out.params['decay'], 0.01, tol=1.e-2)
+    assert_paramval(out.params['shift'], 0.123, tol=1.e-2)
+
+if __name__ == '__main__':
+    test_bounds()

--- a/tests/test_least_squares.py
+++ b/tests/test_least_squares.py
@@ -1,9 +1,13 @@
 from lmfit import Parameters, minimize, fit_report, Minimizer
+from lmfit.minimizer import HAS_LEAST_SQUARES
 from lmfit_testutils import assert_paramval, assert_paramattr
 
 from numpy import linspace, zeros, sin, exp, random, pi, sign
+import nose
 
 def test_bounds():
+    if not HAS_LEAST_SQUARES:
+        raise nose.SkipTest
     p_true = Parameters()
     p_true.add('amp', value=14.0)
     p_true.add('period', value=5.4321)
@@ -40,7 +44,6 @@ def test_bounds():
 
     min = Minimizer(residual, fit_params, (x, data))
     out = min.least_squares()
-
 
     assert(out.nfev  > 10)
     assert(out.nfree > 50)


### PR DESCRIPTION
Sorry for using the wrong repo for putting up the new branch. 

This PR adds support for new least_squares optimizer in scipy 0.17 with
inbuild support for bounds and robust likelihoods. For my problems the solver
generally is much faster than leastsq.

Not implemented yet is error estimation from the covariance matrices. This
can be done in another PR. Test failures are from 3.3 and 2.6, due to old scipy
versions. 