### PR TITLE
Prepare 0.9.4

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -6,7 +6,14 @@ To install the lmfit python module, use::
    python setup.py build
    python setup.py install
 
-Python 2.6 or higher is required, as are numpy and scipy.
+For lmfit 0.9.4, the following versions are required:
+  Python: 2.6, 2.7, 3.3, 3.4, or 3.5
+  Numpy:  1.5 or higher
+  Scipy:  0.13 or higher
+
+Note that Python 2.6 and scipy 0.13 are deprecated, and
+support and testing with them will be dropped in 0.9.5.
+
 
 Matt Newville <newville@cars.uchicago.edu>
-Last Update:  2013-Dec-15
+Last Update:  2016-July-1

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,7 +13,8 @@ Non-Linear Least-Square Minimization and Curve-Fitting for Python
 
 .. warning::
 
-  Support for Python 2.6.x will be officially dropped following version 0.9.4 (in 0.9.5)
+  Support for Python 2.6 and scipy 0.13 will be dropped with version 0.9.5.
+
 
 Lmfit provides a high-level interface to non-linear optimization and curve
 fitting problems for Python. Lmfit builds on and extends many of the

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -10,37 +10,43 @@ Downloading and Installation
 Prerequisites
 ~~~~~~~~~~~~~~~
 
-The lmfit package requires Python, Numpy, and Scipy.  Scipy version 0.13 or
-higher is recommended, but extensive testing on compatibility with various
-versions of scipy has not been done.  Lmfit works with Python 2.7, 3.3 and
-3.4.  Lmfit works with Python 2.6 only for versions <= 0.9.4. No testing has
-been done with Python 3.5, but as the package is pure Python, relying only on
-scipy and numpy, no significant troubles are expected.  The `nose`_ framework
-is required for running the test suite, and IPython and matplotib are
-recommended. If Pandas is available, it will be used in portions of lmfit.
+The lmfit package requires Python, Numpy, and Scipy.
+
+
+Lmfit works with Python 2.7, 3.3, 3.4, and 3.5 Lmfit currently does work
+with Python 2.6, but support will dropped with version 0.9.5.  Scipy
+version 0.13 or higher is required, with 0.17 or higher recommended to be
+able to use the latest optimization features from scipy.  Support for scipy
+0.13 will be dropped in version 0.9.5.  Numpy version 1.5 or higher is
+required.
+
+In order to run the test suite, the `nose`_ framework is required.  Some
+parts of lmfit will be able to make use of IPython (version 4 or higher),
+matplotlib, and pandas if those libraries are installed, but no core
+functionality of lmfit requires these.
 
 
 Downloads
 ~~~~~~~~~~~~~
 
-
-The latest stable version of lmfit is  available from `PyPi <http://pypi.python.org/pypi/lmfit/>`_.
+The latest stable version of lmfit is |release| is available from `PyPi
+<http://pypi.python.org/pypi/lmfit/>`_.
 
 Installation
 ~~~~~~~~~~~~~~~~~
 
-If you have `pip`_  installed, you can install lmfit with::
+If you have `pip`_ installed, you can install lmfit with::
 
     pip install lmfit
 
-or, if  you have `Python Setup Tools`_  installed, you install lmfit with::
-
-   easy_install -U lmfit
-
-
-or, you can download the source kit, unpack it and install with::
+or you can download the source kit, unpack it and install with::
 
    python setup.py install
+
+For Anaconda Python, lmfit is not an official packages, but several
+Anaconda channels provide it, allowing installation with (for example)::
+
+   conda install -c newville lmfit
 
 
 Development Version
@@ -49,7 +55,6 @@ Development Version
 To get the latest development version, use::
 
    git clone http://github.com/lmfit/lmfit-py.git
-
 
 and install using::
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -12,9 +12,8 @@ Prerequisites
 
 The lmfit package requires Python, Numpy, and Scipy.
 
-
-Lmfit works with Python 2.7, 3.3, 3.4, and 3.5 Lmfit currently does work
-with Python 2.6, but support will dropped with version 0.9.5.  Scipy
+Lmfit works with Python 2.7, 3.3, 3.4, and 3.5. Lmfit version 0.9.4 works
+with Python 2.6, but support for it will dropped in version 0.9.5.  Scipy
 version 0.13 or higher is required, with 0.17 or higher recommended to be
 able to use the latest optimization features from scipy.  Support for scipy
 0.13 will be dropped in version 0.9.5.  Numpy version 1.5 or higher is

--- a/lmfit/__init__.py
+++ b/lmfit/__init__.py
@@ -63,6 +63,6 @@ if sys.version_info[:2] == (2, 6):
 import scipy
 scipy_major, scipy_minor, scipy_other = scipy.__version__.split('.', 2)
 
-if in(scipy_major) == 0 and int(scipy_minor) < 14:
+if int(scipy_major) == 0 and int(scipy_minor) < 14:
     print '--> warn'
     warnings.warn('Support for Scipy 0.13 will be dropped in lmfit 0.9.5')

--- a/lmfit/__init__.py
+++ b/lmfit/__init__.py
@@ -57,4 +57,12 @@ del get_versions
 
 # PY26 Depreciation Warning
 if sys.version_info[:2] == (2, 6):
-    warnings.warn('Support for Python 2.6.x is depreciated in Lmfit 0.9.4 and will be dropped in 0.9.5', DeprecationWarning)
+    warnings.warn('Support for Python 2.6.x  will be dropped in lmfit 0.9.5')
+
+# SCIPY 0.13 Depreciation Warning
+import scipy
+scipy_major, scipy_minor, scipy_other = scipy.__version__.split('.', 2)
+
+if in(scipy_major) == 0 and int(scipy_minor) < 14:
+    print '--> warn'
+    warnings.warn('Support for Scipy 0.13 will be dropped in lmfit 0.9.5')

--- a/lmfit/__init__.py
+++ b/lmfit/__init__.py
@@ -25,8 +25,8 @@ from scipy.optimize.  It has a number of useful enhancements, including:
 
   * Many pre-built models for common lineshapes are included and ready to use.
 
-   version: 0.8.0
-   last update: 2014-Sep-21
+   version: 0.9.4
+   last update: 2016-Jul-1
    License: MIT
    Authors:  Matthew Newville, The University of Chicago
              Till Stensitzki, Freie Universitat Berlin
@@ -64,5 +64,4 @@ import scipy
 scipy_major, scipy_minor, scipy_other = scipy.__version__.split('.', 2)
 
 if int(scipy_major) == 0 and int(scipy_minor) < 14:
-    print '--> warn'
     warnings.warn('Support for Scipy 0.13 will be dropped in lmfit 0.9.5')


### PR DESCRIPTION
This add deprecation notices for Python 2.6 and scipy 0.13 to the code and docs.

When merged, I propose this be tagged as 0.9.4rc1



