### PR TITLE
Make MinimizerResult API more similar to ModelResult

### DIFF
--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -458,25 +458,7 @@ For full control of the fitting process, you'll want to create a
 
 The Minimizer object has a few public methods:
 
-.. method:: minimize(method='leastsq', params=None, **kws)
-
-   perform fit using either :meth:`leastsq` or :meth:`scalar_minimize`.
-
-   :param method: name of fitting method.  Must be one of the names in
-		  :ref:`Table of Supported Fitting Methods <fit-methods-table>`
-   :type  method:  str.
-   :param params:  a :class:`Parameters` dictionary for starting values
-   :type  params:  :class:`Parameters` or `None`
-
-   :return: :class:`MinimizerResult` object, containing updated
-	    parameters, fitting statistics, and information.
-
-.. versionchanged:: 0.9.0
-   return value changed to :class:`MinimizerResult`
-
-   Additional keywords are passed on to the correspond :meth:`leastsq`
-   or :meth:`scalar_minimize` method.
-
+.. automethod:: Minimizer.minimize
 
 .. method:: leastsq(params=None, scale_covar=True, **kws)
 

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -15,7 +15,9 @@ when using complicated constraints or comparing results from related fits.
 
 
 The :func:`minimize` function
-===============================
+=============================
+
+.. currentmodule:: lmfit.minimizer
 
 The :func:`minimize` function is a wrapper around :class:`Minimizer` for
 running an optimization problem.  It takes an objective function (the
@@ -23,51 +25,7 @@ function that calculates the array to be minimized), a :class:`Parameters`
 object, and several optional arguments.  See :ref:`fit-func-label` for
 details on writing the objective.
 
-.. currentmodule:: minimizer
-
-.. function:: minimize(function, params[, args=None[, kws=None[, method='leastsq'[, scale_covar=True[, iter_cb=None[, **fit_kws]]]]]])
-
-   find values for the ``params`` so that the sum-of-squares of the array returned
-   from ``function`` is minimized.
-
-   :param function:  function to return fit residual.  See :ref:`fit-func-label` for details.
-   :type  function:  callable.
-   :param params:  a :class:`Parameters` dictionary.  Keywords must be strings
-		   that match ``[a-z_][a-z0-9_]*`` and cannot be a python
-		   reserved word.  Each value must be :class:`Parameter`.
-   :type  params:  :class:`Parameters`.
-   :param args:  arguments tuple to pass to the residual function as  positional arguments.
-   :type  args:  tuple
-   :param kws:   dictionary to pass to the residual function as keyword arguments.
-   :type  kws:  dict
-   :param method:  name of fitting method to use. See  :ref:`fit-methods-label` for details
-   :type  method:  string (default ``leastsq``)
-   :param scale_covar:  whether to automatically scale covariance matrix (``leastsq`` only)
-   :type  scale_covar:  bool (default ``True``)
-   :param iter_cb:  function to be called at each fit iteration. See :ref:`fit-itercb-label` for details.
-   :type  iter_cb:  callable or ``None``
-   :param fit_kws:  dictionary to pass to :scipydoc:`optimize.leastsq` or :scipydoc:`optimize.minimize`.
-   :type  fit_kws:  dict
-
-   :return: :class:`MinimizerResult` instance, which will contain the
-	    optimized parameter, and several goodness-of-fit statistics.
-
-.. versionchanged:: 0.9.0
-   return value changed to :class:`MinimizerResult`
-
-
-   On output, the params will be unchanged.  The best-fit values, and where
-   appropriate, estimated uncertainties and correlations, will all be
-   contained in the returned :class:`MinimizerResult`.  See
-   :ref:`fit-results-label` for further details.
-
-   For clarity, it should be emphasized that this function is simply a
-   wrapper around :class:`Minimizer` that runs a single fit, implemented as::
-
-    fitter = Minimizer(fcn, params, fcn_args=args, fcn_kws=kws,
-		       iter_cb=iter_cb, scale_covar=scale_covar, **fit_kws)
-    return fitter.minimize(method=method)
-
+.. autofunction:: minimize
 
 ..  _fit-func-label:
 

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -133,7 +133,7 @@ class as listed in the :ref:`Table of Supported Fitting Methods
  +-----------------------+------------------------------------------------------------------+
  | Fitting Method        | ``method`` arg to :func:`minimize` or :meth:`Minimizer.minimize` |
  +=======================+==================================================================+
- | Levenberg-Marquardt   |  ``leastsq``                                                     |
+ | Levenberg-Marquardt   |  ``leastsq`` or ``least_squares``                                |
  +-----------------------+------------------------------------------------------------------+
  | Nelder-Mead           |  ``nelder``                                                      |
  +-----------------------+------------------------------------------------------------------+
@@ -178,10 +178,6 @@ class as listed in the :ref:`Table of Supported Fitting Methods
 :class:`MinimizerResult` -- the optimization result
 ========================================================
 
-
-
-.. class:: MinimizerResult(**kws)
-
 .. versionadded:: 0.9.0
 
 An optimization with :func:`minimize` or :meth:`Minimizer.minimize`
@@ -195,6 +191,10 @@ Importantly, the parameters passed in to :meth:`Minimizer.minimize`
 will be not be changed.  To to find the best-fit values, uncertainties
 and so on for each parameter, one must use the
 :attr:`MinimizerResult.params` attribute.
+
+.. autoclass:: MinimizerResult
+
+The list of (possible) attributes follows:
 
 .. attribute::   params
 
@@ -215,6 +215,10 @@ and so on for each parameter, one must use the
 .. attribute:: init_vals
 
   list of initial values for variable parameters using :attr:`var_names`.
+
+.. attribute:: init_vals
+
+    dict of initial values for variable parameters.
 
 .. attribute::  nfev
 
@@ -294,9 +298,9 @@ Goodness-of-Fit Statistics
 +----------------------+----------------------------------------------------------------------------+
 |    ndata             | number of data points:  :math:`N`                                          |
 +----------------------+----------------------------------------------------------------------------+
-|    nfree `           | degrees of freedom in fit:  :math:`N - N_{\rm varys}`                      |
+|    nfree             | degrees of freedom in fit:  :math:`N - N_{\rm varys}`                      |
 +----------------------+----------------------------------------------------------------------------+
-|    residual          | residual array, return value of :func:`func`:  :math:`{\rm Resid}`         |
+|    residual          | residual array, returned by the objective function: :math:`\{\rm Resid_i\}`|
 +----------------------+----------------------------------------------------------------------------+
 |    chisqr            | chi-square: :math:`\chi^2 = \sum_i^N [{\rm Resid}_i]^2`                    |
 +----------------------+----------------------------------------------------------------------------+

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -386,7 +386,7 @@ class Minimizer(object):
             r = (r*r).sum()
         return r
 
-    def prepare_fit(self, params):
+    def prepare_fit(self, params=None):
         """
         Prepares parameters for fitting,
         return array of initial values

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1400,9 +1400,10 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
         objective function to be minimized. When method is `leastsq` or
         `least_squares`, the objective function should return an array
         of residuals (difference between model and data) to be minimized
-        in a least squares sense.  With other scalar methods the objective
-        function need ot return a scalar. The function must have the
-        signature: `fcn(params, *args, **kws)`
+        in a least squares sense. With the scalar methods the objective
+        function can either return the residuals array or a single scalar
+        value. The function must have the signature:
+        `fcn(params, *args, **kws)`
     params : `lmfit.parameter.Parameters` object.
         contains the Parameters for the model.
     method : str, optional

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1394,21 +1394,6 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     to be minimized, a dictionary (:class:`lmfit.parameter.Parameters`)
     containing the model parameters, and several optional arguments.
 
-    Notes
-    -----
-    The objective function should return the value to be minimized. For the
-    Levenberg-Marquardt algorithm from leastsq(), this returned value must
-    be an array, with a length greater than or equal to the number of
-    fitting variables in the model. For the other methods, the return value
-    can either be a scalar or an array. If an array is returned, the sum of
-    squares of the array will be sent to the underlying fitting method,
-    effectively doing a least-squares optimization of the return values.
-
-    A common use for `args` and `kwds` would be to pass in other
-    data needed to calculate the residual, including such things as the
-    data array, dependent variable, uncertainties in the data, and other
-    data structures for the model calculation.
-
     Parameters
     ----------
     fcn : callable
@@ -1467,6 +1452,21 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
 
     .. versionchanged:: 0.9.0
         return value changed to :class:`MinimizerResult`.
+
+    Notes
+    -----
+    The objective function should return the value to be minimized. For the
+    Levenberg-Marquardt algorithm from leastsq(), this returned value must
+    be an array, with a length greater than or equal to the number of
+    fitting variables in the model. For the other methods, the return value
+    can either be a scalar or an array. If an array is returned, the sum of
+    squares of the array will be sent to the underlying fitting method,
+    effectively doing a least-squares optimization of the return values.
+
+    A common use for `args` and `kwds` would be to pass in other
+    data needed to calculate the residual, including such things as the
+    data array, dependent variable, uncertainties in the data, and other
+    data structures for the model calculation.
 
     On output, the params will be unchanged.  The best-fit values, and where
     appropriate, estimated uncertainties and correlations, will all be

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1377,51 +1377,11 @@ def _nan_policy(a, nan_policy='raise', handle_inf=True):
 def minimize(fcn, params, method='leastsq', args=None, kws=None,
              scale_covar=True, iter_cb=None, **fit_kws):
     """
-    A general purpose curvefitting function
-    The minimize function takes a objective function to be minimized, a
-    dictionary (lmfit.parameter.Parameters) containing the model parameters,
-    and several optional arguments.
-
-    Parameters
-    ----------
-    fcn : callable
-        objective function that returns the residual (difference between
-        model and data) to be minimized in a least squares sense.  The
-        function must have the signature:
-        `fcn(params, *args, **kws)`
-    params : lmfit.parameter.Parameters object.
-        contains the Parameters for the model.
-    method : str, optional
-        Name of the fitting method to use.
-        One of:
-            'leastsq'                -    Levenberg-Marquardt (default)
-            'nelder'                 -    Nelder-Mead
-            'lbfgsb'                 -    L-BFGS-B
-            'powell'                 -    Powell
-            'cg'                     -    Conjugate-Gradient
-            'newton'                 -    Newton-CG
-            'cobyla'                 -    Cobyla
-            'tnc'                    -    Truncate Newton
-            'trust-ncg'              -    Trust Newton-CGn
-            'dogleg'                 -    Dogleg
-            'slsqp'                  -    Sequential Linear Squares Programming
-            'differential_evolution' -    differential evolution
-
-    args : tuple, optional
-        Positional arguments to pass to fcn.
-    kws : dict, optional
-        keyword arguments to pass to fcn.
-    iter_cb : callable, optional
-        Function to be called at each fit iteration. This function should
-        have the signature `iter_cb(params, iter, resid, *args, **kws)`,
-        where where `params` will have the current parameter values, `iter`
-        the iteration, `resid` the current residual array, and `*args`
-        and `**kws` as passed to the objective function.
-    scale_covar : bool, optional
-        Whether to automatically scale the covariance matrix (leastsq
-        only).
-    fit_kws : dict, optional
-        Options to pass to the minimizer being used.
+    This function performs a fit of a set of parameters by minimizing
+    an objective (or "cost") function using one one of the several
+    available methods. The minimize function takes a objective function
+    to be minimized, a dictionary (:class:`lmfit.parameter.Parameters`)
+    containing the model parameters, and several optional arguments.
 
     Notes
     -----
@@ -1437,6 +1397,79 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     data needed to calculate the residual, including such things as the
     data array, dependent variable, uncertainties in the data, and other
     data structures for the model calculation.
+
+    Parameters
+    ----------
+    fcn : callable
+        objective function to be minimized. When method is `leastsq` or
+        `least_squares`, the objective function need to return an array
+        of residuals (difference between model and data) to be minimized
+        in a least squares sense.  With other scalar methods the objective
+        function need ot return a scalar. The function must have the
+        signature: `fcn(params, *args, **kws)`
+    params : `lmfit.parameter.Parameters` object.
+        contains the Parameters for the model.
+    method : str, optional
+        Name of the fitting method to use.
+        One of:
+
+        - `'leastsq'`: Levenberg-Marquardt (default).
+          Uses `scipy.optimize.leastsq`.
+        - `'least_squares'`: Levenberg-Marquardt.
+          Uses `scipy.optimize.least_squares`.
+        - 'nelder': Nelder-Mead
+        - `'lbfgsb'`: L-BFGS-B
+        - `'powell'`: Powell
+        - `'cg'`: Conjugate-Gradient
+        - `'newton'`: Newton-CG
+        - `'cobyla'`: Cobyla
+        - `'tnc'`: Truncate Newton
+        - `'trust-ncg'`: Trust Newton-CGn
+        - `'dogleg'`: Dogleg
+        - `'slsqp'`: Sequential Linear Squares Programming
+        - `'differential_evolution'`: differential evolution
+
+        For more details on the fitting methods refer to the
+        `scipy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
+
+    args : tuple, optional
+        Positional arguments to pass to `fcn`.
+    kws : dict, optional
+        keyword arguments to pass to `fcn`.
+    iter_cb : callable, optional
+        Function to be called at each fit iteration. This function should
+        have the signature `iter_cb(params, iter, resid, *args, **kws)`,
+        where where `params` will have the current parameter values, `iter`
+        the iteration, `resid` the current residual array, and `*args`
+        and `**kws` as passed to the objective function.
+    scale_covar : bool, optional
+        Whether to automatically scale the covariance matrix (leastsq
+        only).
+    fit_kws : dict, optional
+        Options to pass to the minimizer being used.
+
+    Returns
+    -------
+    MinimizerResult
+        instance, which will contain the optimized parameter
+        and several goodness-of-fit statistics.
+
+
+    .. versionchanged:: 0.9.0
+        return value changed to :class:`MinimizerResult`.
+
+    On output, the params will be unchanged.  The best-fit values, and where
+    appropriate, estimated uncertainties and correlations, will all be
+    contained in the returned :class:`MinimizerResult`.  See
+    :ref:`fit-results-label` for further details.
+
+    This function is simply a wrapper around :class:`Minimizer`
+    and is equivalent to::
+
+        fitter = Minimizer(fcn, params, fcn_args=args, fcn_kws=kws,
+        	           iter_cb=iter_cb, scale_covar=scale_covar, **fit_kws)
+        fitter.minimize(method=method)
+
     """
     fitter = Minimizer(fcn, params, fcn_args=args, fcn_kws=kws,
                        iter_cb=iter_cb, scale_covar=scale_covar, **fit_kws)

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -386,7 +386,7 @@ class Minimizer(object):
             r = (r*r).sum()
         return r
 
-    def prepare_fit(self, params, method):
+    def prepare_fit(self, params):
         """
         Prepares parameters for fitting,
         return array of initial values
@@ -395,7 +395,6 @@ class Minimizer(object):
         # and which are defined expressions.
         self.result = MinimizerResult()
         result = self.result
-        result.method = method
         if params is not None:
             self.params = params
         if isinstance(self.params, Parameters):
@@ -491,7 +490,8 @@ class Minimizer(object):
         if not HAS_SCALAR_MIN:
             raise NotImplementedError
 
-        result = self.prepare_fit(params=params, method=method)
+        result = self.prepare_fit(params=params)
+        result.method = method
         vars = result.init_vals
         params = result.params
 
@@ -751,7 +751,8 @@ class Minimizer(object):
                 nwalkers = self._lastpos.shape[1]
             tparams = None
 
-        result = self.prepare_fit(params=tparams, method='emcee')
+        result = self.prepare_fit(params=tparams)
+        result.method = 'emcee'
         params = result.params
 
         # check if the userfcn returns a vector of residuals
@@ -931,7 +932,8 @@ class Minimizer(object):
             raise NotImplementedError("Scipy with a version higher than 0.17 "
                                       "is needed for this method.")
 
-        result = self.prepare_fit(params, method='least_squares')
+        result = self.prepare_fit(params)
+        result.method = 'least_squares'
 
         replace_none = lambda x, sign: sign*np.inf if x is None else x
         upper_bounds = [replace_none(i.max, 1) for i in self.params.values()]
@@ -989,7 +991,8 @@ class Minimizer(object):
         success : bool
             True if fit was successful, False if not.
         """
-        result = self.prepare_fit(params=params, method='leastsq')
+        result = self.prepare_fit(params=params)
+        result.method = 'leastsq'
         vars = result.init_vals
         nvars = len(vars)
         lskws = dict(full_output=1, xtol=1.e-7, ftol=1.e-7, col_deriv=False,

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -431,8 +431,8 @@ class Minimizer(object):
             if par.name is None:
                 par.name = name
         result.nvarys = len(result.var_names)
-        result.init_values = {n: v for n, v in zip(result.var_names,
-                                                   result.init_vals)}
+        result.init_values = dict([(n, v) for n, v in zip(result.var_names,
+                                                          result.init_vals)])
         return result
 
     def unprepare_fit(self):

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1149,12 +1149,12 @@ class Minimizer(object):
             For more details on the fitting methods please refer to the
             `scipy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
 
-        params : `lmfit.parameter.Parameters` object.
+        params : :class:`lmfit.parameter.Parameters` object.
             Parameters of the model to use as starting values.
 
         **kwargs
-            Additional arguments to be passed to the underlying minimization
-            function.
+            Additional arguments are passed to the underlying minimization
+            method.
 
         Returns
         -------
@@ -1162,6 +1162,9 @@ class Minimizer(object):
             Object containing the optimized parameter
             and several goodness-of-fit statistics.
 
+
+        .. versionchanged:: 0.9.0
+           return value changed to :class:`MinimizerResult`
         """
 
         function = self.leastsq
@@ -1404,7 +1407,7 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
         function can either return the residuals array or a single scalar
         value. The function must have the signature:
         `fcn(params, *args, **kws)`
-    params : `lmfit.parameter.Parameters` object.
+    params : :class:`lmfit.parameter.Parameters` object.
         contains the Parameters for the model.
     method : str, optional
         Name of the fitting method to use. Valid values are:

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1155,8 +1155,10 @@ class Minimizer(object):
         kwargs.update(kws)
 
         user_method = method.lower()
-        if user_method.startswith('least'):
+        if user_method.startswith('leasts'):
             function = self.leastsq
+        elif user_method.startswith('least_s'):
+            function = self.least_squares
         elif HAS_SCALAR_MIN:
             function = self.scalar_minimize
             for key, val in SCALAR_METHODS.items():

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1398,7 +1398,7 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     ----------
     fcn : callable
         objective function to be minimized. When method is `leastsq` or
-        `least_squares`, the objective function need to return an array
+        `least_squares`, the objective function should return an array
         of residuals (difference between model and data) to be minimized
         in a least squares sense.  With other scalar methods the objective
         function need ot return a scalar. The function must have the

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -146,12 +146,13 @@ SCALAR_METHODS = {'nelder': 'Nelder-Mead',
 
 
 class MinimizerResult(object):
-    """ The result of a minimization.
+    """
+    The result of a minimization.
 
     Attributes
     ----------
-    params : Parameters
-        The best-fit parameters
+    params : lmfit.parameters.Parameters
+        The best-fit parameters resulting from the fit.
     success : bool
         Whether the minimization was successful
     status : int
@@ -1127,29 +1128,39 @@ class Minimizer(object):
         Parameters
         ----------
         method : str, optional
-            Name of the fitting method to use.
-            One of:
-            'leastsq'                -    Levenberg-Marquardt (default)
-            'nelder'                 -    Nelder-Mead
-            'lbfgsb'                 -    L-BFGS-B
-            'powell'                 -    Powell
-            'cg'                     -    Conjugate-Gradient
-            'newton'                 -    Newton-CG
-            'cobyla'                 -    Cobyla
-            'tnc'                    -    Truncate Newton
-            'trust-ncg'              -    Trust Newton-CGn
-            'dogleg'                 -    Dogleg
-            'slsqp'                  -    Sequential Linear Squares Programming
-            'differential_evolution' -    differential evolution
+            Name of the fitting method to use. Valid values are:
 
-        params : Parameters, optional
-            parameters to use as starting values
+            - `'leastsq'`: Levenberg-Marquardt (default).
+              Uses `scipy.optimize.leastsq`.
+            - `'least_squares'`: Levenberg-Marquardt.
+              Uses `scipy.optimize.least_squares`.
+            - 'nelder': Nelder-Mead
+            - `'lbfgsb'`: L-BFGS-B
+            - `'powell'`: Powell
+            - `'cg'`: Conjugate-Gradient
+            - `'newton'`: Newton-CG
+            - `'cobyla'`: Cobyla
+            - `'tnc'`: Truncate Newton
+            - `'trust-ncg'`: Trust Newton-CGn
+            - `'dogleg'`: Dogleg
+            - `'slsqp'`: Sequential Linear Squares Programming
+            - `'differential_evolution'`: differential evolution
+
+            For more details on the fitting methods please refer to the
+            `scipy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
+
+        params : `lmfit.parameter.Parameters` object.
+            Parameters of the model to use as starting values.
+
+        **kwargs
+            Additional arguments to be passed to the underlying minimization
+            function.
 
         Returns
         -------
-        result : MinimizerResult
-
-            MinimizerResult object contains updated params, fit statistics, etc.
+        MinimizerResult
+            Object containing the optimized parameter
+            and several goodness-of-fit statistics.
 
         """
 
@@ -1410,8 +1421,7 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     params : `lmfit.parameter.Parameters` object.
         contains the Parameters for the model.
     method : str, optional
-        Name of the fitting method to use.
-        One of:
+        Name of the fitting method to use. Valid values are:
 
         - `'leastsq'`: Levenberg-Marquardt (default).
           Uses `scipy.optimize.leastsq`.
@@ -1429,7 +1439,7 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
         - `'slsqp'`: Sequential Linear Squares Programming
         - `'differential_evolution'`: differential evolution
 
-        For more details on the fitting methods refer to the
+        For more details on the fitting methods please refer to the
         `scipy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
 
     args : tuple, optional
@@ -1451,7 +1461,7 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     Returns
     -------
     MinimizerResult
-        instance, which will contain the optimized parameter
+        Object containing the optimized parameter
         and several goodness-of-fit statistics.
 
 


### PR DESCRIPTION
In the process of adding support for MinimizerResult in [pybroom](https://github.com/tritemio/pybroom) I found some little inconsistencies between MinimizerResult and ModelResult in lmfit.

This PR makes the interface of the two classes more similar by adding to MinimizerResults two attributes: the dict `init_values` and string `method`.
