### PR TITLE
Fix ignored kws in Minimizer.minimize

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -242,7 +242,7 @@ class Minimizer(object):
                  iter_cb=None, scale_covar=True, nan_policy='raise',
                  **kws):
         """
-        The Minimzer class initialization accepts the following parameters:
+        The Minimizer class initialization accepts the following parameters:
 
         Parameters
         ----------
@@ -1275,6 +1275,7 @@ class Minimizer(object):
 
         function = self.leastsq
         kwargs = {'params': params}
+        kwargs.update(self.kws)
         kwargs.update(kws)
 
         user_method = method.lower()

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -967,8 +967,6 @@ class ModelResult(Minimizer):
             data_kws = {}
         if fit_kws is None:
             fit_kws = {}
-        if fit_kws is None:
-            fit_kws = {}
         if ax_kws is None:
             ax_kws = {}
 


### PR DESCRIPTION
Keyword arguments (to be passed to scipy.optimize functions) can be given during initializations of Minimizer object. However, Minimizer.minimize does not relays these arguments.

This also causes that the dict `fit_kws` passed to `Model.fit` was ignored.