### PR TITLE
Custom cost, replaces #226

### DIFF
--- a/examples/example_stable.py
+++ b/examples/example_stable.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Example using the t-likelihood for stable fitting.
+"""
+import numpy as np
+import scipy.special as sp
+import scipy.stats as stats
+import lmfit
+try:
+    import matplotlib.pyplot as plt
+    HAS_PYLAB = True
+except ImportError:
+    HAS_PYLAB = False
+
+np.random.seed(1)
+x = np.linspace(-5, 5, 30)
+
+# Setup example
+amp_erf = 5
+w = 0.3
+c = 1
+amp_sin = 2
+omega = 3
+
+y = amp_erf*sp.erf(x/w)+2*np.sin(x*omega)+c
+yn = y + np.random.randn(*y.shape)*1.5
+outliers = np.random.randint(0, x.size-1, x.size/5)
+yn[outliers] += np.random.randn(outliers.size)*10
+
+if HAS_PYLAB:
+    plt.style.use('fivethirtyeight')
+    plt.figure(figsize=(8, 5))
+    plt.plot(x, y, lw=3)
+    plt.plot(x, yn, 'o')
+
+def func(x, amp_erf, w, c, omega, amp_sin):
+    y_model = amp_erf*sp.erf(x/w) + amp_sin* np.sin(x*omega) + c
+    return y_model
+def logln(x):
+    "Returning the t-log-likehood of x with df=3"
+    return -stats.t.logpdf(x, df=2).sum()
+mod = lmfit.model.Model(func, ['x'], residual2scalar=logln)
+res = mod.fit(yn, x=x, w=1, c=1, omega=3, amp_sin=2, amp_erf=3)
+
+
+if HAS_PYLAB:
+    plt.plot(x, res.best_fit, 'k', lw=3)
+    plt.plot(x, res.eval(), 'r', lw=3)
+    plt.legend(['True function', 'w. noise+outliers',
+                'Fit', 'Robust Fit'], loc='upper left')

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -3,10 +3,8 @@ Simple minimizer is a wrapper around scipy.leastsq, allowing a
 user to build a fitting model as a function of general purpose
 Fit Parameters that can be fixed or floated, bounded, and written
 as a simple expression of other Fit Parameters.
-
 The user sets up a model in terms of instance of Parameters, writes a
 function-to-be-minimized (residual function) in terms of these Parameters.
-
    Copyright (c) 2011 Matthew Newville, The University of Chicago
    <newville@cars.uchicago.edu>
 """
@@ -95,7 +93,6 @@ def eval_stderr(obj, uvars, _names, _pars):
     given the uncertain values `uvars` (a list of uncertainties.ufloats),
     a list of parameter names that matches uvars, and a dict of param
     objects, keyed by name.
-
     This uses the uncertainties package wrapped function to evaluate the
     uncertainty for an arbitrary expression (in obj._expr_ast) of parameters.
     """
@@ -151,14 +148,11 @@ SCALAR_METHODS = {'nelder': 'Nelder-Mead',
 class MinimizerResult(object):
     """
     A class that holds the results of a minimization.
-
     This is a plain container (with no methods of its own) that
     simply holds the results of the minimization.  Fit results
     include data such as status and error messages, fit statistics,
     and the updated (i.e. best-fit) parameters themselves :attr:`params`.
-
     The list of (possible) `MinimizerResult` attributes follows.
-
     Attributes
     ----------
     params : :class:`lmfit.parameter.Parameters`
@@ -207,7 +201,6 @@ class MinimizerResult(object):
         Akaike Information Criterion statistic.
     bic : float
         Bayesian Information Criterion statistic.
-
     """
     def __init__(self, **kws):
         for key, val in kws.items():
@@ -239,11 +232,10 @@ class Minimizer(object):
                    "or set leastsq_kws['maxfev']  to increase this maximum.")
 
     def __init__(self, userfcn, params, fcn_args=None, fcn_kws=None,
-                 iter_cb=None, scale_covar=True, nan_policy='raise',
+                 iter_cb=None, scale_covar=True, nan_policy='raise',residual2scalar=None,
                  **kws):
         """
         The Minimizer class initialization accepts the following parameters:
-
         Parameters
         ----------
         userfcn : callable
@@ -270,14 +262,15 @@ class Minimizer(object):
         nan_policy : str, optional
             Specifies action if `userfcn` (or a Jacobian) returns nan
             values. One of:
-
                 - 'raise' - a `ValueError` is raised
                 - 'propagate' - the values returned from `userfcn` are un-altered
                 - 'omit' - the non-finite values are filtered.
-
+        residual2scalar: function, optional
+            Specifies a function used to reduce residuals to a scalar for
+            minimization. The sum of squares will be used if this is not
+            passed.
         kws : dict, optional
             Options to pass to the minimizer being used.
-
         Notes
         -----
         The objective function should return the value to be minimized. For the
@@ -290,7 +283,6 @@ class Minimizer(object):
         effectively doing a least-squares optimization of the return values. If
         the objective function returns non-finite values then a `ValueError`
         will be raised because the underlying solvers cannot deal with them.
-
         A common use for the `fcn_args` and `fcn_kwds` would be to pass in
         other data needed to calculate the residual, including such things
         as the data array, dependent variable, uncertainties in the data,
@@ -324,6 +316,7 @@ class Minimizer(object):
         self.params = params
         self.jacfcn = None
         self.nan_policy = nan_policy
+        self.residual2scalar=residual2scalar
 
     @property
     def values(self):
@@ -338,7 +331,6 @@ class Minimizer(object):
         evaluates all parameters, including setting bounds and evaluating
         constraints, and then passes those to the user-supplied function to
         calculate the residual.
-
         Parameters
         ----------------
         fvars : np.ndarray
@@ -347,7 +339,6 @@ class Minimizer(object):
             If true, apply lmfits parameter transformation to constrain
             parameters. This is needed for solvers without inbuilt support for
             bounds.
-
         Returns
         -----------
         residuals : np.ndarray
@@ -382,7 +373,6 @@ class Minimizer(object):
     def __jacobian(self, fvars):
         """
         analytical jacobian to be used with the Levenberg-Marquardt
-
         modified 02-01-2012 by Glenn Jones, Aberystwyth University
         modified 06-29-2015 M Newville to apply gradient scaling
                for bounded variables (thanks to JJ Helmus, N Mayorov)
@@ -408,7 +398,7 @@ class Minimizer(object):
             jac *= grad_scale
         return jac
 
-    def penalty(self, fvars):
+    def penalty(self, fvars, residual2scalar=None):
         """
         Penalty function for scalar minimizers.
 
@@ -417,32 +407,34 @@ class Minimizer(object):
         fvars : numpy.ndarray
             Array of values for the variable parameters
 
+        residual2scalar : Used to reduce the residuals to a scalar if the resisduals
+            are an array of size greater than 1. If this is None, the sum of squares
+            will be used.
+
         Returns
         -------
         r : float
-            The user evaluated user-supplied objective function. If the
-            objective function is an array of size greater than 1, return the
-            array sum-of-squares
+            The user evaluated user-supplied objective function. Or the result
+            of reducing the object function with residual2scalar.
         """
         r = self.__residual(fvars)
+        if residual2scalar is None: # use sum of squares as default
+            residual2scalar = lambda x: (x*x).sum()
         if isinstance(r, ndarray) and r.size > 1:
-            r = (r*r).sum()
+            r = residual2scalar(r)
         return r
 
     def prepare_fit(self, params=None):
         """
         Prepares parameters for fitting, return array of initial values.
-
         Prepares and initializes model and Parameters for subsequent
         fitting. This routine prepares the conversion of :class:`Parameters`
         into fit variables, organizes parameter bounds, and parses, "compiles"
         and checks constrain expressions.   The method also creates and returns
         a new instance of a :class:`MinimizerResult` object that contains the
         copy of the Parameters that will actually be varied in the fit.
-
         This method is called directly by the fitting methods, and it is
         generally not necessary to call this function explicitly.
-
         .. versionchanged:: 0.9.0
             Return value changed to :class:`MinimizerResult`.
         """
@@ -493,7 +485,6 @@ class Minimizer(object):
     def unprepare_fit(self):
         """
         Clean fit state, so that subsequent fits will need to call prepare_fit.
-
         Removes AST compilations of constraint expressions.
         """
         pass
@@ -501,10 +492,8 @@ class Minimizer(object):
     def scalar_minimize(self, method='Nelder-Mead', params=None, **kws):
         """
         Scalar minimization using :scipydoc:`scipy.optimize.minimize`.
-
         Perform fit with any of the scalar minimization algorithms supported by
         :scipydoc:`scipy.optimize.minimize`. Default argument values are:
-
         +-------------------------+-----------------+-----------------------------------------------------+
         | :meth:`scalar_minimize` | Default Value   | Description                                         |
         | arg                     |                 |                                                     |
@@ -515,14 +504,11 @@ class Minimizer(object):
         +-------------------------+-----------------+-----------------------------------------------------+
         |   hess                  | None            | Hessian of objective function                       |
         +-------------------------+-----------------+-----------------------------------------------------+
-
-
         Parameters
         ----------
         method : str, optional
             Name of the fitting method to use.
             One of:
-
             - 'Nelder-Mead' (default)
             - 'L-BFGS-B'
             - 'Powell'
@@ -534,28 +520,22 @@ class Minimizer(object):
             - 'dogleg'
             - 'SLSQP'
             - 'differential_evolution'
-
         params : Parameters, optional
            Parameters to use as starting points.
         kws : dict, optional
             Minimizer options pass to :scipydoc:`scipy.optimize.minimize`.
-
         Returns
         -------
         :class:`MinimizerResult`
             Object containing the optimized parameter
             and several goodness-of-fit statistics.
-
-
         .. versionchanged:: 0.9.0
            Return value changed to :class:`MinimizerResult`.
-
         Notes
         -----
         If the objective function returns a numpy array instead
         of the expected scalar, the sum of squares of the array
         will be used.
-
         Note that bounds and constraints can be set on Parameters
         for any of these methods, so are not supported separately
         for those designed to use bounds. However, if you use the
@@ -588,6 +568,8 @@ class Minimizer(object):
             self.jacfcn = None
             fmin_kws.pop('jac')
 
+        penalty_func = lambda x: self.penalty(x, self.residual2scalar)
+
         if method == 'differential_evolution':
             fmin_kws['method'] = _differential_evolution
             bounds = np.asarray([(par.min, par.max)
@@ -603,9 +585,9 @@ class Minimizer(object):
             # in scipy 0.14 this can be called directly from scipy_minimize
             # When minimum scipy is 0.14 the following line and the else
             # can be removed.
-            ret = _differential_evolution(self.penalty, vars, **fmin_kws)
+            ret = _differential_evolution(penalty_func, vars, **fmin_kws)
         else:
-            ret = scipy_minimize(self.penalty, vars, **fmin_kws)
+            ret = scipy_minimize(penalty_func, vars, **fmin_kws)
 
         result.aborted = self._abort
         self._abort = False
@@ -639,12 +621,10 @@ class Minimizer(object):
               float_behavior='posterior', is_weighted=True, seed=None):
         """
         Bayesian sampling of the posterior distribution using the `emcee`.
-
         Bayesian sampling of the posterior distribution for the parameters
         using the `emcee` Markov Chain Monte Carlo package. The method assumes
         that the prior is Uniform. You need to have `emcee` installed to use
         this method.
-
         Parameters
         ----------
         params : :class:`lmfit.parameter.Parameters`, optional
@@ -702,11 +682,9 @@ class Minimizer(object):
         float_behavior : str, optional
             Specifies meaning of the objective function output if it returns a
             float. One of:
-
             - 'posterior' - objective function returns a log-posterior
               probability
             - 'chi2' - objective function returns :math:`\chi^2`.
-
             See Notes for further details.
         is_weighted : bool, optional
             Has your objective function been weighted by measurement
@@ -728,7 +706,6 @@ class Minimizer(object):
             If `seed` is already a `np.random.RandomState` instance, then that
             `np.random.RandomState` instance is used.
             Specify `seed` for repeatable minimizations.
-
         Returns
         -------
         :class:`MinimizerResult`
@@ -749,8 +726,6 @@ class Minimizer(object):
             `result.flatchain[parname]`. The ``lnprob`` attribute contains the
             log probability for each sample in ``chain``. The sample with the
             highest probability corresponds to the maximum likelihood estimate.
-
-
         Notes
         -----
         This method samples the posterior distribution of the parameters using
@@ -758,11 +733,8 @@ class Minimizer(object):
         log-posterior probability of the model parameters, `F`, given the data,
         `D`, :math:`\ln p(F_{true} | D)`. This 'posterior probability' is
         calculated as:
-
         .. math::
-
             \ln p(F_{true} | D) \propto \ln p(D | F_{true}) + \ln p(F_{true})
-
         where :math:`\ln p(D | F_{true})` is the 'log-likelihood' and
         :math:`\ln p(F_{true})` is the 'log-prior'. The default log-prior
         encodes prior information already known about the model. This method
@@ -770,11 +742,8 @@ class Minimizer(object):
         one of the parameters is outside its limits. The log-prior probability
         term is zero if all the parameters are inside their bounds (known as a
         uniform prior). The log-likelihood function is given by [1]_:
-
         .. math::
-
             \ln p(D|F_{true}) = -\\frac{1}{2}\sum_n \left[\\frac{\left(g_n(F_{true}) - D_n \\right)^2}{s_n^2}+\ln (2\pi s_n^2)\\right]
-
         The first summand in the square brackets represents the residual for a
         given datapoint (:math:`g` being the generative model, :math:`D_n` the
         data and :math:`s_n` the standard deviation, or measurement
@@ -785,14 +754,12 @@ class Minimizer(object):
         However, since the in-built log-prior term is zero, the objective
         function can also just return the log-likelihood, unless you wish to
         create a non-uniform prior.
-
         If a float value is returned by the objective function then this value
         is assumed by default to be the log-posterior probability, i.e.
         `float_behavior is 'posterior'`. If your objective function returns
         :math:`\chi^2`, then you should use a value of `'chi2'` for
         `float_behavior`. `emcee` will then multiply your :math:`\chi^2` value
         by -0.5 to obtain the posterior probability.
-
         However, the default behaviour of many objective functions is to return
         a vector of (possibly weighted) residuals. Therefore, if your objective
         function returns a vector, `res`, then the vector is assumed to contain
@@ -810,7 +777,6 @@ class Minimizer(object):
         (homoscedasticity) for each data point, :math:`s_n = \exp(\_\_lnsigma)`.
         `__lnsigma` will be present in `MinimizerResult.params`, as well as
         `Minimizer.chain`, `nvarys` will also be increased by one.
-
         References
         ----------
         .. [1] http://dan.iel.fm/emcee/current/user/line/
@@ -996,15 +962,12 @@ class Minimizer(object):
     def least_squares(self, params=None, **kws):
         """
         Use the ``least_squares`` (new in scipy 0.17) to perform a fit.
-
         It assumes that the input Parameters have been initialized, and
         a function to minimize has been properly set up.
         When possible, this calculates the estimated uncertainties and
         variable correlations from the covariance matrix.
-
         This method wraps :scipydoc:`scipy.optimize.least_squares`, which
         has inbuilt support for bounds and robust loss functions.
-
         Parameters
         ----------
         params : Parameters, optional
@@ -1012,14 +975,11 @@ class Minimizer(object):
         kws : dict, optional
             Minimizer options to pass to
             :scipydoc:`scipy.optimize.least_squares`.
-
         Returns
         -------
         :class:`MinimizerResult`
             Object containing the optimized parameter
             and several goodness-of-fit statistics.
-
-
         .. versionchanged:: 0.9.0
            Return value changed to :class:`MinimizerResult`.
         """
@@ -1065,16 +1025,13 @@ class Minimizer(object):
     def leastsq(self, params=None, **kws):
         """
         Use Levenberg-Marquardt minimization to perform a fit.
-
         It assumes that the input Parameters have been initialized, and
         a function to minimize has been properly set up.
         When possible, this calculates the estimated uncertainties and
         variable correlations from the covariance matrix.
-
         This method calls :scipydoc:`scipy.optimize.leastsq`.
         By default, numerical derivatives are used, and the following
         arguments are set:
-
         +------------------+----------------+------------------------------------------------------------+
         | :meth:`leastsq`  |  Default Value | Description                                                |
         | arg              |                |                                                            |
@@ -1087,21 +1044,17 @@ class Minimizer(object):
         +------------------+----------------+------------------------------------------------------------+
         |   Dfun           | ``None``       | function to call for Jacobian calculation                  |
         +------------------+----------------+------------------------------------------------------------+
-
         Parameters
         ----------
         params : :class:`lmfit.parameter.Parameters`, optional
            Parameters to use as starting point.
         kws : dict, optional
             Minimizer options to pass to :scipydoc:`scipy.optimize.leastsq`.
-
         Returns
         -------
         :class:`MinimizerResult`
             Object containing the optimized parameter
             and several goodness-of-fit statistics.
-
-
         .. versionchanged:: 0.9.0
            Return value changed to :class:`MinimizerResult`.
         """
@@ -1239,12 +1192,10 @@ class Minimizer(object):
     def minimize(self, method='leastsq', params=None, **kws):
         """
         Perform the minimization.
-
         Parameters
         ----------
         method : str, optional
             Name of the fitting method to use. Valid values are:
-
             - `'leastsq'`: Levenberg-Marquardt (default).
               Uses `scipy.optimize.leastsq`.
             - `'least_squares'`: Levenberg-Marquardt.
@@ -1260,24 +1211,18 @@ class Minimizer(object):
             - `'dogleg'`: Dogleg
             - `'slsqp'`: Sequential Linear Squares Programming
             - `'differential_evolution'`: differential evolution
-
             For more details on the fitting methods please refer to the
             `scipy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
-
         params : :class:`lmfit.parameter.Parameters` object.
             Parameters of the model to use as starting values.
-
         **kwargs
             Additional arguments are passed to the underlying minimization
             method.
-
         Returns
         -------
         :class:`MinimizerResult`
             Object containing the optimized parameter
             and several goodness-of-fit statistics.
-
-
         .. versionchanged:: 0.9.0
            Return value changed to :class:`MinimizerResult`.
         """
@@ -1304,7 +1249,6 @@ class Minimizer(object):
 def _lnprior(theta, bounds):
     """
     Calculates an improper uniform log-prior probability
-
     Parameters
     ----------
     theta : sequence
@@ -1312,7 +1256,6 @@ def _lnprior(theta, bounds):
     bounds : np.ndarray
         Lower and upper bounds of parameters that are varying.
         Has shape (nvarys, 2).
-
     Returns
     -------
     lnprob : float
@@ -1331,7 +1274,6 @@ def _lnpost(theta, userfcn, params, var_names, bounds, userargs=(),
     """
     Calculates the log-posterior probability. See the `Minimizer.emcee` method
     for more details
-
     Parameters
     ----------
     theta : sequence
@@ -1350,23 +1292,18 @@ def _lnpost(theta, userfcn, params, var_names, bounds, userargs=(),
         Extra keyword arguments required for user objective function
     float_behavior : str, optional
         Specifies meaning of objective when it returns a float. One of:
-
         'posterior' - objective function returnins a log-posterior
                       probability.
         'chi2' - objective function returns a chi2 value.
-
     is_weighted : bool
         If `userfcn` returns a vector of residuals then `is_weighted`
         specifies if the residuals have been weighted by data uncertainties.
     nan_policy : str, optional
         Specifies action if `userfcn` returns nan
         values. One of:
-
             'raise' - a `ValueError` is raised
             'propagate' - the values returned from `userfcn` are un-altered
             'omit' - the non-finite values are filtered.
-
-
     Returns
     -------
     lnprob : float
@@ -1420,7 +1357,6 @@ def _lnpost(theta, userfcn, params, var_names, bounds, userargs=(),
 
 def _make_random_gen(seed):
     """Turn seed into a np.random.RandomState instance
-
     If seed is None, return the RandomState singleton used by np.random.
     If seed is an int, return a new RandomState instance seeded with seed.
     If seed is already a RandomState instance, return it.
@@ -1439,24 +1375,20 @@ def _make_random_gen(seed):
 def _nan_policy(a, nan_policy='raise', handle_inf=True):
     """
     Specifies behaviour when an array contains np.nan or np.inf
-
     Parameters
     ----------
     a : array_like
         Input array to consider
     nan_policy : str, optional
         One of:
-
         'raise' - raise a `ValueError` if `a` contains NaN.
         'propagate' - propagate NaN
         'omit' - filter NaN from input array
     handle_inf : bool, optional
         As well as nan consider +/- inf
-
     Returns
     -------
     filtered_array : array_like
-
     Note
     ----
     This function is copied, then modified, from
@@ -1501,14 +1433,13 @@ def _nan_policy(a, nan_policy='raise', handle_inf=True):
 
 
 def minimize(fcn, params, method='leastsq', args=None, kws=None,
-             scale_covar=True, iter_cb=None, **fit_kws):
+             scale_covar=True, iter_cb=None, residual2scalar=None, **fit_kws):
     """
     This function performs a fit of a set of parameters by minimizing
     an objective (or "cost") function using one one of the several
     available methods. The minimize function takes a objective function
     to be minimized, a dictionary (:class:`lmfit.parameter.Parameters`)
     containing the model parameters, and several optional arguments.
-
     Parameters
     ----------
     fcn : callable
@@ -1523,7 +1454,6 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
         contains the Parameters for the model.
     method : str, optional
         Name of the fitting method to use. Valid values are:
-
         - `'leastsq'`: Levenberg-Marquardt (default).
           Uses `scipy.optimize.leastsq`.
         - `'least_squares'`: Levenberg-Marquardt.
@@ -1539,10 +1469,8 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
         - `'dogleg'`: Dogleg
         - `'slsqp'`: Sequential Linear Squares Programming
         - `'differential_evolution'`: differential evolution
-
         For more details on the fitting methods please refer to the
         `scipy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
-
     args : tuple, optional
         Positional arguments to pass to `fcn`.
     kws : dict, optional
@@ -1556,19 +1484,19 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     scale_covar : bool, optional
         Whether to automatically scale the covariance matrix (leastsq
         only).
+    residual2scalar: function, optional
+        Specifies a function used to reduce residuals to a scalar for
+        minimization. The sum of squares will be used if this is not
+        passed.
     fit_kws : dict, optional
         Options to pass to the minimizer being used.
-
     Returns
     -------
     :class:`MinimizerResult`
         Object containing the optimized parameter
         and several goodness-of-fit statistics.
-
-
     .. versionchanged:: 0.9.0
         Return value changed to :class:`MinimizerResult`.
-
     Notes
     -----
     The objective function should return the value to be minimized. For the
@@ -1578,25 +1506,20 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     can either be a scalar or an array. If an array is returned, the sum of
     squares of the array will be sent to the underlying fitting method,
     effectively doing a least-squares optimization of the return values.
-
     A common use for `args` and `kwds` would be to pass in other
     data needed to calculate the residual, including such things as the
     data array, dependent variable, uncertainties in the data, and other
     data structures for the model calculation.
-
     On output, the params will be unchanged.  The best-fit values, and where
     appropriate, estimated uncertainties and correlations, will all be
     contained in the returned :class:`MinimizerResult`.  See
     :ref:`fit-results-label` for further details.
-
     This function is simply a wrapper around :class:`Minimizer`
     and is equivalent to::
-
         fitter = Minimizer(fcn, params, fcn_args=args, fcn_kws=kws,
         	           iter_cb=iter_cb, scale_covar=scale_covar, **fit_kws)
         fitter.minimize(method=method)
-
     """
     fitter = Minimizer(fcn, params, fcn_args=args, fcn_kws=kws,
-                       iter_cb=iter_cb, scale_covar=scale_covar, **fit_kws)
+                       iter_cb=iter_cb, scale_covar=scale_covar,residual2scalar=residual2scalar, **fit_kws)
     return fitter.minimize(method=method)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -72,6 +72,10 @@ class Model(object):
     name: None or string
         name for the model. When `None` (default) the name is the same as
         the model function (`func`).
+    residual2scalar: function, optional
+        Specifies a function used to reduce residuals to a scalar for
+        minimization. The sum of squares will be used if this is not
+        passed.
 
     Note
     ----
@@ -96,7 +100,7 @@ class Model(object):
     _hint_names = ('value', 'vary', 'min', 'max', 'expr')
 
     def __init__(self, func, independent_vars=None, param_names=None,
-                 missing='none', prefix='', name=None, **kws):
+                 missing='none', prefix='', name=None, residual2scalar=None, **kws):
         self.func = func
         self._prefix = prefix
         self._param_root_names = param_names  # will not include prefixes
@@ -116,6 +120,7 @@ class Model(object):
         if name is None and hasattr(self.func, '__name__'):
             name = self.func.__name__
         self._name = name
+        self.residual2scalar=residual2scalar
 
     def _reprstring(self, long=False):
         out = self._name
@@ -720,7 +725,7 @@ class ModelResult(Minimizer):
     """
     def __init__(self, model, params, data=None, weights=None,
                  method='leastsq', fcn_args=None, fcn_kws=None,
-                 iter_cb=None, scale_covar=True, **fit_kws):
+                 iter_cb=None, scale_covar=True, residual2scalar=None, **fit_kws):
         self.model = model
         self.data = data
         self.weights = weights
@@ -729,7 +734,7 @@ class ModelResult(Minimizer):
         self.init_params = deepcopy(params)
         Minimizer.__init__(self, model._residual, params, fcn_args=fcn_args,
                            fcn_kws=fcn_kws, iter_cb=iter_cb,
-                           scale_covar=scale_covar, **fit_kws)
+                           scale_covar=scale_covar, residual2scalar=residual2scalar, **fit_kws)
 
     def fit(self, data=None, params=None, weights=None, method=None, **kwargs):
         """perform fit for a Model, given data and params"""

--- a/tests/test_model_residual2scalar.py
+++ b/tests/test_model_residual2scalar.py
@@ -1,0 +1,31 @@
+import unittest
+import warnings
+import nose
+from numpy.testing import assert_allclose, assert_raises
+from numpy.testing.decorators import knownfailureif
+import numpy as np
+
+from lmfit import Model, Parameter, models
+from lmfit.lineshapes import gaussian
+
+def assert_results_close(actual, desired, rtol=1e-03, atol=1e-03,
+                         err_msg='', verbose=True):
+    for param_name, value in desired.items():
+         assert_allclose(actual[param_name], value, rtol, atol, err_msg, verbose)
+
+def _skip_if_no_pandas():
+    try:
+        import pandas
+    except ImportError:
+        raise nose.SkipTest("Skipping tests that require pandas.")
+
+
+
+class TestResidual2Scalar(unittest.TestCase):
+    def test1(self):
+        model = models.GaussianModel(residual2scalar=lambda x: np.sum(np.abs(x)))
+        params = model.make_params()
+        params["amplitude"].set(100)
+        x=np.linspace(-10,10)
+        data = model.eval(params, x=x)
+        model.fit(data, params, x=x)


### PR DESCRIPTION
I took the code from #226, I updated it to be based on master, and changed the API somewhat. Now you can pass `reduce2scalar` as an argument to either `minimize`, `Minimizer`, or `Model`. I added one test. I don't really understand your test framework, I'm pretty sure there is a way to drop this in to effectively re-use all your tests with very little code, but I don't know how to do it.

I updated the doc strings of everything I touched.
