### PR TITLE
a few small changes to models.py and model.py

### DIFF
--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -15,7 +15,7 @@ spi  = sqrt(pi)
 s2   = sqrt(2.0)
 
 functions = ('gaussian', 'lorentzian', 'voigt', 'pvoigt', 'moffat', 'pearson7',
-             'breit_wigner', 'damped_oscillator', 'logistic', 'lognormal',
+             'breit_wigner', 'damped_oscillator', 'dho', 'logistic', 'lognormal',
              'students_t', 'expgaussian', 'donaich', 'skewed_gaussian',
              'skewed_voigt', 'step', 'rectangle', 'erf', 'erfc', 'wofz',
              'gamma', 'gammaln', 'exponential', 'powerlaw', 'linear',
@@ -92,6 +92,21 @@ def damped_oscillator(x, amplitude=1.0, center=1., sigma=0.1):
     """
     center = max(1.e-9, abs(center))
     return (amplitude/sqrt( (1.0 - (x/center)**2)**2 + (2*sigma*x/center)**2))
+
+def dho(x, amplitude=1., center=0., sigma=1., gamma=1.0):
+    """Damped Harmonic Oscillator, similar to version from PAN
+     = (amplitude*sigma*(bose/pi)* (lm - lp)
+   
+   where  
+      bose(x, gamma) =  1.0/ (1.0 - exp(-x/gamma))
+      lm(x, center, sigma) = 1.0 / ((x-center)**2 + sigma**2)
+      lp(x, center, sigma) = 1.0 / ((x+center)**2 + sigma**2)
+    """
+
+    bose = 1.0/(1.0 - exp(-x/gamma))
+    lm = 1.0/((x-center)**2 + sigma**2)
+    lp = 1.0/((x+center)**2 + sigma**2)
+    return amplitude*sigma*pi*bose*(lm - lp)
 
 def logistic(x, amplitude=1., center=0., sigma=1.):
     """Logistic lineshape (yet another sigmoidal curve)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -162,7 +162,7 @@ class Model(object):
             kw_args = {}
             for name, defval in self.func.kwargs:
                 kw_args[name] = defval
-             keywords_ = list(kw_args.keys())
+            keywords_ = list(kw_args.keys())
         else:
             argspec = inspect.getargspec(self.func)
             pos_args = argspec.args[:]

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -178,11 +178,11 @@ class Model(object):
                 for val in reversed(argspec.defaults):
                     kw_args[pos_args.pop()] = val
 
-        self._func_haskeywords = keywords is not None
+        self._func_haskeywords = keywords_ is not None
         self._func_allargs = pos_args + list(kw_args.keys())
         allargs = self._func_allargs
 
-        if len(allargs) == 0 and keywords is not None:
+        if len(allargs) == 0 and keywords_ is not None:
             return
 
         # default independent_var = 1st argument

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import warnings
 import inspect
 import operator
+from functools import wraps
 from copy import deepcopy
 import numpy as np
 from scipy.stats import t
@@ -44,12 +45,9 @@ except ImportError:
 
 def _ensureMatplotlib(function):
     if _HAS_MATPLOTLIB:
+        @wraps(function)
         def wrapper(*args, **kws):
-            out = function(*args, **kws)
-            return out
-        wrapper.__doc__ = function.__doc__
-        wrapper.__name__ = function.__name__
-        wrapper.__dict__.update(function.__dict__)
+            return function(*args, **kws)
         return wrapper
     else:
         def no_op(*args, **kwargs):

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -156,13 +156,21 @@ class Model(object):
         "build params from function arguments"
         if self.func is None:
             return
-        argspec = inspect.getargspec(self.func)
-        pos_args = argspec.args[:]
-        keywords = argspec.keywords
-        kw_args = {}
-        if argspec.defaults is not None:
-            for val in reversed(argspec.defaults):
-                kw_args[pos_args.pop()] = val
+        if (hasattr(self.func, 'argnames') and
+            hasattr(self.func, 'kwargs')):
+            pos_args = self.func.argnames[:]
+            kw_args = {}
+            for name, defval in self.func.kwargs:
+                kw_args[name] = defval
+             keywords_ = list(kw_args.keys())
+        else:
+            argspec = inspect.getargspec(self.func)
+            pos_args = argspec.args[:]
+            keywords_ = argspec.keywords
+            kw_args = {}
+            if argspec.defaults is not None:
+                for val in reversed(argspec.defaults):
+                    kw_args[pos_args.pop()] = val
 
         self._func_haskeywords = keywords is not None
         self._func_allargs = pos_args + list(kw_args.keys())

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -44,7 +44,13 @@ except ImportError:
 
 def _ensureMatplotlib(function):
     if _HAS_MATPLOTLIB:
-        return function
+        def wrapper(*args, **kws):
+            out = function(*args, **kws)
+            return out
+        wrapper.__doc__ = function.__doc__
+        wrapper.__name__ = function.__name__
+        wrapper.__dict__.update(function.__dict__)
+        return wrapper
     else:
         def no_op(*args, **kwargs):
             print('matplotlib module is required for plotting the results')

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -3,7 +3,7 @@ from .model import Model
 
 from .lineshapes import (gaussian, lorentzian, voigt, pvoigt, moffat, pearson7,
                          step, rectangle, breit_wigner, logistic,
-                         students_t, lognormal, damped_oscillator,
+                         students_t, lognormal, damped_oscillator, dho,
                          expgaussian, skewed_gaussian, donaich,
                          skewed_voigt, exponential, powerlaw, linear,
                          parabolic)
@@ -294,6 +294,18 @@ class DampedOscillatorModel(Model):
     def guess(self, data, x=None, negative=False, **kwargs):
         pars =guess_from_peak(self, data, x, negative,
                               ampscale=0.1, sigscale=0.1)
+        return update_param_vals(pars, self.prefix, **kwargs)
+
+
+class DampedHarmonicOscillatorModel(Model):
+    __doc__ = dho.__doc__ + COMMON_DOC if dho.__doc__ else ""
+    def __init__(self, *args, **kwargs):
+        super(DampedOscillatorModel, self).__init__(dho, *args, **kwargs)
+
+    def guess(self, data, x=None, negative=False, **kwargs):
+        pars =guess_from_peak(self, data, x, negative,
+                              ampscale=0.1, sigscale=0.1)
+        pars['%sgamma' % self.prefix].set(value=1.0, min=0.0)
         return update_param_vals(pars, self.prefix, **kwargs)
 
 class ExponentialGaussianModel(Model):

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1,4 +1,4 @@
-import numpy as np
+simport numpy as np
 from .model import Model
 
 from .lineshapes import (gaussian, lorentzian, voigt, pvoigt, moffat, pearson7,
@@ -46,13 +46,13 @@ def guess_from_peak(model, y, x, negative, ampscale=1.0, sigscale=1.0):
     maxx, minx = max(x), min(x)
     imaxy = index_of(y, maxy)
     cen = x[imaxy]
-    amp = (maxy - miny)*2.0
+    amp = (maxy - miny)*3.0
     sig = (maxx-minx)/6.0
 
     halfmax_vals = np.where(y > (maxy+miny)/2.0)[0]
     if negative:
         imaxy = index_of(y, miny)
-        amp = -(maxy - miny)*2.0
+        amp = -(maxy - miny)*3.0
         halfmax_vals = np.where(y < (maxy+miny)/2.0)[0]
     if len(halfmax_vals) > 2:
         sig = (x[halfmax_vals[-1]] - x[halfmax_vals[0]])/2.0

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1,4 +1,4 @@
-simport numpy as np
+import numpy as np
 from .model import Model
 
 from .lineshapes import (gaussian, lorentzian, voigt, pvoigt, moffat, pearson7,


### PR DESCRIPTION
this PR contains a few small, unrelated changes to Model and Models over the past couple weeks.  

A.  Add a damped-harmonic-oscillator model based on a model from PAN (In IDL, from NIST) used by some collaborators.

B. Increase the default estimate of the amplitude of a peak with `Model.guess`

C. Improve the `ensureMatplotlib` decorator to reveal the docstring and name of the decorated method.

D.  Allow Model to wrap certain function-like objects with `argnames` and `kwargs` arguments.  This is mostly for my X-ray spectroscopy framework xraylarch, which does generate such things (cause, you know, lmfit/python by themselves aren't slow enough!).

These should each have no actual impact on any existing tests or usage.