### PR TITLE
Normalized uniform prior

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1320,10 +1320,14 @@ def _lnprior(theta, bounds):
     """
     if (np.any(theta > bounds[:, 1])
         or np.any(theta < bounds[:, 0])):
-        return -np.inf
+        logp = -np.inf
     else:
-        return -np.sum(np.log(bounds.dot([ -1, 1 ])))
+        logp = -np.sum(np.log(bounds.dot([ -1, 1 ])))
 
+        if not np.isfinite(logp):
+            logp = 0
+
+    return logp
 
 def _lnpost(theta, userfcn, params, var_names, bounds, userargs=(),
             userkws=None, float_behavior='posterior', is_weighted=True,

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -636,7 +636,8 @@ class Minimizer(object):
 
     def emcee(self, params=None, steps=1000, nwalkers=100, burn=0, thin=1,
               ntemps=1, pos=None, reuse_sampler=False, workers=1,
-              float_behavior='posterior', is_weighted=True, seed=None):
+              float_behavior='posterior', is_weighted=True, seed=None,
+              betas=None):
         """
         Bayesian sampling of the posterior distribution using the `emcee`.
 
@@ -728,6 +729,12 @@ class Minimizer(object):
             If `seed` is already a `np.random.RandomState` instance, then that
             `np.random.RandomState` instance is used.
             Specify `seed` for repeatable minimizations.
+        betas : np.ndarray, optional
+            Array giving the inverse temperatures, :math:`\\beta=1/T`,
+            used in the ladder.  The default is chosen so that a Gaussian
+            posterior in the given number of dimensions will have a 0.25
+            tswap acceptance rate.
+
 
         Returns
         -------
@@ -896,6 +903,7 @@ class Minimizer(object):
                          'nan_policy': self.nan_policy}
 
         if ntemps > 1:
+            sampler_kwargs['betas'] = betas
             # the prior and likelihood function args and kwargs are the same
             sampler_kwargs['loglargs'] = lnprob_args
             sampler_kwargs['loglkwargs'] = lnprob_kwargs

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1322,7 +1322,7 @@ def _lnprior(theta, bounds):
         or np.any(theta < bounds[:, 0])):
         return -np.inf
     else:
-        return 0
+        return -np.sum(np.log(bounds.dot([ -1, 1 ])))
 
 
 def _lnpost(theta, userfcn, params, var_names, bounds, userargs=(),

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -450,6 +450,21 @@ class CommonMinimizerTest(unittest.TestCase):
         check_paras(out.params, self.p_true, sig=3)
 
     @decorators.slow
+    def test_emcee_PT_betas(self):
+        # test emcee with parallel tempering
+        if not HAS_EMCEE:
+            return True
+
+        np.random.seed(123456)
+        self.mini.userfcn = residual_for_multiprocessing
+        out = self.mini.emcee(ntemps=4, nwalkers=50, steps=200,
+                              burn=100, thin=10, workers=2,
+                              betas=np.exp(np.linspace(0.0, -np.log(1e6), 4) ) )
+
+        check_paras(out.params, self.p_true, sig=3)
+
+
+    @decorators.slow
     def test_emcee_multiprocessing(self):
         # test multiprocessing runs
         if not HAS_EMCEE:


### PR DESCRIPTION
This PR add a proper normalization of the default uniform prior for the PTSampler, as well as adding the PTSampler betas option.

This allows to run the emcee multinodal.py example using lmfit.Parameters and get proper evidence for the model.

In general this allow to get the evidence of the model using the PTSamper.sampler.thermodynamic_integration_log_evidence() method
