### PR TITLE
Different fit messages depending on fit status code.

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1133,18 +1133,21 @@ class Minimizer(object):
         result.residual = resid = infodict['fvec']
         result.ier = ier
         result.lmdif_message = errmsg
-        result.message = 'Fit succeeded.'
         result.success = ier in [1, 2, 3, 4]
         if result.aborted:
             result.message = 'Fit aborted by user callback.'
             result.success = False
+        elif ier in {1,2,3}:
+            result.message = 'Fit succeeded.'
         elif ier == 0:
-            result.message = 'Invalid Input Parameters.'
+            result.message = 'Invalid Input Parameters. I.e. more variables than data points given, tolerance < 0.0, or no data provided.'
+        elif ier == 4:
+            result.message = 'One or more variable did not affect the fit.'
         elif ier == 5:
             result.message = self._err_maxfev % lskws['maxfev']
         else:
             result.message = 'Tolerance seems to be too small.'
-
+        
         result.ndata = len(resid)
 
         result.chisqr = (resid**2).sum()
@@ -1231,7 +1234,7 @@ class Minimizer(object):
                         params[nam].value = v.nominal_value
 
         if not result.errorbars:
-            result.message = '%s. Could not estimate error-bars' % result.message
+            result.message = '%s Could not estimate error-bars.' % result.message
 
         np.seterr(**orig_warn_settings)
         return result


### PR DESCRIPTION
## A good Pull Request will:
##  1. Follow PEP-8 as closely as possible
##  2. Reference Issue #
##  3. Add at test or explain why this is not needed.
##  4. Consider if an example is needed.
##  5. Include changes to main documentation if the
##     API changes or a new feature is added.

This PR addresses Issue #378 

# Change description
Instead of comparing ier only to 0, 5 or neither of them, which never resulted in result.message being "Fit succeeded." the changes lead to a comparison to five different cases, namely:
- ier is equal to 1, 2 or 3, which results in result.message = 'Fit succeeded.'
- ier is equal to 0, which results in result.message = 'Invalid Input Parameters. I.e. more variables than data points given, tolerance < 0.0, or no data provided.'
- ier is equal to 4, which results in result.message = 'One or more variable did not affect the fit.'
- ier is equal to 5, which results in result.message = self._err_maxfev % lskws['maxfev'] <-- as before
- ier is not any of the above, which results in result.message = 'Tolerance seems to be too small.'

Furthermore I changed the string that is added to result.message when no error-bars could be estimated in such a way that no dot at the beginning of the statement is printed but instead one is printed at the end of the statement.

# Tests:
I tested the modified version by fitting some gaussians to some given datapoints but only provoked the cases where 'Fit succeeded.' and where 'One of more variable did not affect the fit', so ier == 4, appeard. But since those two cases worked properly I don't see why any other cases should not work, except for cases in which the definition of ier is wrong. But this definition was not affected by my changes.

