### PR TITLE
allow values for param hints to be overwritten by explicit setting in Model.make_params()

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -328,6 +328,8 @@ class Model(object):
             for item in self._hint_names:
                 if item in  hint:
                     setattr(par, item, hint[item])
+            if basename in kwargs:
+                par.value = kwargs[basename]
             # Add the new parameter to self._param_names
             if name not in self._param_names:
                 self._param_names.append(name)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from lmfit import Model, Parameter, models
 from lmfit.lineshapes import gaussian
+from lmfit.models import PseudoVoigtModel
 
 def assert_results_close(actual, desired, rtol=1e-03, atol=1e-03,
                          err_msg='', verbose=True):
@@ -473,6 +474,11 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         self.assertEqual(models[0].param_hints['amp'],
                          models[1].param_hints['amp'])
 
+    def test_param_hint_explicit_value(self):
+        # tests Github Issue 384
+        pmod = PseudoVoigtModel()
+        params = pmod.make_params(sigma=2, fraction=0.77)
+        assert_allclose(params['fraction'].value, 0.77, rtol=0.01)
 
     def test_composite_model_with_expr_constrains(self):
         """Smoke test for composite model fitting with expr constraints.


### PR DESCRIPTION
This PR addresses Issue #384, by having parameter values passed into Model.make_params() overwrite values that may otherwise be set by a parameter hint.

A simple test is included.

