### PR TITLE
FIX: set function of Parameter class

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -493,8 +493,7 @@ class Parameter(object):
             To remove a constraint you must supply an empty string.
         """
 
-        if expr is not None:
-            self.__set_expression(expr)
+        self.__set_expression(expr)
 
         if value is not None:
             self._val = value

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -474,7 +474,7 @@ class Parameter(object):
         self.from_internal = lambda val: val
         self._init_bounds()
 
-    def set(self, value=None, vary=None, min=-inf, max=inf, expr=None):
+    def set(self, value=None, vary=None, min=None, max=None, expr=None):
         """
         Set or update Parameter attributes.
 
@@ -493,17 +493,22 @@ class Parameter(object):
             To remove a constraint you must supply an empty string.
         """
 
-        self.__set_expression(expr)
+        if expr is not None:
+            self.__set_expression(expr)
+
         if value is not None:
             self._val = value
         if vary is not None:
             self.vary = vary
-        if min is None:
-            min = -inf
-        if max is None:
-            max = inf
-        self.min = min
-        self.max = max
+
+        if min is not None:
+            self.min = min
+        if max is not None:
+            self.max = max
+        if self.min is None:
+            self.min = -inf
+        if self.max is None:
+            self.max = inf
 
     def _init_bounds(self):
         """make sure initial bounds are self-consistent"""

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -493,21 +493,23 @@ class Parameter(object):
             To remove a constraint you must supply an empty string.
         """
 
-        self.__set_expression(expr)
-
         if value is not None:
             self._val = value
+            self.__set_expression('')
+
         if vary is not None:
             self.vary = vary
+            if vary == True:
+                self.__set_expression('')
 
         if min is not None:
             self.min = min
+
         if max is not None:
             self.max = max
-        if self.min is None:
-            self.min = -inf
-        if self.max is None:
-            self.max = inf
+
+        if expr is not None:
+            self.__set_expression(expr)
 
     def _init_bounds(self):
         """make sure initial bounds are self-consistent"""

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -291,7 +291,8 @@ def test_scalar_minimize_reduce_fcn():
 
     yo = 1.0 + 2.0*np.sin(4*x) * np.exp(-x / 5)
     y = yo + np.random.normal(size=len(yo), scale=0.250)
-    outliers = np.random.random_integers(len(x)/3.0, len(x)-1, len(x)/12)
+    outliers = np.random.random_integers(int(len(x)/3.0), len(x)-1,
+                                         int(len(x)/12))
     y[outliers] += 5*np.random.random(len(outliers))
 
     # define objective function: returns the array to be minimized

--- a/tests/test_params_set.py
+++ b/tests/test_params_set.py
@@ -45,4 +45,48 @@ def test_param_set():
     assert(params['gamma'].vary)
     assert_allclose(params['gamma'].value, gamval, 1e-4, 1e-4, '', True)
 
+    # tests to make sure issue #389 is fixed: set boundaries and make sure
+    # they are kept when changing the value
+    amplitude_vary = params['amplitude'].vary
+    amplitude_expr = params['amplitude'].expr
+    params['amplitude'].set(min=0.0, max=100.0)
+    assert_allclose(params['amplitude'].min, 0.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].max, 100.0, 1e-4, 1e-4, '', True)
+    params['amplitude'].set(value=40.0)
+    assert_allclose(params['amplitude'].value, 40.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].min, 0.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].max, 100.0, 1e-4, 1e-4, '', True)
+    assert(params['amplitude'].expr == amplitude_expr)
+    assert(params['amplitude'].vary == amplitude_vary)
+
+    # test for possible regressions of this fix:
+    # using the set function should only change the requested attribute and
+    # not any others (in case no expression is set)
+    params['amplitude'].set(value=35.0)
+    assert_allclose(params['amplitude'].value, 35.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].min, 0.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].max, 100.0, 1e-4, 1e-4, '', True)
+    assert(params['amplitude'].vary == amplitude_vary)
+    assert(params['amplitude'].expr == amplitude_expr)
+
+    params['amplitude'].set(min=10.0)
+    assert_allclose(params['amplitude'].value, 35.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].min, 10.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].max, 100.0, 1e-4, 1e-4, '', True)
+    assert(params['amplitude'].vary == amplitude_vary)
+    assert(params['amplitude'].expr == amplitude_expr)
+
+    params['amplitude'].set(max=110.0)
+    assert_allclose(params['amplitude'].value, 35.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].min, 10.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].max, 110.0, 1e-4, 1e-4, '', True)
+    assert(params['amplitude'].vary == amplitude_vary)
+    assert(params['amplitude'].expr == amplitude_expr)
+
+    params['amplitude'].set(vary=False)
+    assert_allclose(params['amplitude'].value, 35.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].min, 10.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['amplitude'].max, 110.0, 1e-4, 1e-4, '', True)
+    assert(params['amplitude'].vary == False)
+
 test_param_set()

--- a/tests/test_params_set.py
+++ b/tests/test_params_set.py
@@ -16,7 +16,7 @@ def test_param_set():
     # test #1:  gamma is constrained to equal sigma
     assert(params['gamma'].expr == 'sigma')
     params.update_constraints()
-    sigval = params['gamma'].value
+    sigval = params['sigma'].value
     assert_allclose(params['gamma'].value, sigval, 1e-4, 1e-4, '', True)
 
     # test #2: explicitly setting a param value should work, even when
@@ -45,48 +45,111 @@ def test_param_set():
     assert(params['gamma'].vary)
     assert_allclose(params['gamma'].value, gamval, 1e-4, 1e-4, '', True)
 
-    # tests to make sure issue #389 is fixed: set boundaries and make sure
-    # they are kept when changing the value
+    # test 5: make sure issue #389 is fixed: set boundaries and make sure
+    #         they are kept when changing the value
     amplitude_vary = params['amplitude'].vary
     amplitude_expr = params['amplitude'].expr
     params['amplitude'].set(min=0.0, max=100.0)
+    params.update_constraints()
     assert_allclose(params['amplitude'].min, 0.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].max, 100.0, 1e-4, 1e-4, '', True)
     params['amplitude'].set(value=40.0)
+    params.update_constraints()
     assert_allclose(params['amplitude'].value, 40.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].min, 0.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].max, 100.0, 1e-4, 1e-4, '', True)
     assert(params['amplitude'].expr == amplitude_expr)
     assert(params['amplitude'].vary == amplitude_vary)
 
-    # test for possible regressions of this fix:
-    # using the set function should only change the requested attribute and
-    # not any others (in case no expression is set)
+    # test for possible regressions of this fix (without 'expr'):
+    # the set function should only change the requested attribute(s)
     params['amplitude'].set(value=35.0)
+    params.update_constraints()
     assert_allclose(params['amplitude'].value, 35.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].min, 0.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].max, 100.0, 1e-4, 1e-4, '', True)
     assert(params['amplitude'].vary == amplitude_vary)
     assert(params['amplitude'].expr == amplitude_expr)
 
+    # set minimum
     params['amplitude'].set(min=10.0)
+    params.update_constraints()
     assert_allclose(params['amplitude'].value, 35.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].min, 10.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].max, 100.0, 1e-4, 1e-4, '', True)
     assert(params['amplitude'].vary == amplitude_vary)
     assert(params['amplitude'].expr == amplitude_expr)
 
+    # set maximum
     params['amplitude'].set(max=110.0)
+    params.update_constraints()
     assert_allclose(params['amplitude'].value, 35.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].min, 10.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].max, 110.0, 1e-4, 1e-4, '', True)
     assert(params['amplitude'].vary == amplitude_vary)
     assert(params['amplitude'].expr == amplitude_expr)
 
+    # set vary
     params['amplitude'].set(vary=False)
+    params.update_constraints()
     assert_allclose(params['amplitude'].value, 35.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].min, 10.0, 1e-4, 1e-4, '', True)
     assert_allclose(params['amplitude'].max, 110.0, 1e-4, 1e-4, '', True)
     assert(params['amplitude'].vary == False)
+    assert(params['amplitude'].expr == amplitude_expr)
+
+    # test for possible regressions of this fix for variables WITH 'expr':
+    height_value = params['height'].value
+    height_min = params['height'].min
+    height_max = params['height'].max
+    height_vary = params['height'].vary
+    height_expr = params['height'].expr
+
+    # set vary=True should remove expression
+    params['height'].set(vary=True)
+    params.update_constraints()
+    assert_allclose(params['height'].value, height_value, 1e-4, 1e-4, '', True)
+    assert_allclose(params['height'].min, height_min, 1e-4, 1e-4, '', True)
+    assert_allclose(params['height'].max, height_max, 1e-4, 1e-4, '', True)
+    assert(params['height'].vary == True)
+    assert(params['height'].expr == None)
+
+    # setting an expression should set vary=False
+    params['height'].set(expr=height_expr)
+    params.update_constraints()
+    assert_allclose(params['height'].value, height_value, 1e-4, 1e-4, '', True)
+    assert_allclose(params['height'].min, height_min, 1e-4, 1e-4, '', True)
+    assert_allclose(params['height'].max, height_max, 1e-4, 1e-4, '', True)
+    assert(params['height'].vary == False)
+    assert(params['height'].expr == height_expr)
+
+    # changing min/max should not remove expression
+    params['height'].set(min=0)
+    params.update_constraints()
+    assert_allclose(params['height'].value, height_value, 1e-4, 1e-4, '', True)
+    assert_allclose(params['height'].min, 0.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['height'].max, height_max, 1e-4, 1e-4, '', True)
+    assert(params['height'].vary == height_vary)
+    assert(params['height'].expr == height_expr)
+
+    # changing the value should remove expression and keep vary=False
+    params['height'].set(value=10.0)
+    params.update_constraints()
+    assert_allclose(params['height'].value, 10.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['height'].min, 0.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['height'].max, height_max, 1e-4, 1e-4, '', True)
+    assert(params['height'].vary == False)
+    assert(params['height'].expr == None)
+
+    # passing expr='' should only remove the expression
+    params['height'].set(expr=height_expr) # first restore the original expr
+    params.update_constraints()
+    params['height'].set(expr='')
+    params.update_constraints()
+    assert_allclose(params['height'].value, height_value, 1e-4, 1e-4, '', True)
+    assert_allclose(params['height'].min, 0.0, 1e-4, 1e-4, '', True)
+    assert_allclose(params['height'].max, height_max, 1e-4, 1e-4, '', True)
+    assert(params['height'].vary == False)
+    assert(params['height'].expr == None)
 
 test_param_set()


### PR DESCRIPTION
This PR fixes the set function of the Parameter class, which currently inadvertently affects the max/min/expr settings. Issue and solution discussed in #389.