### PR TITLE
Fix returned logp when using the PTsampler

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -251,8 +251,12 @@ class MinimizerResult(object):
         """
         if hasattr(self, 'chain'):
             if HAS_PANDAS:
-                return pd.DataFrame(self.chain.reshape((-1, self.nvarys)),
-                                    columns=self.var_names)
+                if len(self.chain.shape) == 4:
+                    return pd.DataFrame(self.chain[0,...].reshape((-1, self.nvarys)),
+                                        columns=self.var_names)
+                elif len(self.chain.shape) == 3:
+                    return pd.DataFrame(self.chain.reshape((-1, self.nvarys)),
+                                        columns=self.var_names)
             else:
                 raise NotImplementedError('Please install Pandas to see the '
                                           'flattened chain')

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1056,7 +1056,7 @@ class Minimizer(object):
 
         # discard the burn samples and thin
         chain = self.sampler.chain[..., burn::thin, :]
-        lnprobability = self.sampler.lnprobability[:, burn::thin]
+        lnprobability = self.sampler.lnprobability[..., burn::thin]
 
         # take the zero'th PTsampler temperature for the parameter estimators
         if ntemps > 1:


### PR DESCRIPTION
Fix the `result.lnprob` attribute when using the `~emcee.PTSampler`.

The confusion comes from emcee when `sampler.lnprobability` has a shape (ntemps, nwalkers, nsteps) for the `~emcee.PTSampler`, while the `~emcee.EnsembleSampler` returns a (nwalkers, nsteps). 
