### PR TITLE
Bump minimum scipy version to 0.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,21 @@ python:
     - 3.3
     - 3.4
     - 3.5
+    - 3.6
+
+# test minium required and current version of scipy
+env:
+    - SCIPY_VERSION=0.15
+    - SCIPY_VERSION=0.18.1
+
+matrix:
+    exclude:
+        -  python: 3.3
+           env: SCIPY_VERSION=0.18.1
+        -  python: 3.5
+           env: SCIPY_VERSION=0.15
+        -  python: 3.6
+           env: SCIPY_VERSION=0.15
 
 before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -19,7 +34,8 @@ before_install:
     - conda info -a
 
 install:
-    - conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy pandas matplotlib nose
+    - if [[ $SCIPY_VERSION == 0.15 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy=$SCIPY_VERSION libgfortran=1 pandas matplotlib nose; fi
+    - if [[ $SCIPY_VERSION != 0.15 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy=$SCIPY_VERSION pandas matplotlib nose; fi
     - source activate test_env
     - pip install emcee
     - python setup.py install

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -13,7 +13,7 @@ Prerequisites
 The lmfit package requires Python, Numpy, and Scipy.
 
 Lmfit works with Python 2.7, 3.3, 3.4, and 3.5. Support for Python 2.6
-ended with lmfit version 0.9.4.  Scipy version 0.14 or higher is required,
+ended with lmfit version 0.9.4.  Scipy version 0.15 or higher is required,
 with 0.17 or higher recommended to be able to use the latest optimization
 features from scipy.  Numpy version 1.5 or higher is required.
 

--- a/lmfit/__init__.py
+++ b/lmfit/__init__.py
@@ -39,7 +39,6 @@ Authors: Matthew Newville, The University of Chicago
 
 """
 import sys
-import warnings
 
 from .confidence import conf_interval, conf_interval2d
 from .minimizer import Minimizer, MinimizerException, minimize
@@ -58,7 +57,3 @@ from ._version import get_versions
 
 __version__ = get_versions()['version']
 del get_versions
-
-# PY26 Depreciation Warning
-if sys.version_info[:2] == (2, 6):
-    warnings.warn('Support for Python 2.6.x was dropped with lmfit 0.9.5')

--- a/lmfit/__init__.py
+++ b/lmfit/__init__.py
@@ -41,8 +41,6 @@ Authors: Matthew Newville, The University of Chicago
 import sys
 import warnings
 
-import scipy
-
 from .confidence import conf_interval, conf_interval2d
 from .minimizer import Minimizer, MinimizerException, minimize
 from .parameter import Parameter, Parameters
@@ -64,9 +62,3 @@ del get_versions
 # PY26 Depreciation Warning
 if sys.version_info[:2] == (2, 6):
     warnings.warn('Support for Python 2.6.x was dropped with lmfit 0.9.5')
-
-# SCIPY 0.13 Depreciation Warning
-scipy_major, scipy_minor, scipy_other = scipy.__version__.split('.', 2)
-
-if int(scipy_major) == 0 and int(scipy_minor) < 15:
-    warnings.warn('Support for Scipy 0.14 was dropped with lmfit 0.9.5')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy>=1.5
-scipy>=0.14
+scipy>=0.15

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,19 @@
 #!/usr/bin/env python
 # from distutils.core import setup
+from __future__ import print_function
+
+import sys
+
 from setuptools import setup
 import versioneer
+
+# Minimal Python version sanity check
+# taken from the Jupyter Notebook setup.py -- Modified BSD License
+v = sys.version_info
+if v[:2] < (2, 7) or (v[0] >= 3 and v[:2] < (3, 3)):
+    error = "ERROR: lmfit requires Python version 2.7 or 3.3 or above."
+    print(error, file=sys.stderr)
+    sys.exit(1)
 
 long_desc = """A library for least-squares minimization and data fitting in
 Python.  Built on top of scipy.optimize, lmfit provides a Parameter object


### PR DESCRIPTION
This PR partly addresses #398 and now `scipy` version 0.15 or above is required for `lmfit` and this version is used now for the Travis CI builds. In addition, testing against Python 3.6 is also added since it turns out that #397 isn't blocking this (i.e., `inspect.getargspec()` is still present). Finally, the logic for which Python versions are supported is moved to the `setup.py` such that it will not install with unsupported version.