### PR TITLE
Param set symtable

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -522,7 +522,7 @@ class Parameter(object):
         """
 
         if value is not None:
-            self._val = value
+            self.value = value
             self.__set_expression('')
 
         if vary is not None:

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -138,6 +138,18 @@ class TestParameters(unittest.TestCase):
         pkl = pickle.dumps(p)
         q = pickle.loads(pkl)
 
+
+    def test_set_symtable(self):
+        # test that we use Parameter.set(value=XXX) and have
+        # that new value be used in constraint expressions
+        pars = Parameters()
+        pars.add('x', value=1.0)
+        pars.add('y', expr='x + 1')
+
+        assert_(isclose(pars['y'].value, 2.0))
+        pars['x'].set(value=3.0)
+        assert_(isclose(pars['y'].value, 4.0))
+
     def test_dumps_loads_parameters(self):
         # test that we can dumps() and then loads() a Parameters
         pars = Parameters()


### PR DESCRIPTION
This addresses #400, and changes `Parameter.set()` to set the `value` property, not just the internal value in `_val`.  The difference is that the `Parameters` symbol table is also updated with the property, so that dependent parameters using constraint expressions will be updated as soon as they are evaluated.  

A test is included.

