### PR TITLE
docstring / doc changes for 0.96

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,14 @@ python:
 # test minium required and current version of scipy
 env:
     - SCIPY_VERSION=0.15
-    - SCIPY_VERSION=0.18.1
+    - SCIPY_VERSION=0.19
 
 matrix:
     exclude:
         -  python: 3.3
-           env: SCIPY_VERSION=0.18.1
+           env: SCIPY_VERSION=0.19
+        -  python: 3.4
+           env: SCIPY_VERSION=0.19
         -  python: 3.5
            env: SCIPY_VERSION=0.15
         -  python: 3.6

--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -1,8 +1,8 @@
 <h3>Getting LMFIT</h3>
 <p>Current version: <b>{{ release }}</b></p>
 <p>Install:  &nbsp; <tt>pip install lmfit</tt>
-<p>Download: &nbsp; <a href="http://pypi.python.org/pypi/lmfit/">PyPI (Python.org)</a>
-<p>Develop:  &nbsp; <a href="https://github.com/lmfit/lmfit-py/">github.com</a> <br>
+<p>Download: &nbsp; <a href="http://pypi.python.org/pypi/lmfit/">PyPI</a>
+<p>Develop:  &nbsp; <a href="https://github.com/lmfit/lmfit-py/">GitHub</a> <br>
 
 <h3>Questions?</h3>
 

--- a/doc/bounds.rst
+++ b/doc/bounds.rst
@@ -59,7 +59,7 @@ With these mappings, the value for the bounded Parameter cannot exceed the
 specified bounds, though the internally varied value can be freely varied.
 
 It bears repeating that code from `leastsqbound`_ was adopted to implement
-the transformation described above.  The challenging part (Thanks again to
+the transformation described above.  The challenging part (thanks again to
 Jonathan J. Helmus!) here is to re-transform the covariance matrix so that
 the uncertainties can be estimated for bounded Parameters.  This is
 included by using the derivate :math:`dP_{\rm internal}/dP_{\rm bounded}`

--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -11,7 +11,7 @@ These pre-defined models each subclass from the :class:`model.Model` class of th
 previous chapter and wrap relatively well-known functional forms, such as
 Gaussians, Lorentzian, and Exponentials that are used in a wide range of
 scientific domains.  In fact, all the models are all based on simple, plain
-python functions defined in the :mod:`lineshapes` module.  In addition to
+Python functions defined in the :mod:`lineshapes` module.  In addition to
 wrapping a function into a :class:`model.Model`, these models also provide a
 :meth:`guess` method that is intended to give a reasonable
 set of starting values from a data array that closely approximates the
@@ -19,10 +19,10 @@ data to be fit.
 
 As shown in the previous chapter, a key feature of the :class:`mode.Model` class
 is that models can easily be combined to give a composite
-:class:`model.Model`. Thus while some of the models listed here may seem pretty
-trivial (notably, :class:`ConstantModel` and :class:`LinearModel`), the
-main point of having these is to be able to used in composite models.  For
-example,  a Lorentzian plus a linear background might be represented as::
+:class:`model.CompositeModel`. Thus, while some of the models listed here may
+seem pretty trivial (notably, :class:`ConstantModel` and :class:`LinearModel`),
+the main point of having these is to be able to use them in composite models. For
+example, a Lorentzian plus a linear background might be represented as::
 
     >>> from lmfit.models import LinearModel, LorentzianModel
     >>> peak = LorentzianModel()
@@ -197,13 +197,13 @@ User-defined Models
 .. _asteval: http://newville.github.io/asteval/
 
 As shown in the previous chapter (:ref:`model_chapter`), it is fairly
-straightforward to build fitting models from parametrized python functions.
+straightforward to build fitting models from parametrized Python functions.
 The number of model classes listed so far in the present chapter should
 make it clear that this process is not too difficult.  Still, it is
 sometimes desirable to build models from a user-supplied function.  This
 may be especially true if model-building is built-in to some larger library
 or application for fitting in which the user may not be able to easily
-build and use a new model from python code.
+build and use a new model from Python code.
 
 
 The :class:`ExpressionModel` allows a model to be built from a
@@ -221,11 +221,11 @@ supplied, the determination of what are the parameter names for the model
 happens when the model is created.  To do this, the expression is parsed,
 and all symbol names are found.  Names that are already known (there are
 over 500 function and value names in the asteval namespace, including most
-python builtins, more than 200 functions inherited from numpy, and more
+Python builtins, more than 200 functions inherited from NumPy, and more
 than 20 common lineshapes defined in the :mod:`lineshapes` module) are not
 converted to parameters.  Unrecognized name are expected to be names either
 of parameters or independent variables.  If `independent_vars` is the
-default value of ``None``, and if the expression contains a variable named
+default value of None, and if the expression contains a variable named
 `x`, that will be used as the independent variable.  Otherwise,
 `independent_vars` must be given.
 
@@ -247,7 +247,7 @@ To evaluate this model, you might do the following::
 
 While many custom models can be built with a single line expression
 (especially since the names of the lineshapes like `gaussian`, `lorentzian`
-and so on, as well as many numpy functions, are available), more complex
+and so on, as well as many NumPy functions, are available), more complex
 models will inevitably require multiple line functions.  You can include
 such Python code with the `init_script` argument.  The text of this script
 is evaluated when the model is initialized (and before the actual
@@ -282,9 +282,9 @@ Example 1: Fit Peaked data to Gaussian, Lorentzian, and  Voigt profiles
 Here, we will fit data to three similar line shapes, in order to decide which
 might be the better model.  We will start with a Gaussian profile, as in
 the previous chapter, but use the built-in :class:`GaussianModel` instead
-of writing one ourselves.  This is a slightly different version rom the
+of writing one ourselves.  This is a slightly different version from the
 one in previous example in that the parameter names are different, and have
-built-in default values.  We'll simply use::
+built-in default values.  We will simply use::
 
      from numpy import loadtxt
      from lmfit.models import GaussianModel
@@ -465,12 +465,12 @@ Akaike or Bayesian Information Criteria (see
 :ref:`information_criteria_label`) to assess how likely the model with
 variable ``gamma`` is to explain the data than the model with ``gamma``
 fixed to the value of ``sigma``.  According to theory,
-:math:`\exp(-(\rm{AIC1}-\rm{AIC0})/2)` gives the probably that a model with
-AIC` is more likely than a model with AIC0.  For the two models here, with
+:math:`\exp(-(\rm{AIC1}-\rm{AIC0})/2)` gives the probability that a model with
+AIC1 is more likely than a model with AIC0.  For the two models here, with
 AIC values of -1432 and -1321 (Note: if we had more carefully set the value
 for ``weights`` based on the noise in the data, these values might be
 positive, but there difference would be roughly the same), this says that
-the model with ``gamma`` fixed to ``sigma`` has a probably less than 1.e-25
+the model with ``gamma`` fixed to ``sigma`` has a probability less than 1.e-25
 of being the better model.
 
 

--- a/doc/confidence.rst
+++ b/doc/confidence.rst
@@ -7,10 +7,10 @@ Calculation of confidence intervals
 
 The lmfit :mod:`confidence` module allows you to explicitly calculate
 confidence intervals for variable parameters.  For most models, it is not
-necessary: the estimation of the standard error from the estimated
+necessary since the estimation of the standard error from the estimated
 covariance matrix is normally quite good.
 
-But for some models, e.g. a sum of two exponentials, the approximation
+But for some models, the sum of two exponentials for example, the approximation
 begins to fail. For this case, lmfit has the function :func:`conf_interval`
 to calculate confidence intervals directly.  This is substantially slower
 than using the errors estimated from the covariance matrix, but the results
@@ -30,7 +30,7 @@ within a certain confidence.
 
  F(P_{fix},N-P) = \left(\frac{\chi^2_f}{\chi^2_{0}}-1\right)\frac{N-P}{P_{fix}}
 
-N is the number of data-points, P the number of parameter of the null model.
+`N` is the number of data points, `P` the number of parameters of the null model.
 :math:`P_{fix}` is the number of fixed parameters (or to be more clear, the
 difference of number of parameters between our null model and the alternate
 model).
@@ -120,14 +120,14 @@ which will report::
 
 
 Again we called :func:`conf_interval`, this time with tracing and only for
-1- and 2 :math:`\sigma`.  Comparing these two different estimates, we see
+1- and 2-:math:`\sigma`.  Comparing these two different estimates, we see
 that the estimate for `a1` is reasonably well approximated from the
 covariance matrix, but the estimates for `a2` and especially for `t1`, and
 `t2` are very asymmetric and that going from 1 :math:`\sigma` (68%
 confidence) to 2 :math:`\sigma` (95% confidence) is not very predictable.
 
 Let plots mad of the confidence region are shown the figure on the left
-below for ``a1`` and ``t2``, and for ``a2`` and ``t2`` on the right:
+below for `a1` and `t2`, and for `a2` and `t2` on the right:
 
 .. _figC1:
 
@@ -174,7 +174,7 @@ by using :meth:`Minimizer.emcee` on the same problem.
 
 Credible intervals (the Bayesian equivalent of the frequentist confidence
 interval) can be obtained with this method. MCMC can be used for model
-selection, to determine outliers, to marginalise over nuisance parameters, etc.
+selection, to determine outliers, to marginalise over nuisance parameters, etcetera.
 For example, you may have fractionally underestimated the uncertainties on a
 dataset. MCMC can be used to estimate the true level of uncertainty on each
 datapoint. A tutorial on the possibilities offered by MCMC can be found at [1]_.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -23,11 +23,11 @@ I get import errors from IPython
 
 If you see something like::
 
-        from IPython.html.widgets import Dropdown
+    from IPython.html.widgets import Dropdown
 
     ImportError: No module named 'widgets'
 
-then you need to install the ipywidgets package.   Try 'pip install ipywidgets'.
+then you need to install the ``ipywidgets`` package, try:  ``pip install ipywidgets``.
 
 
 
@@ -35,10 +35,10 @@ then you need to install the ipywidgets package.   Try 'pip install ipywidgets'.
 How can I fit multi-dimensional data?
 ========================================
 
-The fitting routines accept data arrays that are 1 dimensional and double
+The fitting routines accept data arrays that are one dimensional and double
 precision.  So you need to convert the data and model (or the value
 returned by the objective function) to be one dimensional.  A simple way to
-do this is to use numpy's :numpydoc:`ndarray.flatten`, for example::
+do this is to use :numpydoc:`ndarray.flatten`, for example::
 
     def residual(params, x, data=None):
         ....
@@ -48,30 +48,31 @@ do this is to use numpy's :numpydoc:`ndarray.flatten`, for example::
 How can I fit multiple data sets?
 ========================================
 
-As above, the fitting routines accept data arrays that are 1 dimensional
+As above, the fitting routines accept data arrays that are one dimensional
 and double precision.  So you need to convert the sets of data and models
 (or the value returned by the objective function) to be one dimensional.  A
-simple way to do this is to use numpy's :numpydoc:`concatenate`.  As an
+simple way to do this is to use :numpydoc:`concatenate`.  As an
 example, here is a residual function to simultaneously fit two lines to two
 different arrays.  As a bonus, the two lines share the 'offset' parameter::
 
+    import numpy as np
     def fit_function(params, x=None, dat1=None, dat2=None):
         model1 = params['offset'] + x * params['slope1']
         model2 = params['offset'] + x * params['slope2']
 
         resid1 = dat1 - model1
         resid2 = dat2 - model2
-        return numpy.concatenate((resid1, resid2))
+        return np.concatenate((resid1, resid2))
 
 
 
 How can I fit complex data?
 ===================================
 
-As with working with multidimensional data, you need to convert your data
+As with working with multi-dimensional data, you need to convert your data
 and model (or the value returned by the objective function) to be double
-precision floating point numbers. The simplest approach is to use numpy's
-:numpydoc:`ndarray.view` method, perhaps like::
+precision floating point numbers. The simplest approach is to use
+:numpydoc:`ndarray.view`, perhaps like::
 
    import numpy as np
    def residual(params, x, data=None):

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -4,7 +4,7 @@
 
 
 =======================================
-Performing Fits, Analyzing Outputs
+Performing Fits and Analyzing Outputs
 =======================================
 
 As shown in the previous chapter, a simple fit can be performed with the
@@ -40,15 +40,15 @@ but it must look like this:
    Calculate objective residual to be minimized from parameters.
 
    :param params: Parameters.
-   :type  params: :class:`Parameters`
-   :param args:  Positional arguments.  Must match ``args`` argument to :func:`minimize`.
-   :param kws:   Keyword arguments.  Must match ``kws`` argument to :func:`minimize`.
+   :type  params: :class:`~lmfit.parameter.Parameters`
+   :param *args:  Positional arguments.  Must match ``args`` argument to :func:`minimize`.
+   :param **kws:   Keyword arguments.  Must match ``kws`` argument to :func:`minimize`.
    :return: Residual array (generally data-model) to be minimized in the least-squares sense.
-   :rtype: numpy array.  The length of this array cannot change between calls.
+   :rtype: numpy.ndarray.  The length of this array cannot change between calls.
 
 
 A common use for the positional and keyword arguments would be to pass in other
-data needed to calculate the residual, including such things as the data array,
+data needed to calculate the residual, including things as the data array,
 dependent variable, uncertainties in the data, and other data structures for the
 model calculation.
 
@@ -86,10 +86,10 @@ simple way to do this is with :meth:`Parameters.valuesdict`, as shown below::
             return (model - data)
         return (model - data)/eps
 
-In this example, ``x`` is a positional (required) argument, while the
-``data`` array is actually optional (so that the function returns the model
+In this example, `x` is a positional (required) argument, while the
+`data` array is actually optional (so that the function returns the model
 calculation if the data is neglected).  Also note that the model
-calculation will divide ``x`` by the value of the 'period' Parameter.  It
+calculation will divide `x` by the value of the ``period`` Parameter.  It
 might be wise to ensure this parameter cannot be 0.  It would be possible
 to use the bounds on the :class:`Parameter` to do this::
 
@@ -166,9 +166,9 @@ class as listed in the :ref:`Table of Supported Fitting Methods
 .. warning::
 
   Much of this documentation assumes that the Levenberg-Marquardt method is
-  the method used.  Many of the fit statistics and estimates for
-  uncertainties in parameters discussed in :ref:`fit-results-label` are
-  done only for this method.
+  used.  Many of the fit statistics and estimates for uncertainties in
+  parameters discussed in :ref:`fit-results-label` are done only for this
+  method.
 
 ..  _fit-results-label:
 
@@ -194,8 +194,8 @@ well formatted text tables you can execute::
     result.params.pretty_print()
 
 with `results` being a `MinimizerResult` object. Note that the method
-:meth:`lmfit.parameter.Parameters.pretty_print` accepts several arguments
-for customizing the output (e.g., column width, numeric format, etc.).
+:meth:`~lmfit.parameter.Parameters.pretty_print` accepts several arguments
+for customizing the output (e.g., column width, numeric format, etcetera).
 
 .. autoclass:: MinimizerResult
 
@@ -241,7 +241,7 @@ Goodness-of-Fit Statistics
 Note that the calculation of chi-square and reduced chi-square assume
 that the returned residual function is scaled properly to the
 uncertainties in the data.  For these statistics to be meaningful, the
-person writing the function to be minimized must scale them properly.
+person writing the function to be minimized **must** scale them properly.
 
 After a fit using using the :meth:`leastsq` method has completed
 successfully, standard errors for the fitted variables and correlations
@@ -322,15 +322,15 @@ used to abort a fit.
    User-supplied function to be run at each iteration.
 
    :param params: Parameters.
-   :type  params: :class:`Parameters`.
+   :type  params: :class:`~lmfit.parameter.Parameters`
    :param iter:   Iteration number.
-   :type  iter:   integer
+   :type  iter:   int
    :param resid:  Residual array.
-   :type  resid:  ndarray
-   :param args:  Positional arguments.  Must match ``args`` argument to :func:`minimize`
-   :param kws:   Keyword arguments.  Must match ``kws`` argument to :func:`minimize`
+   :type  resid:  numpy.ndarray
+   :param *args:  Positional arguments.  Must match ``args`` argument to :func:`minimize`
+   :param **kws:   Keyword arguments.  Must match ``kws`` argument to :func:`minimize`
    :return:      Residual array (generally data-model) to be minimized in the least-squares sense.
-   :rtype:    ``None`` for normal behavior, any value like ``True`` to abort fit.
+   :rtype:    None for normal behavior, any value like True to abort the fit.
 
 
 Normally, the iteration callback would have no return value or return
@@ -345,7 +345,7 @@ statistics are not likely to be meaningful, and uncertainties will not be comput
 Using the :class:`Minimizer` class
 =======================================
 
-For full control of the fitting process, you'll want to create a
+For full control of the fitting process, you will want to create a
 :class:`Minimizer` object.
 
 .. autoclass :: Minimizer
@@ -364,7 +364,7 @@ The Minimizer object has a few public methods:
 
 .. automethod:: Minimizer.brute
 
-For more information, check the examples in 'examples/lmfit_brute.py'
+For more information, check the examples in ``examples/lmfit_brute.py``.
 
 .. automethod:: Minimizer.emcee
 
@@ -415,11 +415,11 @@ Solving with :func:`minimize` gives the Maximum Likelihood solution.::
 
 However, this doesn't give a probability distribution for the parameters.
 Furthermore, we wish to deal with the data uncertainty. This is called
-marginalisation of a nuisance parameter. emcee requires a function that returns
+marginalisation of a nuisance parameter. ``emcee`` requires a function that returns
 the log-posterior probability. The log-posterior probability is a sum of the
 log-prior probability and log-likelihood functions. The log-prior probability is
-assumed to be zero if all the parameters are within their bounds and `-np.inf`
-if any of the parameters are outside their bounds.::
+assumed to be zero if all the parameters are within their bounds and ``-np.inf``
+if any of the parameters are outside their bounds.
 
     >>> # add a noise parameter
     >>> mi.params.add('f', value=1, min=0.001, max=2)
@@ -434,13 +434,13 @@ if any of the parameters are outside their bounds.::
     ...    resid += np.log(2 * np.pi * s**2)
     ...    return -0.5 * np.sum(resid)
 
-Now we have to set up the minimizer and do the sampling.::
+Now we have to set up the minimizer and do the sampling::
 
     >>> mini = lmfit.Minimizer(lnprob, mi.params)
     >>> res = mini.emcee(burn=300, steps=600, thin=10, params=mi.params)
 
 Lets have a look at those posterior distributions for the parameters.  This requires
-installation of the `corner` package.::
+installation of the `corner` package::
 
     >>> import corner
     >>> corner.corner(res.flatchain, labels=res.var_names, truths=list(res.params.valuesdict().values()))
@@ -501,7 +501,7 @@ Getting and Printing Fit Reports
 
 .. autofunction:: fit_report
 
-An example using this to write out a fit report would be
+An example using this to write out a fit report would be:
 
 .. literalinclude:: ../examples/doc_withreport.py
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,6 @@
 .. lmfit documentation master file,
 
-Non-Linear Least-Square Minimization and Curve-Fitting for Python
+Non-Linear Least-Squares Minimization and Curve-Fitting for Python
 ===========================================================================
 
 .. _Levenberg-Marquardt:     http://en.wikipedia.org/wiki/Levenberg-Marquardt_algorithm
@@ -10,7 +10,7 @@ Non-Linear Least-Square Minimization and Curve-Fitting for Python
 
 Lmfit provides a high-level interface to non-linear optimization and curve
 fitting problems for Python. It builds on and extends many of the
-optimization methods of scipy `scipy.optimize`_.  Initially inspired by (and
+optimization methods of `scipy.optimize`_.  Initially inspired by (and
 named for) extending the `Levenberg-Marquardt`_ method from
 :scipydoc:`optimize.leastsq`, lmfit now provides a number of useful
 enhancements to optimization and data fitting problems, including:
@@ -30,16 +30,16 @@ enhancements to optimization and data fitting problems, including:
   * Improved estimation of confidence intervals.  While
     :scipydoc:`optimize.leastsq` will automatically calculate
     uncertainties and correlations from the covariance matrix, the accuracy
-    of these estimates are sometimes questionable.  To help address this,
-    lmfit has functions to explicitly explore parameter space to determine
+    of these estimates is sometimes questionable.  To help address this,
+    lmfit has functions to explicitly explore parameter space and determine
     confidence levels even for the most difficult cases.
 
   * Improved curve-fitting with the :class:`~lmfit.model.Model` class.  This
     extends the capabilities of :scipydoc:`optimize.curve_fit`, allowing
-    you to turn a function that models for your data into a python class
+    you to turn a function that models your data into a Python class
     that helps you parametrize and fit data with that model.
 
-  * Many :ref:`pre-built models <builtin_models_chapter>` for common
+  * Many :ref:`built-in models <builtin_models_chapter>` for common
     lineshapes are included and ready to use.
 
 The lmfit package is Free software, using an Open Source license.  The

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -3,6 +3,9 @@ Downloading and Installation
 ====================================
 
 .. _lmfit github repository:   http://github.com/lmfit/lmfit-py
+.. _python:  http://python.org
+.. _scipy:  http://scipy.org/scipylib/index.html
+.. _numpy:  http://numpy.org/
 .. _nose:   http://nose.readthedocs.org/
 .. _pytest: http://pytest.org/
 .. _emcee:  http://dan.iel.fm/emcee/
@@ -13,17 +16,17 @@ Downloading and Installation
 Prerequisites
 ~~~~~~~~~~~~~~~
 
-The lmfit package requires Python, Numpy, and Scipy.
+The lmfit package requires `Python`_, `NumPy`_, and `SciPy`_.
 
-Lmfit works with Python 2.7, 3.3, 3.4, 3.5, and 3.6. Support for Python 2.6
+Lmfit works with Python versions 2.7, 3.3, 3.4, 3.5, and 3.6. Support for Python 2.6
 ended with lmfit version 0.9.4.  Scipy version 0.15 or higher is required,
 with 0.17 or higher recommended to be able to use the latest optimization
-features from scipy.  Numpy version 1.5 or higher is required.
+features.  NumPy version 1.5 or higher is required.
 
 In order to run the test suite, either the `nose`_ or `pytest`_ package is
 required.  Some functionality of lmfit requires the `emcee`_ package, some
 functionality will make use of the `pandas`_, `Jupyter`_ or `matplotlib`_
-packages if these are available.  We highly recommend each of these
+packages if available.  We highly recommend each of these
 packages.
 
 
@@ -36,7 +39,7 @@ The latest stable version of lmfit is |release| is available from `PyPi
 Installation
 ~~~~~~~~~~~~~~~~~
 
-With pip now widely avaliable, you can install lmfit with::
+With ``pip`` now widely avaliable, you can install lmfit with::
 
     pip install lmfit
 
@@ -44,7 +47,7 @@ Alternatively, you can download the source kit, unpack it and install with::
 
    python setup.py install
 
-For Anaconda Python, lmfit is not an official packages, but several
+For Anaconda Python, lmfit is not an official package, but several
 Anaconda channels provide it, allowing installation with (for example)::
 
    conda install -c conda-forge lmfit

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -21,7 +21,7 @@ The lmfit package requires `Python`_, `NumPy`_, and `SciPy`_.
 Lmfit works with Python versions 2.7, 3.3, 3.4, 3.5, and 3.6. Support for Python 2.6
 ended with lmfit version 0.9.4.  Scipy version 0.15 or higher is required,
 with 0.17 or higher recommended to be able to use the latest optimization
-features.  NumPy version 1.5 or higher is required.
+features.  NumPy version 1.5.1 or higher is required.
 
 In order to run the test suite, either the `nose`_ or `pytest`_ package is
 required.  Some functionality of lmfit requires the `emcee`_ package, some

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -8,7 +8,7 @@ The lmfit package is designed to provide simple tools to help you build
 complex fitting models for non-linear least-squares problems and apply
 these models to real data.  This section gives an overview of the concepts
 and describes how to set up and perform simple fits.  Some basic knowledge
-of Python, numpy, and modeling data are assumed -- this is not a tutorial
+of Python, NumPy, and modeling data are assumed -- this is not a tutorial
 on why or how to perform a minimization or fit data, but is rather aimed at
 explaining how to use lmfit to do these things.
 
@@ -54,7 +54,7 @@ To perform the minimization with :mod:`scipy.optimize`, one would do::
     vars = [10.0, 0.2, 3.0, 0.007]
     out = leastsq(residual, vars, args=(x, data, eps_data))
 
-Though it is wonderful to be able to use python for such optimization
+Though it is wonderful to be able to use Python for such optimization
 problems, and the scipy library is robust and easy to use, the approach
 here is not terribly different from how one would do the same fit in C or
 Fortran.  There are several practical challenges to using this approach,
@@ -73,14 +73,14 @@ including:
 
   c) There is no simple, robust way to put bounds on values for the
      variables, or enforce mathematical relationships between the
-     variables.  In fact, those optimization methods that do provide
+     variables.  In fact, the optimization methods that do provide
      bounds, require bounds to be set for all variables with separate
      arrays that are in the same arbitrary order as variable values.
      Again, this is acceptable for small or one-off cases, but becomes
      painful if the fitting model needs to change.
 
 These shortcomings are really solely due to the use of traditional arrays of
-variables, as matches closely the implementation of the Fortran code.  The
+variables, and matches closely the implementation of the Fortran code.  The
 lmfit module overcomes these shortcomings by using objects -- a core reason for working with
 Python.  The key concept for lmfit is to use :class:`Parameter`
 objects instead of plain floating point numbers as the variables for the
@@ -130,7 +130,7 @@ be fixed or bounded.  This can be done during definition::
     params.add('frequency', value=3.0, max=10)
 
 where ``vary=False`` will prevent the value from changing in the fit, and
-``min=0.0`` will set a lower bound on that parameters value). It can also be done
+``min=0.0`` will set a lower bound on that parameters value. It can also be done
 later by setting the corresponding attributes after they have been
 created::
 
@@ -148,5 +148,5 @@ objective function.
 
 Finally, in addition to the :class:`Parameters` approach to fitting data,
 lmfit allows switching optimization methods without changing
-the objective function, provides tools for writing fitting reports, and
-provides better determination of Parameters confidence levels.
+the objective function, provides tools for generating fitting reports, and
+provides a better determination of Parameters confidence levels.

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -19,22 +19,22 @@ While it offers many benefits over :scipydoc:`optimize.leastsq`, using
 requires more effort than using :scipydoc:`optimize.curve_fit`.
 
 The :class:`Model` class in lmfit provides a simple and flexible approach
-to curve-fitting problems.  Like scipydoc:`optimize.curve_fit`, a
+to curve-fitting problems.  Like :scipydoc:`optimize.curve_fit`, a
 :class:`Model` uses a *model function* -- a function that is meant to
-calculate a model for some phenomenon -- and then` uses that to best match
+calculate a model for some phenomenon -- and then uses that to best match
 an array of supplied data.  Beyond that similarity, its interface is rather
-different from scipydoc:`optimize.curve_fit`, for example in that it uses
+different from :scipydoc:`optimize.curve_fit`, for example in that it uses
 :class:`~lmfit.parameter.Parameters`, but also offers several other
 important advantages.
 
-In addition to allowing you turn any model function into a curve-fitting
+In addition to allowing you to turn any model function into a curve-fitting
 method, lmfit also provides canonical definitions for many known line shapes
 such as Gaussian or Lorentzian peaks and Exponential decays that are widely
 used in many scientific domains.  These are available in the :mod:`models`
 module that will be discussed in more detail in the next chapter
 (:ref:`builtin_models_chapter`).  We mention it here as you may want to
 consult that list before writing your own model.  For now, we focus on
-turning python function into high-level fitting models with the
+turning Python functions into high-level fitting models with the
 :class:`Model` class, and using these to fit data.
 
 
@@ -46,19 +46,18 @@ peak.  As we will see, there is a buit-in :class:`GaussianModel` class that
 can help do this, but here we'll build our own.  We start with a simple
 definition of the model function:
 
-    >>> from numpy import sqrt, pi, exp, linspace
+    >>> from numpy import sqrt, pi, exp, linspace, random
     >>>
     >>> def gaussian(x, amp, cen, wid):
     ...    return amp * exp(-(x-cen)**2 /wid)
-    ...
 
 We want to use this function to fit to data :math:`y(x)` represented by the
-arrays ``y`` and ``x``.  With :scipydoc:`optimize.curve_fit`, this would be::
+arrays `y` and `x`.  With :scipydoc:`optimize.curve_fit`, this would be::
 
     >>> from scipy.optimize import curve_fit
     >>>
     >>> x = linspace(-10,10, 101)
-    >>> y = y = gaussian(x, 2.33, 0.21, 1.51) + np.random.normal(0, 0.2, len(x))
+    >>> y = gaussian(x, 2.33, 0.21, 1.51) + random.normal(0, 0.2, len(x))
     >>>
     >>> init_vals = [1, 0, 1]     # for [amp, cen, wid]
     >>> best_vals, covar = curve_fit(gaussian, x, y, p0=init_vals)
@@ -71,8 +70,8 @@ initial guesses.  The results returned are the optimal values for the
 parameters and the covariance matrix.  It's simple and useful, but it
 misses the benefits of lmfit.
 
-With lmfit, we create a :class:`Model` that wraps the ``gaussian`` model
-function, which automatically generate the appropriate residual function,
+With lmfit, we create a :class:`Model` that wraps the `gaussian` model
+function, which automatically generates the appropriate residual function,
 and determines the corresponding parameter names from the function
 signature itself::
 
@@ -80,20 +79,21 @@ signature itself::
     >>> gmodel = Model(gaussian)
     >>> gmodel.param_names
     set(['amp', 'wid', 'cen'])
-    >>> gmodel.independent_vars)
+    >>> gmodel.independent_vars
     ['x']
 
-As you can see, the Model ``gmodel`` determined the names of the parameters
+As you can see, the Model `gmodel` determined the names of the parameters
 and the independent variables.  By default, the first argument of the
 function is taken as the independent variable, held in
 :attr:`independent_vars`, and the rest of the functions positional
 arguments (and, in certain cases, keyword arguments -- see below) are used
-for Parameter names.  Thus, for the ``gaussian`` function above, the
-independent variable is ``x``, and the parameters are named ``amp``,
-``cen``, and ``wid``, and -- all taken directly from the signature of the
-model function. As we will see below, you can modify these default
-determination of what is the independent variable is and which function
-arguments should be identified as parameter names.
+for Parameter names.  Thus, for the `gaussian` function above, the
+independent variable is `x`, and the parameters are named `amp`,
+`cen`, and `wid`, and -- all taken directly from the signature of the
+model function. As we will see below, you can modify the default
+assignment of independent variable / arguments and specify yourself what
+the independent variable is and which function arguments should be identified
+as parameter names.
 
 The Parameters are *not* created when the model is created. The model knows
 what the parameters should be named, but not anything about the scale and
@@ -112,7 +112,7 @@ arguments to :meth:`make_params`:
     >>> params = gmod.make_params(cen=5, amp=200, wid=1)
 
 or assign them (and other parameter properties) after the
-:class:`~lmfit.parameter.Parameters` has been created.
+:class:`~lmfit.parameter.Parameters` class has been created.
 
 A :class:`Model` has several methods associated with it.  For example, one
 can use the :meth:`eval` method to evaluate the model or the :meth:`fit`
@@ -129,7 +129,7 @@ or with::
     >>> y = gmod.eval(x=x, cen=6.5, amp=100, wid=2.0)
 
 Admittedly, this a slightly long-winded way to calculate a Gaussian
-function, given that you could have called your ``gaussian`` function
+function, given that you could have called your `gaussian` function
 directly.  But now that the model is set up, we can use its
 :meth:`fit` method to fit this model to data, as with::
 
@@ -144,7 +144,7 @@ Putting everything together,  (included in the
 
 .. literalinclude:: ../examples/doc_model1.py
 
-which is pretty compact and to the point.  The returned ``result`` will be
+which is pretty compact and to the point.  The returned `result` will be
 a :class:`ModelResult` object.  As we will see below, this has many
 components, including a :meth:`fit_report` method, which will show::
 
@@ -183,9 +183,9 @@ Note that the model fitting was really performed with::
     gmodel = Model(gaussian)
     result = gmodel.fit(y, params, x=x, amp=5, cen=5, wid=1)
 
-These lines clearly express that we want to turn the ``gaussian`` function
+These lines clearly express that we want to turn the `gaussian` function
 into a fitting model, and then fit the :math:`y(x)` data to this model,
-starting with values of 5 for ``amp``, 5 for ``cen`` and 1 for ``wid``.  In
+starting with values of 5 for `amp`, 5 for `cen` and 1 for `wid`.  In
 addition, all the other features of lmfit are included:
 :class:`~lmfit.parameter.Parameters` can have bounds and constraints and
 the result is a rich object that can be reused to explore the model fit in
@@ -236,10 +236,10 @@ function as a fitting model.
 
    Describes what to do for missing values.  The choices are:
 
-    * ``None``: Do not check for null or missing values (default).
-    * ``'none'``: Do not check for null or missing values.
-    * ``'drop'``: Drop null or missing observations in data.  If pandas is installed, ``pandas.isnull`` is used, otherwise :attr:`numpy.isnan` is used.
-    * ``'raise'``: Raise a (more helpful) exception when data contains null or missing values.
+    * None: Do not check for null or missing values (default).
+    * 'none': Do not check for null or missing values.
+    * 'drop': Drop null or missing observations in data.  If pandas is installed, :func:`pandas.isnull` is used, otherwise :func:`numpy.isnan` is used.
+    * 'raise': Raise a (more helpful) exception when data contains null or missing values.
 
 .. attribute:: name
 
@@ -262,41 +262,42 @@ function as a fitting model.
 .. attribute:: prefix
 
    Prefix used for name-mangling of parameter names.  The default is ''.
-   If a particular :class:`Model` has arguments ``amplitude``,
-   ``center``, and ``sigma``, these would become the parameter names.
-   Using a prefix of ``g1_`` would convert these parameter names to
-   ``g1_amplitude``, ``g1_center``, and ``g1_sigma``.   This can be
+   If a particular :class:`Model` has arguments `amplitude`,
+   `center`, and `sigma`, these would become the parameter names.
+   Using a prefix of `'g1_'` would convert these parameter names to
+   `g1_amplitude`, `g1_center`, and `g1_sigma`.   This can be
    essential to avoid name collision in composite models.
 
 
 Determining parameter names and independent variables for a function
 -----------------------------------------------------------------------
 
-The :class:`Model` created from the supplied function ``func`` will create
+The :class:`Model` created from the supplied function `func` will create
 a :class:`~lmfit.parameter.Parameters` object, and names are inferred from the function
 arguments, and a residual function is automatically constructed.
 
 
 By default, the independent variable is take as the first argument to the
-function.  You can explicitly set this, of course, and will need to if the
-independent variable is not first in the list, or if there are actually more
-than one independent variables.
+function.  You can, of course, explicitly set this, and will need to do so
+if the independent variable is not first in the list, or if there are actually
+more than one independent variables.
 
 If not specified, Parameters are constructed from all positional arguments
 and all keyword arguments that have a default value that is numerical, except
 the independent variable, of course.   Importantly, the Parameters can be
-modified after creation.  In fact, you'll have to do this because none of the
-parameters have valid initial values.  You can place bounds and constraints
-on Parameters, or fix their values.
-
+modified after creation.  In fact, you will have to do this because none of the
+parameters have valid initial values. In addition, one can place bounds and
+constraints on Parameters, or fix their values.
 
 
 Explicitly specifying ``independent_vars``
 -------------------------------------------------
 
 As we saw for the Gaussian example above, creating a :class:`Model` from a
-function is fairly easy. Let's try another::
+function is fairly easy. Let's try another one::
 
+    >>> from lmfit import Model
+    >>> import numpy as np
     >>> def decay(t, tau, N):
     ...    return N*np.exp(-t/tau)
     ...
@@ -309,11 +310,11 @@ function is fairly easy. Let's try another::
     tau <Parameter 'tau', None, bounds=[None:None]>
     N <Parameter 'N', None, bounds=[None:None]>
 
-Here, ``t`` is assumed to be the independent variable because it is the
+Here, `t` is assumed to be the independent variable because it is the
 first argument to the function.  The other function arguments are used to
 create parameters for the model.
 
-If you want ``tau`` to be the independent variable in the above example,
+If you want `tau` to be the independent variable in the above example,
 you can say so::
 
     >>> decay_model = Model(decay, independent_vars=['tau'])
@@ -332,7 +333,7 @@ variable* here is simple, and based on how it treats arguments of the
 function you are modeling:
 
 independent variable
-    a function argument that is not a parameter or otherwise part of the
+    A function argument that is not a parameter or otherwise part of the
     model, and that will be required to be explicitly provided as a
     keyword argument for each fit with :meth:`Model.fit` or evaluation
     with :meth:`Model.eval`.
@@ -346,7 +347,7 @@ Functions with keyword arguments
 
 If the model function had keyword parameters, these would be turned into
 Parameters if the supplied default value was a valid number (but not
-``None``, ``True``, or ``False``).
+None, True, or False).
 
     >>> def decay2(t, tau, N=10, check_positive=False):
     ...    if check_small:
@@ -362,17 +363,17 @@ Parameters if the supplied default value was a valid number (but not
     t <Parameter 't', None, bounds=[None:None]>
     N <Parameter 'N', 10, bounds=[None:None]>
 
-Here, even though ``N`` is a keyword argument to the function, it is turned
+Here, even though `N` is a keyword argument to the function, it is turned
 into a parameter, with the default numerical value as its initial value.
 By default, it is permitted to be varied in the fit -- the 10 is taken as
 an initial value, not a fixed value.  On the other hand, the
-``check_positive`` keyword argument, was not converted to a parameter
+`check_positive` keyword argument, was not converted to a parameter
 because it has a boolean default value.    In some sense,
-``check_positive`` becomes like an independent variable to the model.
+`check_positive` becomes like an independent variable to the model.
 However, because it has a default value it is not required to be given for
 each model evaluation or fit, as independent variables are.
 
-Defining a ``prefix`` for the Parameters
+Defining a `prefix` for the Parameters
 --------------------------------------------
 
 As we will see in the next chapter when combining models, it is sometimes
@@ -380,7 +381,7 @@ necessary to decorate the parameter names in the model, but still have them
 be correctly used in the underlying model function.  This would be
 necessary, for example, if two parameters in a composite model (see
 :ref:`composite_models_section` or examples in the next chapter) would have
-the same name.  To avoid this, we can add a ``prefix`` to the
+the same name.  To avoid this, we can add a `prefix` to the
 :class:`Model` which will automatically do this mapping for us.
 
     >>> def myfunc(x, amplitude=1, center=0, sigma=1):
@@ -394,15 +395,15 @@ the same name.  To avoid this, we can add a ``prefix`` to the
     f1_center <Parameter 'f1_center', None, bounds=[None:None]>
     f1_sigma <Parameter 'f1_sigma', None, bounds=[None:None]>
 
-You would refer to these parameters as ``f1_amplitude`` and so forth, and
-the model will know to map these to the ``amplitude`` argument of ``myfunc``.
+You would refer to these parameters as `f1_amplitude` and so forth, and
+the model will know to map these to the `amplitude` argument of `myfunc`.
 
 
 Initializing model parameters
 --------------------------------
 
 As mentioned above, the parameters created by :meth:`Model.make_params` are
-generally created with invalid initial values of ``None``.  These values
+generally created with invalid initial values of None.  These values
 **must** be initialized in order for the model to be evaluated or used in a
 fit.  There are four different ways to do this initialization that can be
 used in any combination:
@@ -524,11 +525,12 @@ The :class:`ModelResult` class
 
 A :class:`ModelResult` (which had been called `ModelFit` prior to version
 0.9) is the object returned by :meth:`Model.fit`.  It is a subclass of
-:class:`~lmfit.minimizer.Minimizer`, and so contains many of the fit results.  Of course, it
-knows the :class:`Model` and the set of :class:`~lmfit.parameter.Parameters` used in the
-fit, and it has methods to evaluate the model, to fit the data (or re-fit
-the data with changes to the parameters, or fit with different or modified
-data) and to print out a report for that fit.
+:class:`~lmfit.minimizer.Minimizer`, and so contains many of the fit results.
+Of course, it knows the :class:`Model` and the set of
+:class:`~lmfit.parameter.Parameters` used in the fit, and it has methods to
+evaluate the model, to fit the data (or re-fit the data with changes to
+the parameters, or fit with different or modified data) and to print out a
+report for that fit.
 
 While a :class:`Model` encapsulates your model function, it is fairly
 abstract and does not contain the parameters or data used in a particular
@@ -582,7 +584,7 @@ comparing different models, including `chisqr`, `redchi`, `aic`, and `bic`.
 
 .. attribute:: best_fit
 
-   ndarray result of model function, evaluated at provided
+   numpy.ndarray result of model function, evaluated at provided
    independent variables and with best-fit parameters.
 
 .. attribute:: best_values
@@ -599,16 +601,16 @@ comparing different models, including `chisqr`, `redchi`, `aic`, and `bic`.
 
 .. attribute:: ci_out
 
-   Confidence interval data (see :ref:`confidence_chapter`) or `None`  if
+   Confidence interval data (see :ref:`confidence_chapter`) or None if
    the confidence intervals have not been calculated.
 
 .. attribute:: covar
 
-   ndarray (square) covariance matrix returned from fit.
+   numpy.ndarray (square) covariance matrix returned from fit.
 
 .. attribute:: data
 
-   ndarray of data to compare to model.
+   numpy.ndarray of data to compare to model.
 
 .. attribute:: errorbars
 
@@ -620,7 +622,7 @@ comparing different models, including `chisqr`, `redchi`, `aic`, and `bic`.
 
 .. attribute:: init_fit
 
-   Ndarray result of model function, evaluated at provided
+   numpy.ndarray result of model function, evaluated at provided
    independent variables and with initial parameters.
 
 .. attribute:: init_params
@@ -629,19 +631,19 @@ comparing different models, including `chisqr`, `redchi`, `aic`, and `bic`.
 
 .. attribute:: init_values
 
-   Dictionary with  parameter names as keys, and initial values as values.
+   Dictionary with parameter names as keys, and initial values as values.
 
 .. attribute:: iter_cb
 
    Optional callable function, to be called at each fit iteration.  This
-   must take take arguments of ``params, iter, resid, *args, **kws``, where
-   ``params`` will have the current parameter values, ``iter`` the
-   iteration, ``resid`` the current residual array, and ``*args`` and
-   ``**kws`` as passed to the objective function.  See :ref:`fit-itercb-label`.
+   must take take arguments of ``(params, iter, resid, *args, **kws)``, where
+   `params` will have the current parameter values, `iter` the
+   iteration, `resid` the current residual array, and `*args` and
+   `**kws` as passed to the objective function.  See :ref:`fit-itercb-label`.
 
 .. attribute:: jacfcn
 
-   Optional callable function, to be called to calculate jacobian array.
+   Optional callable function, to be called to calculate Jacobian array.
 
 .. attribute::  lmdif_message
 
@@ -685,7 +687,7 @@ comparing different models, including `chisqr`, `redchi`, `aic`, and `bic`.
 
 .. attribute::  residual
 
-   ndarray for residual.
+   numpy.ndarray for residual.
 
 .. attribute::  scale_covar
 
@@ -697,8 +699,8 @@ comparing different models, including `chisqr`, `redchi`, `aic`, and `bic`.
 
 .. attribute:: weights
 
-   ndarray (or ``None``) of weighting values to be used in fit.  If not
-   ``None``, it will be used as a multiplicative factor of the residual
+   numpy.ndarray (or None) of weighting values to be used in fit.  If not
+   None, it will be used as a multiplicative factor of the residual
    array, so that ``weights*(data - fit)`` is minimized in the
    least-squares sense.
 
@@ -825,13 +827,13 @@ Models :meth:`ModelResult.eval_components` method of the `result`::
 
 which returns a dictionary of the components, using keys of the model name
 (or `prefix` if that is set).  This will use the parameter values in
-``result.params`` and the independent variables (``x``) used during the
+`result.params` and the independent variables (`x`) used during the
 fit.  Note that while the :class:`ModelResult` held in `result` does store the
-best parameters and the best estimate of the model in ``result.best_fit``,
-the original model and parameters in ``pars`` are left unaltered.
+best parameters and the best estimate of the model in `result.best_fit`,
+the original model and parameters in `pars` are left unaltered.
 
 You can apply this composite model to other data sets, or evaluate the
-model at other values of ``x``.  You may want to do this to give a finer or
+model at other values of `x`.  You may want to do this to give a finer or
 coarser spacing of data point, or to extrapolate the model outside the
 fitting range.  This can be done with::
 
@@ -839,7 +841,7 @@ fitting range.  This can be done with::
     predicted = mod.eval(x=xwide)
 
 In this example, the argument names for the model functions do not overlap.
-If they had, the ``prefix`` argument to :class:`Model` would have allowed
+If they had, the `prefix` argument to :class:`Model` would have allowed
 us to identify which parameter went with which component model.  As we will
 see in the next chapter, using composite models with the built-in models
 provides a simple way to build up complex models.

--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -6,14 +6,14 @@
 :class:`Parameter`  and :class:`Parameters`
 ================================================
 
-This chapter describes :class:`Parameter` objects which is a key concept of
+This chapter describes the :class:`Parameter` object, which is a key concept of
 lmfit.
 
 A :class:`Parameter` is the quantity to be optimized in all minimization
 problems, replacing the plain floating point number used in the
 optimization routines from :mod:`scipy.optimize`.  A :class:`Parameter` has
 a value that can either be varied in the fit or held at a fixed value, and
-can have upper and/or lower bounds placd on the value.  It can even have a
+can have upper and/or lower bounds placed on the value.  It can even have a
 value that is constrained by an algebraic expression of other Parameter
 values.  Since :class:`Parameter` objects live outside the core
 optimization routines, they can be used in **all** optimization routines
@@ -25,11 +25,11 @@ that describe the phenomenon and gives the user more flexibility in using
 and testing variations of that model.
 
 Whereas a :class:`Parameter` expands on an individual floating point
-variable, the optimization methods still actually need an ordered group of
+variable, the optimization methods actually still need an ordered group of
 floating point variables.  In the :mod:`scipy.optimize` routines this is
-required to be a 1-dimensional numpy ndarray.  In lmfit, this 1-dimensional
+required to be a one-dimensional :numpydoc:`ndarray`.  In lmfit, this one-dimensional
 array is replaced by a :class:`Parameters` object, which works as an
-ordered dictionary of :class:`Parameter` objects, with a few additional
+ordered dictionary of :class:`Parameter` objects with a few additional
 features and methods.  That is, while the concept of a :class:`Parameter`
 is central to lmfit, one normally creates and interacts with a
 :class:`Parameters` instance that contains many :class:`Parameter` objects.
@@ -82,8 +82,9 @@ The :class:`Parameters` class
 Simple Example
 ==================
 
-Using :class:`~lmfit.parameter.Parameters` and :func:`~lmfit.minimizer.minimize`
-function (discussed in the next chapter) might look like this:
+A basic example making use of :class:`~lmfit.parameter.Parameters` and the
+:func:`~lmfit.minimizer.minimize` function (discussed in the next chapter)
+might look like this:
 
 .. literalinclude:: ../examples/doc_basic.py
 

--- a/doc/sphinx/theme/lmfitdoc/layout.html
+++ b/doc/sphinx/theme/lmfitdoc/layout.html
@@ -24,7 +24,7 @@
    <li><a href="{{ pathto('parameters') }}">parameters</a>|</li>
    <li><a href="{{ pathto('fitting') }}"> minimize</a>|</li>
    <li><a href="{{ pathto('model') }}"> model</a>|</li>
-   <li><a href="{{ pathto('builtin_models') }}"> builtin models</a>|</li>
+   <li><a href="{{ pathto('builtin_models') }}"> built-in models</a>|</li>
    <li><a href="{{ pathto('confidence') }}">confidence intervals</a>|</li>
    <li><a href="{{ pathto('bounds') }}">bounds</a>|</li>
    <li><a href="{{ pathto('constraints') }}">constraints</a>]</li>

--- a/doc/support.rst
+++ b/doc/support.rst
@@ -10,9 +10,9 @@ Getting Help
 If you have questions, comments, or suggestions for LMFIT, please use the
 `mailing list`_.  This provides an on-line conversation that is and
 archived well and can be searched well with standard web searches.  If you
-find a bug with the code or documentation, use the `github issues`_ Issue
-tracker to submit a report.  If you have an idea for how to solve the
-problem and are familiar with python and github, submitting a github Pull
+find a bug in the code or documentation, use `GitHub Issues`_
+to submit a report.  If you have an idea for how to solve the
+problem and are familiar with Python and GitHub, submitting a GitHub Pull
 Request would be greatly appreciated.
 
 If you are unsure whether to use the mailing list or the Issue tracker,

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -6,40 +6,40 @@ Release Notes
 
 .. _lmfit github repository:   http://github.com/lmfit/lmfit-py
 
-This section discusses changes between versions, especially significant
-changes to the use and behavior of the library.  This is not meant to be a
-comprehensive list of changes.  For such a complete record, consult the
-`lmfit github repository`_.
+This section discusses changes between versions, especially changes
+significant to the use and behavior of the library.  This is not meant
+to be a comprehensive list of changes.  For such a complete record,
+consult the `lmfit github repository`_.
 
 .. _whatsnew_096_label:
 
 Version 0.9.6 Release Notes
 ==========================================
 
-Support for scipy 0.14 has been dropped: scipy 0.15 is not required.  This
+Support for SciPy 0.14 has been dropped: SciPy 0.15 is now required.  This
 is especially important for lmfit maintenance, as it means we can now rely
-on scipy having code for differential evolution and do not need to keep a
+on SciPy having code for differential evolution and do not need to keep a
 local copy.
 
 A brute force method was added, which can be used either with
 :meth:`Minimizer.brute` or using the `method='brute'` option to
-:meth:`Minimizer.minimize`.   This method requires that finite bounds be
-placed on each variable parameter, and that the parameter has a finite
+:meth:`Minimizer.minimize`.  This method requires finite bounds on
+all varying parameters, or that parameters have a finite
 `brute_step` attribute set to specify the step size.
 
 Custom cost functions can now be used for the scalar minimizers using the
 `reduce_fcn` option.
 
 Many improvements to documentation and docstrings in the code were made.
-As part of that effort, all API documentation in this main sphinx
+As part of that effort, all API documentation in this main Sphinx
 documentation now derives from the docstrings.
 
 Uncertainties in the resulting best-fit for a model can now be calculated
 from the uncertainties in the model parameters.
 
-Parameters now have two new attributes: `brute_step` to specify the step
-size to take with the `brute` method, and `user_data` which is unused but
-can be used to hold additional information the user may desire.   This will
+Parameters have two new attributes: `brute_step`, to specify the step
+size when using the `brute` method, and `user_data`, which is unused but
+can be used to hold additional information the user may desire.  This will
 be preserved on copy and pickling.
 
 Several bug fixes and cleanups.
@@ -54,14 +54,14 @@ Tests can now be run either with nose or pytest.
 Version 0.9.5 Release Notes
 ==========================================
 
-Support for Python 2.6 and scipy 0.13 has been dropped.
+Support for Python 2.6 and SciPy 0.13 has been dropped.
 
 .. _whatsnew_094_label:
 
 Version 0.9.4 Release Notes
 ==========================================
 
-Some support for the new `least_squares` routine from scipy 0.17 has been
+Some support for the new `least_squares` routine from SciPy 0.17 has been
 added.
 
 
@@ -70,7 +70,7 @@ so that the Parameter value does not need `sigma = params['sigma'].value`.
 The older, explicit usage still works, but the docs, samples, and tests
 have been updated to use the simpler usage.
 
-Support for Python 2.6 and scipy 0.13 is now explicitly deprecated and wil
+Support for Python 2.6 and SciPy 0.13 is now explicitly deprecated and wil
 be dropped in version 0.9.5.
 
 .. _whatsnew_093_label:

--- a/lmfit/__init__.py
+++ b/lmfit/__init__.py
@@ -1,5 +1,5 @@
 """Lmfit provides a high-level interface to non-linear optimization and
-curve fitting problems for Python.
+curve-fitting problems for Python.
 
 Lmfit builds on the Levenberg-Marquardt algorithm of
 scipy.optimize.leastsq(), but also supports most of the optimization

--- a/lmfit/confidence.py
+++ b/lmfit/confidence.py
@@ -30,7 +30,7 @@ def f_compare(ndata, nparas, new_chi, best_chi, nfix=1.):
 
 
 def copy_vals(params):
-    """Save the values and stderrs of params in temporay dict."""
+    """Save the values and stderrs of params in temporary dict."""
     tmp_params = {}
     for para_key in params:
         tmp_params[para_key] = (params[para_key].value,
@@ -39,7 +39,7 @@ def copy_vals(params):
 
 
 def restore_vals(tmp_params, params):
-    """Restore values and stderrs of params in temporay dict."""
+    """Restore values and stderrs of params from a temporary dict."""
     for para_key in params:
         params[para_key].value, params[para_key].stderr = tmp_params[para_key]
 
@@ -51,8 +51,8 @@ def conf_interval(minimizer, result, p_names=None, sigmas=(1, 2, 3),
     The parameter for which the ci is calculated will be varied, while
     the remaining parameters are re-optimized for minimizing chi-square.
     The resulting chi-square is used  to calculate the probability with
-    a given statistic e.g. F-statistic. This function uses a 1d-rootfinder
-    from scipy to find the values resulting in the searched confidence
+    a given statistic (e.g., F-test). This function uses a 1d-rootfinder
+    from SciPy to find the values resulting in the searched confidence
     region.
 
     Parameters
@@ -67,36 +67,35 @@ def conf_interval(minimizer, result, p_names=None, sigmas=(1, 2, 3),
     sigmas : list, optional
         The sigma-levels to find. Default is [1, 2, 3]. See Note below.
     trace : bool, optional
-        Defaults to False, if true, each result of a probability calculation
-        is saved along with the parameter. This can be used to plot so
-        called "profile traces".
-    maxiter : int
+        Defaults to False, if True, each result of a probability calculation
+        is saved along with the parameter. This can be used to plot so-called
+        "profile traces".
+    maxiter : int, optional
         Maximum of iteration to find an upper limit. Default is 200.
-    prob_func : ``None`` or callable
+    verbose: bool, optional
+        Print extra debuging information. Default is False.
+    prob_func : None or callable, optional
         Function to calculate the probability from the optimized chi-square.
-        Default (``None``) uses built-in f_compare (F test).
-    verbose: bool
-        Print extra debuging information. Default is ``False``.
-
+        Default is None and uses built-in f_compare (F-test).
 
     Returns
     -------
     output : dict
-        A dict, which contains a list of (sigma, vals)-tuples for each name.
-    trace_dict : dict
-        Only if trace is set true. Is a dict, the key is the parameter which
+        A dictionary that contains a list of (sigma, vals)-tuples for each name.
+    trace_dict : dict, optional
+        Only if trace is True. Is a dict, the key is the parameter which
         was fixed. The values are again a dict with the names as keys, but with
         an additional key 'prob'. Each contains an array of the corresponding
         values.
 
     Note
     -----
-    The values for `sigma` are taken as the number of standard deviations for a normal
-    distribution and converted to probabilities.   That is, the default sigma=(1, 2, 3)
-    will use probabilities of 0.6827, 0.9545, and 0.9973.    If any of the sigma values
-    is less than 1, that will be interpreted as a probability. That is, a value of 1 and
-    0.6827 will give the same results, within precision errors.
-
+    The values for `sigma` are taken as the number of standard deviations for
+    a normal distribution and converted to probabilities. That is, the default
+    ``sigma=(1, 2, 3)`` will use probabilities of 0.6827, 0.9545, and 0.9973.
+    If any of the sigma values is less than 1, that will be interpreted as a
+    probability. That is, a value of 1 and 0.6827 will give the same results,
+    within precision.
 
     See also
     --------
@@ -104,7 +103,6 @@ def conf_interval(minimizer, result, p_names=None, sigmas=(1, 2, 3),
 
     Examples
     --------
-
     >>> from lmfit.printfuncs import *
     >>> mini = minimize(some_func, params)
     >>> mini.leastsq()
@@ -122,7 +120,8 @@ def conf_interval(minimizer, result, p_names=None, sigmas=(1, 2, 3),
     >>> free = trace['para1']['not_para1']
     >>> prob = trace['para1']['prob']
 
-    This makes it possible to plot the dependence between free and fixed.
+    This makes it possible to plot the dependence between free and fixed
+    parameters.
 
     """
     ci = ConfidenceInterval(minimizer, result, p_names, prob_func, sigmas,
@@ -134,7 +133,7 @@ def conf_interval(minimizer, result, p_names=None, sigmas=(1, 2, 3),
 
 
 def map_trace_to_names(trace, params):
-    """Map trace to param names."""
+    """Map trace to parameter names."""
     out = {}
     allnames = list(params.keys()) + ['prob']
     for name in trace.keys():
@@ -331,7 +330,7 @@ def conf_interval2d(minimizer, result, x_name, y_name, nx=10, ny=10,
                     limits=None, prob_func=None):
     r"""Calculate confidence regions for two fixed parameters.
 
-    The method is explained in *conf_interval*: here we are fixing
+    The method itself is explained in *conf_interval*: here we are fixing
     two parameters.
 
     Parameters
@@ -340,38 +339,37 @@ def conf_interval2d(minimizer, result, x_name, y_name, nx=10, ny=10,
         The minimizer to use, holding objective function.
     result : MinimizerResult
         The result of running minimize().
-    x_name : string
+    x_name : str
         The name of the parameter which will be the x direction.
-    y_name : string
+    y_name : str
         The name of the parameter which will be the y direction.
-    nx, ny : ints, optional
-        Number of points.
-    limits : tuple: optional
+    nx : int, optional
+        Number of points in the x direction.
+    ny : int, optional
+        Number of points in the y direction.
+    limits : tuple, optional
         Should have the form ((x_upper, x_lower),(y_upper, y_lower)). If not
         given, the default is 5 std-errs in each direction.
+    prob_func : None or callable, optional
+        Function to calculate the probability from the optimized chi-square.
+        Default is None and uses built-in f_compare (F-test).
 
     Returns
     -------
-    x : (nx)-array
-        x-coordinates
-    y : (ny)-array
-        y-coordinates
-    grid : (nx,ny)-array
-        Grid contains the calculated probabilities.
+    x : numpy.ndarray
+        X-coordinates (same shape as nx).
+    y : numpy.ndarray
+        Y-coordinates (same shape as ny).
+    grid : numpy.ndarray
+        Grid containing the calculated probabilities (with shape (nx, ny)).
 
     Examples
     --------
-
     >>> mini = Minimizer(some_func, params)
     >>> result = mini.leastsq()
     >>> x, y, gr = conf_interval2d(mini, result, 'para1','para2')
     >>> plt.contour(x,y,gr)
 
-    Other Parameters
-    ----------------
-    prob_func : ``None`` or callable
-        Function to calculate the probability from the optimized chi-square.
-        Default (``None``) uses built-in f_compare (F test).
     """
     # used to detect that .leastsq() has run!
     params = result.params

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -10,6 +10,7 @@ Original copyright:
    Copyright (c) 2011 Matthew Newville, The University of Chicago
 
 See LICENSE for more complete authorship information and license.
+
 """
 
 from collections import namedtuple
@@ -94,13 +95,12 @@ wrap_ueval = uncertainties.wrap(asteval_with_uncertainties)
 def eval_stderr(obj, uvars, _names, _pars):
     """Evaluate uncertainty and set .stderr for a parameter `obj`.
 
-    Given the uncertain values `uvars` (a list of uncertainties.ufloats), a list of
-    parameter names that matches uvars, and a dict of param objects, keyed by
-    name.
+    Given the uncertain values `uvars` (a list of uncertainties.ufloats), a
+    list of parameter names that matches uvars, and a dict of param objects,
+    keyed by name.
 
     This uses the uncertainties package wrapped function to evaluate the
-    uncertainty for an arbitrary expression (in obj._expr_ast) of
-    parameters.
+    uncertainty for an arbitrary expression (in obj._expr_ast) of parameters.
 
     """
     if not isinstance(obj, Parameter) or getattr(obj, '_expr_ast', None) is None:
@@ -116,12 +116,10 @@ class MinimizerException(Exception):
     """General Purpose Exception."""
 
     def __init__(self, msg):
-        """TODO: add public method docstring."""
         Exception.__init__(self)
         self.msg = msg
 
     def __str__(self):
-        """TODO: add magic method docstring."""
         return "\n%s" % self.msg
 
 
@@ -141,29 +139,69 @@ SCALAR_METHODS = {'nelder': 'Nelder-Mead',
 
 
 def reduce_chisquare(r):
-    """Reduce residual array r to scalar as chi-square (r*r).sum()."""
+    """Reduce residual array to scalar (chi-square).
+
+    Calculate the chi-square value from the residual array `r`: (r*r).sum()
+
+    Parameters
+    ----------
+    r : numpy.ndarray
+        Residual array.
+
+    Returns
+    -------
+    float
+        Chi-square calculated from the residual array
+
+    """
     return (r*r).sum()
 
 
 def reduce_negentropy(r):
-    """Reduce residual array r to scalar using negative entropy and the normal
-    (Gaussian) probability distribution of r as pdf:
+    """Reduce residual array to scalar (negentropy).
+
+    Reduce residual array `r` to scalar using negative entropy and the normal
+    (Gaussian) probability distribution of `r` as pdf:
 
        (norm.pdf(r)*norm.logpdf(r)).sum()
+
     since pdf(r) = exp(-r*r/2)/sqrt(2*pi), this is
        ((r*r/2 - log(sqrt(2*pi))) * exp(-r*r/2)).sum()
+
+    Parameters
+    ----------
+    r : numpy.ndarray
+        Residual array.
+
+    Returns
+    -------
+    float
+        Negative entropy value calculated from the residual array
 
     """
     return (norm_dist.pdf(r)*norm_dist.logpdf(r)).sum()
 
 
 def reduce_cauchylogpdf(r):
-    """Reduce residual array r to scalar using negative log-likelihood and a
-    Cauchy (Lorentzian) distribution of r:
+    """Reduce residual array to scalar (cauchylogpdf).
+
+    Reduce residual array `r` to scalar using negative log-likelihood and a
+    Cauchy (Lorentzian) distribution of `r`:
 
        -scipy.stats.cauchy.logpdf(r)
+
     (where the Cauchy pdf = 1/(pi*(1+r*r))). This gives greater
     suppression of outliers compared to normal sum-of-squares.
+
+    Parameters
+    ----------
+    r : numpy.ndarray
+        Residual array.
+
+    Returns
+    -------
+    float
+        Negative entropy value calculated from the residual array
 
     """
     return -cauchy_dist.logpdf(r).sum()
@@ -175,13 +213,13 @@ class MinimizerResult(object):
 
     Minimization results include data such as status and error messages,
     fit statistics, and the updated (i.e., best-fit) parameters themselves
-    :attr:`params`.
+    in the :attr:`params` attribute.
 
-    The list of (possible) `MinimizerResult` attributes follows.
+    The list of (possible) `MinimizerResult` attributes is given below:
 
     Attributes
     ----------
-    params : :class:`lmfit.parameter.Parameters`
+    params : :class:`~lmfit.parameter.Parameters`
         The best-fit parameters resulting from the fit.
     status : int
         Termination status of the optimizer. Its value depends on the
@@ -200,46 +238,46 @@ class MinimizerResult(object):
     nfev : int
         Number of function evaluations.
     success : bool
-        Boolean (``True``/``False``) for whether fit succeeded.
+        True if the fit succeeded, otherwise False.
     errorbars : bool
-        Boolean (``True``/``False``) for whether uncertainties were estimated.
-    message : string
+        True if uncertainties were estimated, otherwise False.
+    message : str
         Message about fit success.
     ier : int
         Integer error value from :scipydoc:`optimize.leastsq` (`leastsq` only).
-    lmdif_message : string
+    lmdif_message : str
         Message from :scipydoc:`optimize.leastsq` (`leastsq` only).
     nvarys : int
-        Number of variables in fit :math:`N_{\\rm varys}`.
+        Number of variables in fit: :math:`N_{\rm varys}`.
     ndata : int
-        Number of data points:  :math:`N`.
+        Number of data points: :math:`N`.
     nfree : int
-        Degrees of freedom in fit:  :math:`N - N_{\\rm varys}`.
+        Degrees of freedom in fit: :math:`N - N_{\rm varys}`.
     residual : numpy.ndarray
-        Residual array :math:`{\\rm Resid_i}`. Return value of the objective
+        Residual array :math:`{\rm Resid_i}`. Return value of the objective
         function when using the best-fit values of the parameters.
     chisqr : float
-        Chi-square: :math:`\chi^2 = \sum_i^N [{\\rm Resid}_i]^2`.
+        Chi-square: :math:`\chi^2 = \sum_i^N [{\rm Resid}_i]^2`.
     redchi : float
         Reduced chi-square:
-        :math:`\chi^2_{\\nu}= {\chi^2} / {(N - N_{\\rm varys})}`.
+        :math:`\chi^2_{\nu}= {\chi^2} / {(N - N_{\rm varys})}`.
     aic : float
-        Akaike Information Criterion statistic.
-        :math:`N \ln(\chi^2/N) + 2 N_{\\rm varys}`
+        Akaike Information Criterion statistic:
+        :math:`N \ln(\chi^2/N) + 2 N_{\rm varys}`.
     bic : float
-        Bayesian Information Criterion statistic.
-        :math:`N \ln(\chi^2/N) + \ln(N) N_{\\rm varys}`
+        Bayesian Information Criterion statistic:
+        :math:`N \ln(\chi^2/N) + \ln(N) N_{\rm varys}`.
     flatchain : pandas.DataFrame
-        a flatchain view of the sampling chain from the `emcee` method.
+        A flatchain view of the sampling chain from the `emcee` method.
 
     Methods
-    ----------
-    show_candidates:  pretty_print() representaiton of candidates from
-       `brute` method.
+    -------
+    show_candidates
+        Pretty_print() representation of candidates from the `brute` method.
+
     """
 
     def __init__(self, **kws):
-        """TODO: add public method docstring."""
         for key, val in kws.items():
             setattr(self, key, val)
 
@@ -263,8 +301,13 @@ class MinimizerResult(object):
     def show_candidates(self, candidate_nmb='all'):
         """A pretty_print() representation of the candidates.
 
-        Showing all candidates (default) or the specified candidate-#
-        from the brute force method.
+        Showing candidates (default is 'all') or the specified candidate-#
+        from the `brute` method.
+
+        Parameters
+        ----------
+        candidate_nmb : int or 'all'
+            The candidate-number to show using the :meth:`pretty_print` method.
 
         """
         if hasattr(self, 'candidates'):
@@ -281,9 +324,7 @@ class MinimizerResult(object):
 
 
 class Minimizer(object):
-    """
-    A general minimizer for curve fitting and optimization.
-    """
+    """A general minimizer for curve fitting and optimization."""
 
     _err_nonparam = ("params must be a minimizer.Parameters() instance or list "
                      "of Parameters()")
@@ -299,12 +340,12 @@ class Minimizer(object):
         ----------
         userfcn : callable
             Objective function that returns the residual (difference between
-            model and data) to be minimized in a least squares sense.  The
+            model and data) to be minimized in a least-squares sense.  This
             function must have the signature::
 
                 userfcn(params, *fcn_args, **fcn_kws)
 
-        params : :class:`lmfit.parameter.Parameters` object.
+        params : :class:`~lmfit.parameter.Parameters`
             Contains the Parameters for the model.
         fcn_args : tuple, optional
             Positional arguments to pass to `userfcn`.
@@ -318,49 +359,49 @@ class Minimizer(object):
 
             where `params` will have the current parameter values, `iter`
             the iteration, `resid` the current residual array, and `*fcn_args`
-            and `**fcn_kws` as passed to the objective function.
+            and `**fcn_kws` are passed to the objective function.
         scale_covar : bool, optional
-            Whether to automatically scale the covariance matrix (leastsq only).
+            Whether to automatically scale the covariance matrix (`leastsq` only).
         nan_policy : str, optional
-            Specifies action if `userfcn` (or a Jacobian) returns nan
+            Specifies action if `userfcn` (or a Jacobian) returns NaN
             values. One of:
 
             - 'raise' : a `ValueError` is raised
             - 'propagate' : the values returned from `userfcn` are un-altered
-            - 'omit' : non-finite values are filtered.
+            - 'omit' : non-finite values are filtered
 
         reduce_fcn : str or callable, optional
             Function to convert a residual array to a scalar value for the scalar
             minimizers. Optional values are (where `r` is the residual array):
 
-            - None       : sum of squares of residual [default]
+            - None : sum of squares of residual [default]
 
                = (r*r).sum()
 
             - 'negentropy' : neg entropy, using normal distribution
 
-               = rho*log(rho)).sum()` for rho=exp(-r*r/2)/(sqrt(2*pi))
+               = rho*log(rho).sum()`, where  rho = exp(-r*r/2)/(sqrt(2*pi))
 
             - 'neglogcauchy': neg log likelihood, using Cauchy distribution
 
                = -log(1/(pi*(1+r*r))).sum()
 
-            - callable   : must take 1 argument (r) and return a float.
+            - callable : must take one argument (`r`) and return a float.
 
-        kws : dict, optional
+        **kws : dict, optional
             Options to pass to the minimizer being used.
 
         Notes
         -----
-        The objective function should return the value to be minimized. For the
-        Levenberg-Marquardt algorithm from :meth:`leastsq` or
-        :meth:`least_squares`, this returned value must
-        be an array, with a length greater than or equal to the number of
-        fitting variables in the model. For the other methods, the return value
-        can either be a scalar or an array. If an array is returned, the sum of
-        squares of the array will be sent to the underlying fitting method,
-        effectively doing a least-squares optimization of the return values. If
-        the objective function returns non-finite values then a `ValueError`
+        The objective function should return the value to be minimized. For
+        the Levenberg-Marquardt algorithm from :meth:`leastsq` or
+        :meth:`least_squares`, this returned value must be an array, with a
+        length greater than or equal to the number of fitting variables in
+        the model. For the other methods, the return value can either be a
+        scalar or an array. If an array is returned, the sum of squares of
+        the array will be sent to the underlying fitting method, effectively
+        doing a least-squares optimization of the return values. If the
+        objective function returns non-finite values then a `ValueError`
         will be raised because the underlying solvers cannot deal with them.
 
         A common use for the `fcn_args` and `fcn_kws` would be to pass in
@@ -406,24 +447,24 @@ class Minimizer(object):
     def __residual(self, fvars, apply_bounds_transformation=True):
         """Residual function used for least-squares fit.
 
-        With the new, candidate values of fvars (the fitting variables),
+        With the new, candidate values of `fvars` (the fitting variables),
         this evaluates all parameters, including setting bounds and
         evaluating constraints, and then passes those to the user-supplied
         function to calculate the residual.
 
         Parameters
         ----------
-        fvars : np.ndarray
+        fvars : numpy.ndarray
             Array of new parameter values suggested by the minimizer.
-        apply_bounds_transformation : bool, optional, default=`True`
-            whether to apply lmfits parameter transformation to constrain
-            parameters. This is needed for solvers without inbuilt support for
-            bounds.
+        apply_bounds_transformation : bool, optional
+            Whether to apply lmfits parameter transformation to constrain
+            parameters (default is True). This is needed for solvers without
+            inbuilt support for bounds.
 
         Returns
         -------
-        residual : np.ndarray
-             The evaluated function values for given fvars.
+        residual : numpy.ndarray
+             The evaluated function values for given `fvars`.
 
         """
         # set parameter values
@@ -490,12 +531,12 @@ class Minimizer(object):
         Parameters
         ----------
         fvars : numpy.ndarray
-            Array of values for the variable parameters
+            Array of values for the variable parameters.
 
         Returns
         -------
         r : float
-            The user evaluated user-supplied objective function.
+            The evaluated user-supplied objective function.
 
             If the objective function is an array of size greater than 1,
             use the scalar returned by `self.reduce_fcn`.  This defaults
@@ -520,9 +561,11 @@ class Minimizer(object):
         Returns
         -------
         r : float
-            The user evaluated user-supplied objective function. If the
-            objective function is an array of size greater than 1, return the
-            array sum-of-squares
+            The  evaluated user-supplied objective function.
+
+            If the objective function is an array of size greater than 1,
+            use the scalar returned by `self.reduce_fcn`.  This defaults
+            to sum-of-squares, but can be replaced by other options.
 
         """
         r = self.__residual(fvars, apply_bounds_transformation=False)
@@ -531,7 +574,7 @@ class Minimizer(object):
         return r
 
     def prepare_fit(self, params=None):
-        """Prepare parameters for fitting, return array of initial values.
+        """Prepare parameters for fitting.
 
         Prepares and initializes model and Parameters for subsequent
         fitting. This routine prepares the conversion of :class:`Parameters`
@@ -540,6 +583,18 @@ class Minimizer(object):
         a new instance of a :class:`MinimizerResult` object that contains the
         copy of the Parameters that will actually be varied in the fit.
 
+        Parameters
+        ----------
+        params : :class:`~lmfit.parameter.Parameters`, optional
+            Contains the Parameters for the model; if None, then the
+            Parameters used to initialize the Minimizer object are used.
+
+        Returns
+        -------
+        :class:`MinimizerResult`
+
+        Notes
+        -----
         This method is called directly by the fitting methods, and it is
         generally not necessary to call this function explicitly.
 
@@ -605,9 +660,10 @@ class Minimizer(object):
         return result
 
     def unprepare_fit(self):
-        """Clean fit state, so thatt subsequent fits will need to call prepare_fit().
+        """Clean fit state, so that subsequent fits need to call prepare_fit().
 
         removes AST compilations of constraint expressions.
+
         """
         pass
 
@@ -632,8 +688,7 @@ class Minimizer(object):
         Parameters
         ----------
         method : str, optional
-            Name of the fitting method to use.
-            One of:
+            Name of the fitting method to use. One of:
 
             - 'Nelder-Mead' (default)
             - 'L-BFGS-B'
@@ -647,16 +702,16 @@ class Minimizer(object):
             - 'SLSQP'
             - 'differential_evolution'
 
-        params : Parameters, optional
-           Parameters to use as starting points.
-        kws : dict, optional
+        params : :class:`~lmfit.parameter.Parameters`, optional
+           Parameters to use as starting point.
+        **kws : dict, optional
             Minimizer options pass to :scipydoc:`optimize.minimize`.
 
         Returns
         -------
         :class:`MinimizerResult`
-            Object containing the optimized parameter
-            and several goodness-of-fit statistics.
+            Object containing the optimized parameter and several
+            goodness-of-fit statistics.
 
 
         .. versionchanged:: 0.9.0
@@ -664,7 +719,7 @@ class Minimizer(object):
 
         Notes
         -----
-        If the objective function returns a numpy array instead
+        If the objective function returns a NumPy array instead
         of the expected scalar, the sum of squares of the array
         will be used.
 
@@ -751,7 +806,7 @@ class Minimizer(object):
               ntemps=1, pos=None, reuse_sampler=False, workers=1,
               float_behavior='posterior', is_weighted=True, seed=None):
         r"""
-        Bayesian sampling of the posterior distribution using the `emcee`.
+        Bayesian sampling of the posterior distribution using `emcee`.
 
         Bayesian sampling of the posterior distribution for the parameters
         using the `emcee` Markov Chain Monte Carlo package. The method assumes
@@ -760,7 +815,7 @@ class Minimizer(object):
 
         Parameters
         ----------
-        params : :class:`lmfit.parameter.Parameters`, optional
+        params : :class:`~lmfit.parameter.Parameters`, optional
             Parameters to use as starting point. If this is not specified
             then the Parameters used to initialize the Minimizer object are
             used.
@@ -780,7 +835,7 @@ class Minimizer(object):
             Only accept 1 in every `thin` samples.
         ntemps : int, optional
             If `ntemps > 1` perform a Parallel Tempering.
-        pos : np.ndarray, optional
+        pos : numpy.ndarray, optional
             Specify the initial positions for the sampler.  If `ntemps == 1`
             then `pos.shape` should be `(nwalkers, nvarys)`. Otherwise,
             `(ntemps, nwalkers, nvarys)`. You can also initialise using a
@@ -792,7 +847,7 @@ class Minimizer(object):
             If you have already run `emcee` on a given `Minimizer` object then
             it possesses an internal ``sampler`` attribute. You can continue to
             draw from the same sampler (retaining the chain history) if you set
-            this option to `True`. Otherwise a new sampler is created. The
+            this option to True. Otherwise a new sampler is created. The
             `nwalkers`, `ntemps`, `pos`, and `params` keywords are ignored with
             this option.
             **Important**: the Parameters used to create the sampler must not
@@ -818,7 +873,7 @@ class Minimizer(object):
 
             - 'posterior' - objective function returns a log-posterior
               probability
-            - 'chi2' - objective function returns :math:`\chi^2`.
+            - 'chi2' - objective function returns :math:`\chi^2`
 
             See Notes for further details.
         is_weighted : bool, optional
@@ -835,11 +890,11 @@ class Minimizer(object):
             **Important** this parameter only has any effect if your objective
             function returns an array. If your objective function returns a
             float, then this parameter is ignored. See Notes for more details.
-        seed : int or `np.random.RandomState`, optional
-            If `seed` is an int, a new `np.random.RandomState` instance is used,
-            seeded with `seed`.
-            If `seed` is already a `np.random.RandomState` instance, then that
-            `np.random.RandomState` instance is used.
+        seed : int or `numpy.random.RandomState`, optional
+            If `seed` is an int, a new `numpy.random.RandomState` instance is
+            used, seeded with `seed`.
+            If `seed` is already a `numpy.random.RandomState` instance, then
+            that `numpy.random.RandomState` instance is used.
             Specify `seed` for repeatable minimizations.
 
         Returns
@@ -879,8 +934,8 @@ class Minimizer(object):
         where :math:`\ln p(D | F_{true})` is the 'log-likelihood' and
         :math:`\ln p(F_{true})` is the 'log-prior'. The default log-prior
         encodes prior information already known about the model. This method
-        assumes that the log-prior probability is `-np.inf` (impossible) if the
-        one of the parameters is outside its limits. The log-prior probability
+        assumes that the log-prior probability is `-numpy.inf` (impossible) if
+        the one of the parameters is outside its limits. The log-prior probability
         term is zero if all the parameters are inside their bounds (known as a
         uniform prior). The log-likelihood function is given by [1]_:
 
@@ -913,7 +968,7 @@ class Minimizer(object):
         to be correctly weighted by the standard deviation (measurement
         uncertainty) of the data points (`res = (data - model) / sigma`) and
         the log-likelihood (and log-posterior probability) is calculated as:
-        `-0.5 * np.sum(res**2)`.
+        `-0.5 * numpy.sum(res**2)`.
         This ignores the second summand in the square brackets. Consequently,
         in order to calculate a fully correct log-posterior probability value
         your objective function should return a single value. If
@@ -927,6 +982,7 @@ class Minimizer(object):
         References
         ----------
         .. [1] http://dan.iel.fm/emcee/current/user/line/
+
         """
         if not HAS_EMCEE:
             raise NotImplementedError('You must have emcee to use'
@@ -1111,7 +1167,7 @@ class Minimizer(object):
         return result
 
     def least_squares(self, params=None, **kws):
-        """Use the ``least_squares`` (new in scipy 0.17) to perform a fit.
+        """Use the `least_squares` (new in scipy 0.17) to perform a fit.
 
         It assumes that the input Parameters have been initialized, and
         a function to minimize has been properly set up.
@@ -1123,17 +1179,16 @@ class Minimizer(object):
 
         Parameters
         ----------
-        params : Parameters, optional
-           Parameters to use as starting points.
-        kws : dict, optional
-            Minimizer options to pass to
-            :scipydoc:`optimize.least_squares`.
+        params : :class:`~lmfit.parameter.Parameters`, optional
+           Parameters to use as starting point.
+        **kws : dict, optional
+            Minimizer options to pass to :scipydoc:`optimize.least_squares`.
 
         Returns
         -------
         :class:`MinimizerResult`
-            Object containing the optimized parameter
-            and several goodness-of-fit statistics.
+            Object containing the optimized parameter and several
+            goodness-of-fit statistics.
 
 
         .. versionchanged:: 0.9.0
@@ -1141,7 +1196,7 @@ class Minimizer(object):
 
         """
         if not HAS_LEAST_SQUARES:
-            raise NotImplementedError("Scipy with a version higher than 0.17 "
+            raise NotImplementedError("SciPy with a version higher than 0.17 "
                                       "is needed for this method.")
 
         result = self.prepare_fit(params)
@@ -1199,14 +1254,14 @@ class Minimizer(object):
         +------------------+----------------+------------------------------------------------------------+
         |   maxfev         | 2000*(nvar+1)  | Maximum number of function calls (nvar= # of variables)    |
         +------------------+----------------+------------------------------------------------------------+
-        |   Dfun           | ``None``       | Function to call for Jacobian calculation                  |
+        |   Dfun           | None           | Function to call for Jacobian calculation                  |
         +------------------+----------------+------------------------------------------------------------+
 
         Parameters
         ----------
-        params : :class:`lmfit.parameter.Parameters`, optional
+        params : :class:`~lmfit.parameter.Parameters`, optional
            Parameters to use as starting point.
-        kws : dict, optional
+        **kws : dict, optional
             Minimizer options to pass to :scipydoc:`optimize.leastsq`.
 
         Returns
@@ -1381,8 +1436,8 @@ class Minimizer(object):
 
         Parameters
         ----------
-        params : :class:`lmfit.parameter.Parameters` object, optional
-            Contains the Parameters for the model; if None, then the
+        params : :class:`~lmfit.parameter.Parameters` object, optional
+            Contains the Parameters for the model. If None, then the
             Parameters used to initialize the Minimizer object are used.
         Ns : int, optional
             Number of grid points along the axes, if not otherwise specified
@@ -1427,11 +1482,12 @@ class Minimizer(object):
         scenarios given below with their respective slice-object:
 
             - lower bound (:attr:`min`) and :attr:`brute_step` are specified:
-                range = (min, min + Ns*brute_step, brute_step).
+                range = (`min`, `min` + `Ns` * `brute_step`, `brute_step`).
             - upper bound (:attr:`max`) and :attr:`brute_step` are specified:
-                range = (max - Ns*brute_step, max, brute_step).
+                range = (`max` - `Ns` * `brute_step`, `max`, `brute_step`).
             - numerical value (:attr:`value`) and :attr:`brute_step` are specified:
-                range = (value - (Ns//2)*brute_step, value + (Ns//2)*brute_step, brute_step).
+                range = (`value` - (`Ns`//2) * `brute_step`, `value` +
+                (`Ns`//2) * `brute_step`, `brute_step`).
 
         """
         result = self.prepare_fit(params=params)
@@ -1517,10 +1573,10 @@ class Minimizer(object):
         method : str, optional
             Name of the fitting method to use. Valid values are:
 
-            - `'leastsq'`: Levenberg-Marquardt (default).
-            - `'least_squares'`: Least-Squares minimization, using Trust Region Reflective method by default.
+            - `'leastsq'`: Levenberg-Marquardt (default)
+            - `'least_squares'`: Least-Squares minimization, using Trust Region Reflective method by default
             - `'differential_evolution'`: differential evolution
-            - `'brute'`: brute force method.
+            - `'brute'`: brute force method
             - '`nelder`': Nelder-Mead
             - `'lbfgsb'`: L-BFGS-B
             - `'powell'`: Powell
@@ -1532,28 +1588,28 @@ class Minimizer(object):
             - `'dogleg'`: Dogleg
             - `'slsqp'`: Sequential Linear Squares Programming
 
-            In most cases, these methods wrap and use the method of the
-            same name from `scipy.optimize`, or uses
+            In most cases, these methods wrap and use the method with the
+            same name from `scipy.optimize`, or use
             `scipy.optimize.minimize` with the same `method` argument.
             Thus '`leastsq`' will use `scipy.optimize.leastsq`, while
             '`powell`' will use `scipy.optimize.minimizer(....,
             method='powell')`
 
             For more details on the fitting methods please refer to the
-            `scipy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
+            `SciPy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
 
-        params : :class:`lmfit.parameter.Parameters` object.
+        params : :class:`~lmfit.parameter.Parameters`, optional
             Parameters of the model to use as starting values.
 
-        **kwargs
+        **kws : optional
             Additional arguments are passed to the underlying minimization
             method.
 
         Returns
         -------
         :class:`MinimizerResult`
-            Object containing the optimized parameter
-            and several goodness-of-fit statistics.
+            Object containing the optimized parameter and several
+            goodness-of-fit statistics.
 
 
         .. versionchanged:: 0.9.0
@@ -1587,7 +1643,7 @@ def _lnprior(theta, bounds):
     Parameters
     ----------
     theta : sequence
-        Float parameter values (only those being varied)
+        Float parameter values (only those being varied).
     bounds : np.ndarray
         Lower and upper bounds of parameters that are varying.
         Has shape (nvarys, 2).
@@ -1595,7 +1651,7 @@ def _lnprior(theta, bounds):
     Returns
     -------
     lnprob : float
-        Log prior probability
+        Log prior probability.
 
     """
     if np.any(theta > bounds[:, 1]) or np.any(theta < bounds[:, 0]):
@@ -1614,42 +1670,41 @@ def _lnpost(theta, userfcn, params, var_names, bounds, userargs=(),
     Parameters
     ----------
     theta : sequence
-        Float parameter values (only those being varied)
+        Float parameter values (only those being varied).
     userfcn : callable
-        User objective function
-    params : lmfit.Parameters
-        The entire set of Parameters
+        User objective function.
+    params : :class:`~lmfit.parameters.Parameters`
+        The entire set of Parameters.
     var_names : list
-        The names of the parameters that are varying
-    bounds : np.ndarray
+        The names of the parameters that are varying.
+    bounds : numpy.ndarray
         Lower and upper bounds of parameters. Has shape (nvarys, 2).
     userargs : tuple, optional
-        Extra positional arguments required for user objective function
+        Extra positional arguments required for user objective function.
     userkws : dict, optional
-        Extra keyword arguments required for user objective function
+        Extra keyword arguments required for user objective function.
     float_behavior : str, optional
         Specifies meaning of objective when it returns a float. One of:
 
         'posterior' - objective function returnins a log-posterior
-                      probability.
-        'chi2' - objective function returns a chi2 value.
+                      probability
+        'chi2' - objective function returns a chi2 value
 
     is_weighted : bool
         If `userfcn` returns a vector of residuals then `is_weighted`
         specifies if the residuals have been weighted by data uncertainties.
     nan_policy : str, optional
-        Specifies action if `userfcn` returns nan
-        values. One of:
+        Specifies action if `userfcn` returns NaN values. One of:
 
             'raise' - a `ValueError` is raised
             'propagate' - the values returned from `userfcn` are un-altered
-            'omit' - the non-finite values are filtered.
+            'omit' - the non-finite values are filtered
 
 
     Returns
     -------
     lnprob : float
-        Log posterior probability
+        Log posterior probability.
 
     """
     # the comparison has to be done on theta and bounds. DO NOT inject theta
@@ -1698,12 +1753,12 @@ def _lnpost(theta, userfcn, params, var_names, bounds, userargs=(),
 
 
 def _make_random_gen(seed):
-    """Turn seed into a np.random.RandomState instance.
+    """Turn seed into a numpy.random.RandomState instance.
 
-    If seed is None, return the RandomState singleton used by np.random.
-    If seed is an int, return a new RandomState instance seeded with
-    seed. If seed is already a RandomState instance, return it.
-    Otherwise raise ValueError.
+    If seed is None, return the RandomState singleton used by
+    numpy.random. If seed is an int, return a new RandomState instance
+    seeded with seed. If seed is already a RandomState instance, return
+    it. Otherwise raise ValueError.
 
     """
     if seed is None or seed is np.random:
@@ -1717,20 +1772,20 @@ def _make_random_gen(seed):
 
 
 def _nan_policy(a, nan_policy='raise', handle_inf=True):
-    """Specify behaviour when an array contains np.nan or np.inf.
+    """Specify behaviour when an array contains numpy.nan or numpy.inf.
 
     Parameters
     ----------
     a : array_like
-        Input array to consider
+        Input array to consider.
     nan_policy : str, optional
         One of:
 
-        'raise' - raise a `ValueError` if `a` contains NaN.
+        'raise' - raise a `ValueError` if `a` contains NaN
         'propagate' - propagate NaN
         'omit' - filter NaN from input array
     handle_inf : bool, optional
-        As well as nan consider +/- inf
+        As well as NaN consider +/- inf.
 
     Returns
     -------
@@ -1785,7 +1840,7 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     cost) function using one one of the several available methods.
 
     The minimize function takes a objective function to be minimized,
-    a dictionary (:class:`lmfit.parameter.Parameters`) containing the model
+    a dictionary (:class:`~lmfit.parameter.Parameters`) containing the model
     parameters, and several optional arguments.
 
     Parameters
@@ -1794,19 +1849,19 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
         Objective function to be minimized. When method is `leastsq` or
         `least_squares`, the objective function should return an array
         of residuals (difference between model and data) to be minimized
-        in a least squares sense. With the scalar methods the objective
+        in a least-squares sense. With the scalar methods the objective
         function can either return the residuals array or a single scalar
         value. The function must have the signature:
         `fcn(params, *args, **kws)`
-    params : :class:`lmfit.parameter.Parameters` object
+    params : :class:`~lmfit.parameter.Parameters`
         Contains the Parameters for the model.
     method : str, optional
         Name of the fitting method to use. Valid values are:
 
-        - `'leastsq'`: Levenberg-Marquardt (default).
-        - `'least_squares'`: Least-Squares minimization, using Trust Region Reflective method by default.
-        - `'differential_evolution'`: differential evolution.
-        - `'brute'`: brute force method.
+        - `'leastsq'`: Levenberg-Marquardt (default)
+        - `'least_squares'`: Least-Squares minimization, using Trust Region Reflective method by default
+        - `'differential_evolution'`: differential evolution
+        - `'brute'`: brute force method
         - '`nelder`': Nelder-Mead
         - `'lbfgsb'`: L-BFGS-B
         - `'powell'`: Powell
@@ -1819,13 +1874,13 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
         - `'slsqp'`: Sequential Linear Squares Programming
 
         In most cases, these methods wrap and use the method of the same
-        name from `scipy.optimize`, or uses `scipy.optimize.minimize` with
+        name from `scipy.optimize`, or use `scipy.optimize.minimize` with
         the same `method` argument.  Thus '`leastsq`' will use
         `scipy.optimize.leastsq`, while '`powell`' will use
         `scipy.optimize.minimizer(...., method='powell')`
 
         For more details on the fitting methods please refer to the
-        `scipy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
+        `SciPy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
 
     args : tuple, optional
         Positional arguments to pass to `fcn`.
@@ -1838,18 +1893,18 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
         the iteration, `resid` the current residual array, and `*args`
         and `**kws` as passed to the objective function.
     scale_covar : bool, optional
-        Whether to automatically scale the covariance matrix (leastsq only).
+        Whether to automatically scale the covariance matrix (`leastsq` only).
     reduce_fcn : str or callable, optional
         Function to convert a residual array to a scalar value for the scalar
         minimizers. See notes in `Minimizer`.
-    fit_kws : dict, optional
+    **fit_kws : dict, optional
         Options to pass to the minimizer being used.
 
     Returns
     -------
     :class:`MinimizerResult`
-        Object containing the optimized parameter
-        and several goodness-of-fit statistics.
+        Object containing the optimized parameter and several
+        goodness-of-fit statistics.
 
 
     .. versionchanged:: 0.9.0

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -26,6 +26,7 @@ from numpy.linalg import LinAlgError
 from scipy.optimize import brute as scipy_brute
 from scipy.optimize import leastsq as scipy_leastsq
 from scipy.optimize import minimize as scipy_minimize
+from scipy.optimize import differential_evolution
 from scipy.stats import cauchy as cauchy_dist
 from scipy.stats import norm as norm_dist
 import six
@@ -41,9 +42,6 @@ from .parameter import Parameter, Parameters
 #    OptimizeResult        0.13
 #    diff_evolution        0.15
 #    least_squares         0.17
-
-
-from scipy.optimize import differential_evolution
 
 # check for scipy.opitimize.least_squares
 HAS_LEAST_SQUARES = False
@@ -287,7 +285,7 @@ class MinimizerResult(object):
         if hasattr(self, 'chain'):
             if HAS_PANDAS:
                 if len(self.chain.shape) == 4:
-                    return pd.DataFrame(self.chain[0,...].reshape((-1, self.nvarys)),
+                    return pd.DataFrame(self.chain[0, ...].reshape((-1, self.nvarys)),
                                         columns=self.var_names)
                 elif len(self.chain.shape) == 3:
                     return pd.DataFrame(self.chain.reshape((-1, self.nvarys)),
@@ -758,7 +756,7 @@ class Minimizer(object):
         if method == 'differential_evolution':
             for par in params.values():
                 if (par.vary and
-                    not (np.isfinite(par.min) and np.isfinite(par.max))):
+                        not (np.isfinite(par.min) and np.isfinite(par.max))):
                     raise ValueError('differential_evolution requires finite '
                                      'bound for all varying parameters')
 
@@ -1632,7 +1630,7 @@ class Minimizer(object):
             function = self.scalar_minimize
             for key, val in SCALAR_METHODS.items():
                 if (key.lower().startswith(user_method) or
-                    val.lower().startswith(user_method)):
+                        val.lower().startswith(user_method)):
                     kwargs['method'] = val
         return function(**kwargs)
 

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -53,6 +53,7 @@ def _ensureMatplotlib(function):
 
         return no_op
 
+
 class Model(object):
     """Create a model from a user-supplied model function.
 
@@ -865,6 +866,7 @@ class CompositeModel(Model):
         out.update(self.left._make_all_args(params=params, **kwargs))
         return out
 
+
 class ModelResult(Minimizer):
     """Result from the Model fit.
 
@@ -1148,7 +1150,6 @@ class ModelResult(Minimizer):
                             min_correl=min_correl, sort_pars=sort_pars)
         modname = self.model._reprstring(long=True)
         return '[[Model]]\n    %s\n%s\n' % (modname, report)
-
 
     @_ensureMatplotlib
     def plot_fit(self, ax=None, datafmt='o', fitfmt='-', initfmt='--',

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -54,53 +54,15 @@ def _ensureMatplotlib(function):
         return no_op
 
 class Model(object):
-    """Create a model from a user-supplied model function that returns an
-    array of data to model some data as for a curve-fitting problem.
+    """Create a model from a user-supplied model function.
 
-    The model function will normally take an independent variable (generally,
-    the first argument) and a series of arguments that are meant to be parameters
-    for the model.  Thus, a simple peak using a Gaussian defined as
+    The model function will normally take an independent variable
+    (generally, the first argument) and a series of arguments that are
+    meant to be parameters for the model. It will return an array of
+    data to model some data as for a curve-fitting problem.
 
-    >>> import numpy as np
-    >>> def gaussian(x, amp, cen, wid):
-    ...     return amp * np.exp(-(x-cen)**2 / wid)
-
-    can be turned into a Model with
-
-    >>> gmodel = Model(gaussian)
-
-    this will automatically discover the names of the independent variables and parameters:
-
-    >>> print(gmodel.param_names, gmodel.independent_vars)
-    ['amp', 'cen', 'wid'], ['x']
-
-    The :meth:`make_params` method will create a Parameters object for this model, optionally
-    taking initial values:
-
-    >>> params = gmodel.make_params(amp=1, cen=0, wid=1)
-
-    You can also use :meth:`set_param_hint` to set default attributes for the parameters
-    created, so that doing
-
-    >>> gmodel.set_param_hint('wid', min=0.0)
-
-    would set a bound on the 'wid' Parameter created by :meth:`make_params`.
-
-    A model and corresponding Parameters can be used to evaluate the model for a given
-    input array (or single value) of independent variables with:
-
-    >>> xdata = np.linspace(-1, 1, 101)
-    >>> yinit = gmodel.eval(params, x=xdata)
-
-    and can be used to fit the Parameters to match an array of data:
-
-    >>> result = gmodel.fit(data=ydata, params, x=xdata)
-
-    which will return a `ModelResult` object.
-
-    Models can be combined into a `CompositeModel` by adding (or
-    multiplying, subtracting, or dividing) two or models.
     """
+
     _forbidden_args = ('data', 'weights', 'params')
     _invalid_ivar = "Invalid independent variable name ('%s') for function %s"
     _invalid_par = "Invalid parameter name ('%s') for function %s"
@@ -115,27 +77,30 @@ class Model(object):
         """
         Parameters
         ----------
-        func: function to be wrapped
-        independent_vars: list of strings or ``None`` (default)
-            arguments to func that are independent variables
-        param_names: list of strings or ``None`` (default)
-            names of arguments to func that are to be made into parameters
-        missing:  ``None`` or string
-            how to handle `nan` and missing values in data. One of:
+        func : callable
+            Function to be wrapped.
+        independent_vars : list of str, optional
+            Arguments to func that are independent variables (default is None).
+        param_names : list of str, optional
+            Names of arguments to func that are to be made into parameters
+            (default is None).
+        missing : str, optional
+            How to handle NaN and missing values in data. One of:
 
-            - 'none' or ``None``: Do not check for null or missing values (default)
+            - 'none' or None : Do not check for null or missing values (default).
 
-            - 'drop': Drop null or missing observations in data. if pandas is
+            - 'drop' : Drop null or missing observations in data. If pandas is
               installed, `pandas.isnull` is used, otherwise `numpy.isnan` is used.
+            - 'raise' : Raise a (more helpful) exception when data contains
+              null or missing values.
 
-            - 'raise': Raise a (more helpful) exception when data contains null
-               or missing values.
-
-        name: ``None`` or string
-            name for the model. When ``None`` (default) the name is the same as
+        prefix : str, optional
+            Prefix used for the model.
+        name : str, optional
+            Name for the model. When None (default) the name is the same as
             the model function (`func`).
-        kws: optional dict
-            additional keyword arguments to pass to model function.
+        **kws : dict, optional
+            Additional keyword arguments to pass to model function.
 
         Notes
         -----
@@ -145,12 +110,27 @@ class Model(object):
         2. The model function must return an array that will be the same
         size as the data being modeled.
 
-        Example
-        -------
-        >>> def decay(t, tau, N):
-        ...     return N*np.exp(-t/tau)
-        ...
-        >>> my_model = Model(decay, independent_vars=['t'])
+        Examples
+        --------
+        The model function will normally take an independent variable (generally,
+        the first argument) and a series of arguments that are meant to be
+        parameters for the model.  Thus, a simple peak using a Gaussian
+        defined as:
+
+        >>> import numpy as np
+        >>> def gaussian(x, amp, cen, wid):
+        ...     return amp * np.exp(-(x-cen)**2 / wid)
+
+        can be turned into a Model with:
+
+        >>> gmodel = Model(gaussian)
+
+        this will automatically discover the names of the independent variables
+        and parameters:
+
+        >>> print(gmodel.param_names, gmodel.independent_vars)
+        ['amp', 'cen', 'wid'], ['x']
+
         """
         self.func = func
         self._prefix = prefix
@@ -186,7 +166,7 @@ class Model(object):
 
     @property
     def name(self):
-        """return Model name"""
+        """Return Model name."""
         return self._reprstring(long=False)
 
     @name.setter
@@ -195,16 +175,16 @@ class Model(object):
 
     @property
     def prefix(self):
-        """return Model prefix"""
+        """Return Model prefix."""
         return self._prefix
 
     @property
     def param_names(self):
-        """TODO: add method docstring."""
+        """Return the parameters of the Model."""
         return self._param_names
 
     def __repr__(self):
-        """TODO: docstring in magic method."""
+        """ Return representation of Model."""
         return "<lmfit.Model: %s>" % (self.name)
 
     def copy(self, **kwargs):
@@ -212,7 +192,7 @@ class Model(object):
         raise NotImplementedError("Model.copy does not work. Make a new Model")
 
     def _parse_params(self):
-        """Build params from function arguments."""
+        """Build parameters from function arguments."""
         if self.func is None:
             return
         if hasattr(self.func, 'argnames') and hasattr(self.func, 'kwargs'):
@@ -288,28 +268,34 @@ class Model(object):
         self._param_names = names[:]
 
     def set_param_hint(self, name, **kwargs):
-        """Set *hints* to use when creating parameters with `make_params()`
-        for the named parameter.  This is especially convenient for setting initial
-        values.  The ``name`` can include the models ``prefix`` or not.
+        """Set *hints* to use when creating parameters with `make_params()` for
+        the named parameter.
 
-        The hint given can also include optional bounds and constraints
-        (value, vary, min, max, expr) which will be used by make_params()
-        when building default parameters.
+        This is especially convenient for setting initial values. The `name`
+        can include the models `prefix` or not. The hint given can also
+        include optional bounds and constraints ``(value, vary, min, max, expr)``,
+        which will be used by make_params() when building default parameters.
 
         Parameters
         ----------
         name : string
-            Parameter name
-        value : float or ``None`` (default)
-            value for parameter.
-        min : float or ``-np.inf`` (default)
-            lower bound for parameter value.
-        max : float or ``np.inf`` (default)
-            upper bound for parameter value.
-        vary : bool (default ``True``)
-            whether to vary of fix parameter value
-        expr : string or ``None`` (default)
-            expression to use to constrain parameter value.
+            Parameter name.
+
+        **kwargs : optional
+            Arbitrary keyword arguments, needs to be a Parameter attribute.
+            Can be any of the following:
+
+            - value : float, optional
+                Numerical Parameter value.
+            - vary : bool, optional
+                Whether the Parameter is varied during a fit (default is True).
+            - min : float, optional
+                Lower bound for value (default is `-numpy.inf`, no lower bound).
+            - max : float, optional
+                Upper bound for value (default is `numpy.inf`, no upper bound).
+            - expr : str, optional
+                Mathematical expression used to constrain the value during the fit.
+
 
         Example
         --------
@@ -332,10 +318,12 @@ class Model(object):
                 warnings.warn(self._invalid_hint % (key, name))
 
     def print_param_hints(self, colwidth=8):
-        """Print a nicely aligned text-table of parameters hints.
+        """Print a nicely aligned text-table of parameter hints.
 
-        The argument `colwidth` is the width of each column, except for
-        first and last columns.
+        Parameters
+        ----------
+        colwidth : int, optional
+           Width of each column, except for first and last columns.
 
         """
         name_len = max(len(s) for s in self.param_hints)
@@ -355,11 +343,11 @@ class Model(object):
 
         Parameters
         ----------
-        kwargs : optional initial values
-            parameter names and initial values
+        verbose : bool, optional
+            Whether to print out messages (default is False).
+        **kwargs : optional
+            Parameter names and initial values.
 
-        verbose : bool (default ``False``):
-            whether to print out messages
 
         Returns
         ---------
@@ -369,7 +357,10 @@ class Model(object):
         -----
         1. The parameters may or may not have decent initial values for each
         parameter.
-        2. This applies any default values or parameter hints that may have been set.
+
+        2. This applies any default values or parameter hints that may have
+        been set.
+
         """
         params = Parameters()
 
@@ -433,18 +424,20 @@ class Model(object):
 
     def guess(self, data, **kws):
         """Guess starting values for the parameters of a model.
-        This is not implemented for all models, but is available
-        for many of the built-in models.
+
+        This is not implemented for all models, but is available for many of
+        the built-in models.
 
         Parameters
         ----------
-        data : array-like
-            array of data to use to guess parameter values.
-        kws : additional keyword arguments, passed to model function.
+        data : array_like
+            Array of data to use to guess parameter values.
+        **kws : optional
+            Additional keyword arguments, passed to model function.
 
         Returns
         -------
-        params  : Parameters
+        params : Parameters
 
         Notes
         -----
@@ -455,6 +448,7 @@ class Model(object):
         Raises
         ------
         NotImplementedError
+
         """
         cname = self.__class__.__name__
         msg = 'guess() not implemented for %s' % cname
@@ -473,7 +467,7 @@ class Model(object):
         part of the residual and the imaginary part is treated
         correspondingly.
 
-        Since the underlying scipy.optimize routines expect np.float
+        Since the underlying scipy.optimize routines expect numpy.float
         arrays, the only complex type supported is np.complex.
 
         The "ravels" throughout are necessary to support pandas.Series.
@@ -545,23 +539,23 @@ class Model(object):
         return args
 
     def eval(self, params=None, **kwargs):
-        """Evaluate the model with the supplied parameters and keyword arguments
+        """Evaluate the model with supplied parameters and keyword arguments.
 
         Parameters
         -----------
-        params : Parameters or ``None``
-            parameters to use in Model
-        kwargs : optional
-            keyword arguments to pass to model function.
+        params : Parameters, optional
+            Parameters to use in Model.
+        **kwargs : optional
+            Additional keyword arguments to pass to model function.
 
         Returns
         -------
-        val : ndarray
-            value of model given the parameters and other arguments.
+        numpy.ndarray
+            Value of model given the parameters and other arguments.
 
         Notes
         -----
-        1. if `params` is ``None``, the values for all parameters are
+        1. if `params` is None, the values for all parameters are
         expected to be provided as keyword arguments.  If `params` is
         given, and a keyword argument for a parameter value is also given,
         the keyword argument will be used.
@@ -569,6 +563,7 @@ class Model(object):
         2. all non-parameter arguments for the model function, **including
         all the independent variables** will need to be passed in using
         keyword arguments.
+
         """
         return self.func(**self.make_funcargs(params, kwargs))
 
@@ -582,15 +577,17 @@ class Model(object):
 
         Parameters
         -----------
-        params : Parameters or ``None``
-            parameters to use in Model
-        kwargs : optional
-            keyword arguments to pass to model function.
+        params : Parameters, optional
+            Parameters to use in Model.
+        **kwargs : optional
+            Additional keyword arguments to pass to model function.
 
-        Returns:
-        --------
-        comps : OrderedDict
-            keys are prefixes for component model, values are value of each component.
+        Returns
+        -------
+        OrderedDict
+            Keys are prefixes for component model, values are value of each
+            component.
+
         """
         key = self._prefix
         if len(key) < 1:
@@ -600,38 +597,41 @@ class Model(object):
     def fit(self, data, params=None, weights=None, method='leastsq',
             iter_cb=None, scale_covar=True, verbose=False, fit_kws=None,
             **kwargs):
-        """Fit the model to the data using the supplied Parameters
+        """Fit the model to the data using the supplied Parameters.
 
         Parameters
         ----------
-        data: array-like
-            array of data to be fig.
-        params: Parameters or ``None`` (default)
-            parameters to use in fit.
-        weights: array-like of same size as data or ``None`` (default)
-            weights to use for the calculation of the fit residual.
-        method: string  (default = 'leastsq')
-            name of fitting method to use
-        iter_cb:  callable or ``None`` (default)
-             callback function to call at each iteration.
-        scale_covar:  bool (default ``True``)
-             whether to automatically scale the covariance matrix when calculating
-             uncertainties. `leastsq` method only.
-        verbose: bool (default ``True``)
-             whether to print a message when a new parameter is added because of a hint.
-        fit_kws: dict or ``None`` (default)
-             default fitting options, such as xtol and maxfev, for scipy optimizer
-        kwargs: optional
-             arguments to pass to the  model function, possibly overriding params
+        data : array_like
+            Array of data to be fit.
+        params : Parameters, optional
+            Parameters to use in fit (default is None).
+        weights : array_like of same size as `data`, optional
+            Weights to use for the calculation of the fit residual (default
+            is None).
+        method : str, optional
+            Name of fitting method to use (default is `'leastsq'`).
+        iter_cb : callable, optional
+             Callback function to call at each iteration (default is None).
+        scale_covar : bool, optional
+             Whether to automatically scale the covariance matrix when
+             calculating uncertainties (default is True, `leastsq` method only).
+        verbose: bool, optional
+             Whether to print a message when a new parameter is added because
+             of a hint (default is True).
+        fit_kws: dict, optional
+             Options to pass to the minimizer being used.
+        **kwargs: optional
+             Arguments to pass to the  model function, possibly overriding
+             params.
 
         Returns
         -------
-        lmfit.ModelResult
+        ModelResult
 
         Examples
         --------
-        Take t to be the independent variable and data to be the curve we will fit.
-        Use keyword arguments to set initial guesses:
+        Take `t` to be the independent variable and data to be the curve we
+        will fit. Use keyword arguments to set initial guesses:
 
         >>> result = my_model.fit(data, tau=5, N=3, t=t)
 
@@ -645,7 +645,7 @@ class Model(object):
 
         Notes
         -----
-        1. if `params` is ``None``, the values for all parameters are
+        1. if `params` is None, the values for all parameters are
         expected to be provided as keyword arguments.  If `params` is
         given, and a keyword argument for a parameter value is also given,
         the keyword argument will be used.
@@ -657,6 +657,7 @@ class Model(object):
         3. Parameters (however passed in), are copied on input, so the
         original Parameter objects are unchanged, and the updated values
         are in the returned `ModelResult`.
+
         """
         if params is None:
             params = self.make_params(verbose=verbose)
@@ -731,37 +732,38 @@ class Model(object):
         return output
 
     def __add__(self, other):
-        """TODO: docstring in magic method."""
+        """+"""
         return CompositeModel(self, other, operator.add)
 
     def __sub__(self, other):
-        """TODO: docstring in magic method."""
+        """-"""
         return CompositeModel(self, other, operator.sub)
 
     def __mul__(self, other):
-        """TODO: docstring in magic method."""
+        """*"""
         return CompositeModel(self, other, operator.mul)
 
     def __div__(self, other):
-        """TODO: docstring in magic method."""
+        """/"""
         return CompositeModel(self, other, operator.truediv)
 
     def __truediv__(self, other):
-        """TODO: docstring in magic method."""
+        """/"""
         return CompositeModel(self, other, operator.truediv)
 
 
 class CompositeModel(Model):
-    """A composite model combines two models (`left` and `right`) with a
-    binary operator (`op`).
-
+    """Combine two models (`left` and `right`) with a binary operator (`op`)
+    into a CompositeModel.
 
     Normally, one does not have to explicitly create a `CompositeModel`,
     but can use normal Python operators `+`, '-', `*`, and `/` to combine
-    components as doing::
+    components as in::
 
     >>> mod = Model(fcn1) + Model(fcn2) * Model(fcn3)
+
     """
+
     _names_collide = ("\nTwo models have parameters named '{clash}'. "
                       "Use distinct names.")
     _bad_arg = "CompositeModel: argument {arg} is not a Model"
@@ -773,19 +775,20 @@ class CompositeModel(Model):
         """
         Parameters
         ----------
-        left :  `Model` instance
-            left-hand model
-        right :  `Model` instance
-            right-hand model
-        op :  callable binary operator
-            operator to combine `left` and `right` models.
-        kwargs : optional
-            additional keywords are passed to `Model` when creating this
+        left : Model
+            Left-hand model.
+        right : Model
+            Right-hand model.
+        op : callable binary operator
+            Operator to combine `left` and `right` models.
+        **kws : optional
+            Additional keywords are passed to `Model` when creating this
             new model.
 
         Notes
         -----
         1. The two models must use the same independent variable.
+
         """
         if not isinstance(left, Model):
             raise ValueError(self._bad_arg.format(arg=left))
@@ -841,14 +844,14 @@ class CompositeModel(Model):
                        self.right.eval(params=params, **kwargs))
 
     def eval_components(self, **kwargs):
-        """Return ordered dict of name, results for each component."""
+        """Return OrderedDict of name, results for each component."""
         out = OrderedDict(self.left.eval_components(**kwargs))
         out.update(self.right.eval_components(**kwargs))
         return out
 
     @property
     def param_names(self):
-        """TODO: docstring in public method."""
+        """Return parameter names for composite model."""
         return self.left.param_names + self.right.param_names
 
     @property
@@ -857,43 +860,46 @@ class CompositeModel(Model):
         return self.left.components + self.right.components
 
     def _make_all_args(self, params=None, **kwargs):
-        """Generate **all** function args for all functions."""
+        """Generate **all** function arguments for all functions."""
         out = self.right._make_all_args(params=params, **kwargs)
         out.update(self.left._make_all_args(params=params, **kwargs))
         return out
 
 class ModelResult(Minimizer):
-    """Result from Model fit.
-    This has many attributes and methods for viewing and working with the
-    results of a fit using Model.  It inherits from Minimizer, so that it
-    can be used to modify and re-run the fit for the Model.
+    """Result from the Model fit.
+
+    This has many attributes and methods for viewing and working with
+    the results of a fit using Model. It inherits from Minimizer, so
+    that it can be used to modify and re-run the fit for the Model.
+
     """
+
     def __init__(self, model, params, data=None, weights=None,
                  method='leastsq', fcn_args=None, fcn_kws=None,
                  iter_cb=None, scale_covar=True, **fit_kws):
         """
         Parameters
         ----------
-        model : Model instance
-            model to use.
-        params : Parameters instance
-            parameters with initial values for model.
-        data : array-like or ``None``
-            data to be modeled.
-        weights : array-like or ``None``
-            weights to multiply (data-model) for fit residual.
-        method : string
-            name of minimization method to use
-        fcn_args : sequence or ``None``
-            positional arguments to send to model function
-        fcn_dict : dict or ``None``
-            keyword arguments to send to model function
-        iter_cb : callable or ``None``
-            function to call on each iteration of fit.
-        scale_covar :  bool
-            whether to scale covariance matrix for uncertainty evaluation
-        fit_kws : optional
-            keyword arguments to send to minimization routine.
+        model : Model
+            Model to use.
+        params : Parameters
+            Parameters with initial values for model.
+        data : array_like, optional
+            Data to be modeled.
+        weights : array_like, optional
+            Weights to multiply (data-model) for fit residual.
+        method : str, optional
+            Name of minimization method to use (default is `'leastsq'`).
+        fcn_args : sequence, optional
+            Positional arguments to send to model function.
+        fcn_dict : dict, optional
+            Keyword arguments to send to model function.
+        iter_cb : callable, optional
+            Function to call on each iteration of fit.
+        scale_covar : bool, optional
+            Whether to scale covariance matrix for uncertainty evaluation.
+        **fit_kws : optional
+            Keyword arguments to send to minimization routine.
         """
         self.model = model
         self.data = data
@@ -910,16 +916,17 @@ class ModelResult(Minimizer):
 
         Parameters
         ----------
-        data : array-like or ``None``
-            data to be modeled.
-        params : Parameters instance
-            parameters with initial values for model.
-        weights : array-like or ``None``
-            weights to multiply (data-model) for fit residual.
-        method : string
-            name of minimization method to use
-        kwargs : optional
-            keyword arguments to send to minimization routine.
+        data : array_like, optional
+            Data to be modeled.
+        params : Parameters, optional
+            Parameters with initial values for model.
+        weights : array_like, optional
+            Weights to multiply (data-model) for fit residual.
+        method : str, optional
+            Name of minimization method to use (default is `'leastsq'`).
+        **kwargs : optional
+            Keyword arguments to send to minimization routine.
+
         """
         if data is not None:
             self.data = data
@@ -952,15 +959,16 @@ class ModelResult(Minimizer):
 
         Parameters
         ----------
-        params : Parameters or ``None`` (default)
+        params : Parameters, optional
             Parameters to use.
-        kwargs : optional
-            options to send Model.eval()
+        **kwargs : optional
+            Options to send to Model.eval()
 
         Returns
         -------
-        out : ndarray
-           array for evaluated model
+        out : numpy.ndarray
+           Array for evaluated model.
+
         """
         self.userkws.update(kwargs)
         if params is None:
@@ -972,15 +980,15 @@ class ModelResult(Minimizer):
 
         Parameters
         ----------
-        params : Parameters or ``None``
-            parameters, defaults to ModelResult.params
-        kwargs : optional
-             keyword arguments to pass to model function.
+        params : Parameters, optional
+            Parameters, defaults to ModelResult.params
+        **kwargs : optional
+             Leyword arguments to pass to model function.
 
         Returns
         -------
-        comps : ordered dictionary
-             keys are prefixes of component models, and values are
+        OrderedDict
+             Keys are prefixes of component models, and values are
              the estimated model value for each component of the model.
 
         """
@@ -991,22 +999,22 @@ class ModelResult(Minimizer):
 
     def eval_uncertainty(self, params=None, sigma=1, **kwargs):
         """Evaluate the uncertainty of the *model function* from the
-        uncertainties for the best-fit parameters.  This can be used
-        to give confidence bands for the model.
+        uncertainties for the best-fit parameters.  This can be used to give
+        confidence bands for the model.
 
         Parameters
         ----------
-        params : Parameters or ``None``
-             parameters, defaults to ModelResult .params
-        sigma : float
-             confidence level, i.e. how many sigma [default=1]
-        kwargs : optional
-             values of options, independent variables, etc
+        params : Parameters, optional
+             Parameters, defaults to ModelResult.params.
+        sigma : float, optional
+             Confidence level, i.e. how many sigma (default  is 1).
+        **kwargs : optional
+             Values of options, independent variables, etcetera.
 
         Returns
         -------
-        out : ndarray
-           uncertainty at each value of the model.
+        numpy.ndarray
+           Uncertainty at each value of the model.
 
         Example
         -------
@@ -1021,13 +1029,15 @@ class ModelResult(Minimizer):
         Notes
         -----
         1. This is based on the excellent and clear example from
-           https://www.astro.rug.nl/software/kapteyn/kmpfittutorial.html#confidence-and-prediction-intervals which references the original work of
+           https://www.astro.rug.nl/software/kapteyn/kmpfittutorial.html#confidence-and-prediction-intervals,
+           which references the original work of:
            J. Wolberg,Data Analysis Using the Method of Least Squares, 2006, Springer
-        2. the value of sigma is number of `sigma` values, and is converted to a
+        2. The value of sigma is number of `sigma` values, and is converted to a
            probability.  Values or 1, 2, or 3 give probalities of 0.6827, 0.9545,
            and 0.9973, respectively. If the sigma value is < 1, it is interpreted
            as the probability itself.  That is, `sigma=1` and `sigma=0.6827` will
            give the same results, within precision errors.
+
         """
         self.userkws.update(kwargs)
         if params is None:
@@ -1066,29 +1076,35 @@ class ModelResult(Minimizer):
         return np.sqrt(df2*self.redchi) * t.ppf((prob+1)/2.0, ndata-nvarys)
 
     def conf_interval(self, **kwargs):
-        """Calculate the confidence intervals for the variable parameters
-        using :func:`confidence.conf_interval()`.  keyword arguments are
-        passed to that function.  The result is stored in :attr:`ci_out`,
-        and so can be accessed without recalculating them.
+        """Calculate the confidence intervals for the variable parameters.
+
+        Confidence intervals are calculated using the
+        :func:`confidence.conf_interval()` function and keyword
+        arguments (`**kwargs`) are passed to that function. The result
+        is stored in the :attr:`ci_out` attribute so that it can be
+        accessed without recalculating them.
+
         """
         if self.ci_out is None:
             self.ci_out = conf_interval(self, self, **kwargs)
         return self.ci_out
 
     def ci_report(self, with_offset=True, ndigits=5, **kwargs):
-        """Return a nicely formatted text report of the confidence
-        intervals, as from :func:`ci_report()`.
+        """Return a nicely formatted text report of the confidence intervals.
 
         Parameters
         ----------
-        with_offset : bool (default `True`)
-             Whether to subtract best value from all other values.
-        ndigits : int (default 5)
-            Number of significant digits to show.
+        with_offset : bool, optional
+             Whether to subtract best value from all other values (default is True).
+        ndigits : int, optional
+            Number of significant digits to show (default is 5).
+        **kwargs: optional
+            Keyword arguments that are passed to the `conf_interval` function.
 
         Returns
         -------
-        Text of formatted report on confidence intervals.
+        str
+            Text of formatted report on confidence intervals.
 
         """
         return ci_report(self.conf_interval(**kwargs),
@@ -1096,35 +1112,36 @@ class ModelResult(Minimizer):
 
     def fit_report(self, modelpars=None, show_correl=True,
                    min_correl=0.1, sort_pars=False):
-        """Return a printable fit report for the fit with fit statistics,
-        best-fit values with uncertainties and correlations.
+        """Return a printable fit report.
+
+        The report contains fit statistics and best-fit values with
+        uncertainties and correlations.
 
 
         Parameters
         ----------
-        inpars  : Parameters
-           input Parameters from fit or MinimizerResult returned from a fit.
-        modelpars : optional
-           known Model Parameters
-        show_correl : bool, default ``True``
-           whether to show list of sorted correlations
-        min_correl : float, default 0.1
-           smallest correlation absolute value to show.
-        sort_pars : bool, default ``False``, or callable
-           whether to show parameter names sorted in alphanumerical order.  If
-           ``False``, then the parameters will be listed in the order they were
-           added to the Parameters dictionary. If callable, then this (one
-           argument) function is used to extract a comparison key from each
-           list element.
+        modelpars : Parameters, optional
+           Known Model Parameters.
+        show_correl : bool, optional
+           Whether to show list of sorted correlations (default is True).
+        min_correl : float, optional
+           Smallest correlation in absolute value to show (default is 0.1).
+        sort_pars : callable, optional
+           Whether to show parameter names sorted in alphanumerical order
+           (default is False). If False, then the parameters will be listed in
+           the order as they were added to the Parameters dictionary. If callable,
+           then this (one argument) function is used to extract a comparison key
+           from each list element.
 
         Returns
         -------
-        text : string
-           multi-line text of fit report
+        text : str
+           Multi-line text of fit report.
 
         See Also
         --------
         :func:`fit_report()`
+
         """
         report = fit_report(self.params, modelpars=modelpars,
                             show_correl=show_correl,
@@ -1138,8 +1155,9 @@ class ModelResult(Minimizer):
                  xlabel=None, ylabel=None, yerr=None, numpoints=None,
                  data_kws=None, fit_kws=None, init_kws=None, ax_kws=None):
         """Plot the fit results using matplotlib, if available.
+
         The plot will include the data points, the initial fit curve, and
-        the best-fit curve. If the fit  model included weights or if ``yerr``
+        the best-fit curve. If the fit  model included weights or if `yerr`
         is specified, errorbars will also be plotted.
 
 
@@ -1148,31 +1166,31 @@ class ModelResult(Minimizer):
         ax : matplotlib.axes.Axes, optional
             The axes to plot on. The default in None, which means use the
             current pyplot axis or create one if there is none.
-        datafmt : string, optional
-            matplotlib format string for data points
-        fitfmt : string, optional
-            matplotlib format string for fitted curve
-        initfmt : string, optional
-            matplotlib format string for initial conditions for the fit
-        xlabel : string, optional
-            matplotlib format string for labeling the x-axis
-        ylabel : string, optional
-            matplotlib format string for labeling the y-axis
-        yerr : ndarray, optional
-            array of uncertainties for data array
+        datafmt : str, optional
+            Matplotlib format string for data points.
+        fitfmt : str, optional
+            Matplotlib format string for fitted curve.
+        initfmt : str, optional
+            Matplotlib format string for initial conditions for the fit.
+        xlabel : str, optional
+            Matplotlib format string for labeling the x-axis.
+        ylabel : str, optional
+            Matplotlib format string for labeling the y-axis.
+        yerr : numpy.ndarray, optional
+            Array of uncertainties for data array.
         numpoints : int, optional
             If provided, the final and initial fit curves are evaluated not
             only at data points, but refined to contain `numpoints` points in
             total.
-        data_kws : dictionary, optional
-            keyword arguments passed on to the plot function for data points
-        fit_kws : dictionary, optional
-            keyword arguments passed on to the plot function for fitted curve
-        init_kws : dictionary, optional
-            keyword arguments passed on to the plot function for the initial
-            conditions of the fit
-        ax_kws : dictionary, optional
-            keyword arguments for a new axis, if there is one being created
+        data_kws : dict, optional
+            Keyword arguments passed on to the plot function for data points.
+        fit_kws : dict, optional
+            Keyword arguments passed on to the plot function for fitted curve.
+        init_kws : dict, optional
+            Keyword arguments passed on to the plot function for the initial
+            conditions of the fit.
+        ax_kws : dict, optional
+            Keyword arguments for a new axis, if there is one being created.
 
         Returns
         -------
@@ -1183,9 +1201,9 @@ class ModelResult(Minimizer):
         For details about plot format strings and keyword arguments see
         documentation of matplotlib.axes.Axes.plot.
 
-        If yerr is specified or if the fit model included weights, then
-        matplotlib.axes.Axes.errorbar is used to plot the data.  If yerr is
-        not specified and the fit includes weights, yerr set to 1/self.weights
+        If `yerr` is specified or if the fit model included weights, then
+        matplotlib.axes.Axes.errorbar is used to plot the data.  If `yerr` is
+        not specified and the fit includes weights, `yerr` set to 1/self.weights
 
         If `ax` is None then `matplotlib.pyplot.gca(**ax_kws)` is called.
 
@@ -1255,25 +1273,26 @@ class ModelResult(Minimizer):
     @_ensureMatplotlib
     def plot_residuals(self, ax=None, datafmt='o', yerr=None, data_kws=None,
                        fit_kws=None, ax_kws=None):
-        """Plot the fit residuals using matplotlib, if available. If ``yerr``
-        is supplied or if the model included weights, errorbars will also
-        be plotted.
+        """Plot the fit residuals using matplotlib, if available.
+
+        If `yerr` is supplied or if the model included weights, errorbars
+        will also be plotted.
 
         Parameters
         ----------
         ax : matplotlib.axes.Axes, optional
             The axes to plot on. The default in None, which means use the
             current pyplot axis or create one if there is none.
-        datafmt : string, optional
-            matplotlib format string for data points
-        yerr : ndarray, optional
-            array of uncertainties for data array
-        data_kws : dictionary, optional
-            keyword arguments passed on to the plot function for data points
-        fit_kws : dictionary, optional
-            keyword arguments passed on to the plot function for fitted curve
-        ax_kws : dictionary, optional
-            keyword arguments for a new axis, if there is one being created
+        datafmt : str, optional
+            Matplotlib format string for data points.
+        yerr : numpy.ndarray, optional
+            Array of uncertainties for data array.
+        data_kws : dict, optional
+            Keyword arguments passed on to the plot function for data points.
+        fit_kws : dict, optional
+            Keyword arguments passed on to the plot function for fitted curve.
+        ax_kws : dict, optional
+            Keyword arguments for a new axis, if there is one being created.
 
         Returns
         -------
@@ -1284,9 +1303,9 @@ class ModelResult(Minimizer):
         For details about plot format strings and keyword arguments see
         documentation of matplotlib.axes.Axes.plot.
 
-        If yerr is specified or if the fit model included weights, then
-        matplotlib.axes.Axes.errorbar is used to plot the data.  If yerr is
-        not specified and the fit includes weights, yerr set to 1/self.weights
+        If `yerr` is specified or if the fit model included weights, then
+        matplotlib.axes.Axes.errorbar is used to plot the data.  If `yerr` is
+        not specified and the fit includes weights, `yerr` set to 1/self.weights
 
         If `ax` is None then `matplotlib.pyplot.gca(**ax_kws)` is called.
 
@@ -1337,24 +1356,25 @@ class ModelResult(Minimizer):
              fit_kws=None, init_kws=None, ax_res_kws=None, ax_fit_kws=None,
              fig_kws=None):
         """Plot the fit results and residuals using matplotlib, if available.
+
         The method will produce a matplotlib figure with both results of the
         fit and the residuals plotted. If the fit model included weights,
         errorbars will also be plotted.
 
         Parameters
         ----------
-        datafmt : string, optional
-            matplotlib format string for data points
-        fitfmt : string, optional
-            matplotlib format string for fitted curve
-        initfmt : string, optional
-            matplotlib format string for initial conditions for the fit
-        xlabel : string, optional
-            matplotlib format string for labeling the x-axis
-        ylabel : string, optional
-            matplotlib format string for labeling the y-axis
-        yerr : ndarray, optional
-            array of uncertainties for data array
+        datafmt : str, optional
+            Matplotlib format string for data points.
+        fitfmt : str, optional
+            Matplotlib format string for fitted curve.
+        initfmt : str, optional
+            Matplotlib format string for initial conditions for the fit.
+        xlabel : str, optional
+            Matplotlib format string for labeling the x-axis.
+        ylabel : str, optional
+            Matplotlib format string for labeling the y-axis.
+        yerr : numpy.ndarray, optional
+            Array of uncertainties for data array.
         numpoints : int, optional
             If provided, the final and initial fit curves are evaluated not
             only at data points, but refined to contain `numpoints` points in
@@ -1362,19 +1382,19 @@ class ModelResult(Minimizer):
         fig : matplotlib.figure.Figure, optional
             The figure to plot on. The default is None, which means use the
             current pyplot figure or create one if there is none.
-        data_kws : dictionary, optional
-            keyword arguments passed on to the plot function for data points
-        fit_kws : dictionary, optional
-            keyword arguments passed on to the plot function for fitted curve
-        init_kws : dictionary, optional
-            keyword arguments passed on to the plot function for the initial
-            conditions of the fit
-        ax_res_kws : dictionary, optional
-            keyword arguments for the axes for the residuals plot
-        ax_fit_kws : dictionary, optional
-            keyword arguments for the axes for the fit plot
-        fig_kws : dictionary, optional
-            keyword arguments for a new figure, if there is one being created
+        data_kws : dict, optional
+            Keyword arguments passed on to the plot function for data points.
+        fit_kws : dict, optional
+            Keyword arguments passed on to the plot function for fitted curve.
+        init_kws : dict, optional
+            Keyword arguments passed on to the plot function for the initial
+            conditions of the fit.
+        ax_res_kws : dict, optional
+            Keyword arguments for the axes for the residuals plot.
+        ax_fit_kws : dict, optional
+            Keyword arguments for the axes for the fit plot.
+        fig_kws : dict, optional
+            Keyword arguments for a new figure, if there is one being created.
 
         Returns
         -------
@@ -1384,9 +1404,9 @@ class ModelResult(Minimizer):
         -----
         The method combines ModelResult.plot_fit and ModelResult.plot_residuals.
 
-        If yerr is specified or if the fit model included weights, then
-        matplotlib.axes.Axes.errorbar is used to plot the data.  If yerr is
-        not specified and the fit includes weights, yerr set to 1/self.weights
+        If `yerr` is specified or if the fit model included weights, then
+        matplotlib.axes.Axes.errorbar is used to plot the data.  If `yerr` is
+        not specified and the fit includes weights, `yerr` set to 1/self.weights
 
         If `fig` is None then `matplotlib.pyplot.figure(**fig_kws)` is called,
         otherwise `fig_kws` is ignored.

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -78,47 +78,52 @@ COMMON_INIT_DOC = """
     Parameters
     ----------
     independent_vars: ['x']
-        arguments to func that are independent variables
-    prefix: string or ``None``
-       string to prepend to paramter names, needed to add two Models that
+        Arguments to func that are independent variables.
+    prefix: string, optional
+       String to prepend to parameter names, needed to add two Models that
        have parameter names in common.
-    missing:  string or ``None``
-        how to handle `nan` and missing values in data. One of:
+    missing:  str or None, optional
+        How to handle NaN and missing values in data. One of:
 
-        - 'none' or ``None``: Do not check for null or missing values (default)
+        - 'none' or None: Do not check for null or missing values (default).
 
         - 'drop': Drop null or missing observations in data. if pandas is
           installed, `pandas.isnull` is used, otherwise `numpy.isnan` is used.
 
-        - 'raise': Raise a (more helpful) exception when data contains nullz
+        - 'raise': Raise a (more helpful) exception when data contains null
           or missing values.
-    kwargs : optional
-        keyword arguments to pass to :class:`Model`.
-"""
+    **kwargs : optional
+        Keyword arguments to pass to :class:`Model`.
+
+    """
 
 COMMON_GUESS_DOC = """Guess starting values for the parameters of a model.
 
     Parameters
     ----------
-    data : array-like
-        array of data to use to guess parameter values.
-    kws : additional keyword arguments, passed to model function.
+    data : array_like
+        Array of data to use to guess parameter values.
+    **kws : optional
+        Additional keyword arguments, passed to model function.
 
     Returns
     -------
-    params  : Parameters
-"""
+    params : Parameters
+
+    """
 
 COMMON_DOC = COMMON_INIT_DOC
 
 class ConstantModel(Model):
-    """Constant model, with a single Parameter: ``c``
+    """Constant model, with a single Parameter: ``c``.
 
     Note that this is 'constant' in the sense of having no dependence on
-    the independent variable ``x``, not in the sense of being non-varying.
-    To be clear, ``c`` will be a Parameter that will be varied in the
-    fit (by default, of course).
+    the independent variable ``x``, not in the sense of being non-
+    varying. To be clear, ``c`` will be a Parameter that will be varied
+    in the fit (by default, of course).
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -136,14 +141,15 @@ class ConstantModel(Model):
     guess.__doc__    = COMMON_GUESS_DOC
 
 class ComplexConstantModel(Model):
-    """Complex constant model, with wo Parameters:
-    ``re``, and ``im``.
+    """Complex constant model, with wo Parameters: ``re``, and ``im``.
 
     Note that ``re`` and ``im`` are 'constant' in the sense of having no
     dependence on the independent variable ``x``, not in the sense of
     being non-varying. To be clear, ``re`` and ``im`` will be Parameters
     that will be varied in the fit (by default, of course).
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -162,15 +168,18 @@ class ComplexConstantModel(Model):
     guess.__doc__    = COMMON_GUESS_DOC
 
 class LinearModel(Model):
-    """Linear model, with two Parameters
-    ``intercept`` and ``slope``, defined as
+    """Linear model, with two Parameters ``intercept`` and ``slope``.
+
+    Defined as:
 
     .. math::
 
         f(x; m, b) = m x + b
 
     with  ``slope`` for :math:`m` and  ``intercept`` for :math:`b`.
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -189,13 +198,16 @@ class LinearModel(Model):
 
 
 class QuadraticModel(Model):
-    """A quadratic model, with three Parameters
-    ``a``, ``b``, and ``c``, defined as
+    """A quadratic model, with three Parameters ``a``, ``b``, and ``c``.
+
+    Defined as:
 
     .. math::
 
         f(x; a, b, c) = a x^2 + b x + c
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -216,7 +228,7 @@ ParabolicModel = QuadraticModel
 
 
 class PolynomialModel(Model):
-    """A polynomial model with up to 7 Parameters, specfied by ``degree``.
+    r"""A polynomial model with up to 7 Parameters, specfied by ``degree``.
 
     .. math::
 
@@ -225,9 +237,12 @@ class PolynomialModel(Model):
     with parameters ``c0``, ``c1``, ..., ``c7``.  The supplied ``degree``
     will specify how many of these are actual variable parameters.  This
     uses :numpydoc:`polyval` for its calculation of the polynomial.
+
     """
+
     MAX_DEGREE = 7
     DEGREE_ERR = "degree must be an integer less than %d."
+
     def __init__(self, degree, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -256,7 +271,7 @@ class PolynomialModel(Model):
     guess.__doc__    = COMMON_GUESS_DOC
 
 class GaussianModel(Model):
-    r"""A model based on a Gaussian or normal distribution lineshape
+    r"""A model based on a Gaussian or normal distribution lineshape.
     (see http://en.wikipedia.org/wiki/Normal_distribution), with three Parameters:
     ``amplitude``, ``center``, and ``sigma``.
     In addition, parameters ``fwhm`` and ``height`` are included as constraints
@@ -270,9 +285,12 @@ class GaussianModel(Model):
     :math:`\mu`, and ``sigma`` to :math:`\sigma`.  The full width at
     half maximum is :math:`2\sigma\sqrt{2\ln{2}}`, approximately
     :math:`2.3548\sigma`.
+
     """
+
     fwhm_factor = 2.354820
     height_factor = 1./np.sqrt(2*np.pi)
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -303,9 +321,12 @@ class LorentzianModel(Model):
     where the parameter ``amplitude`` corresponds to :math:`A`, ``center`` to
     :math:`\mu`, and ``sigma`` to :math:`\sigma`.  The full width at
     half maximum is :math:`2\sigma`.
+
     """
+
     fwhm_factor = 2.0
     height_factor = 1./np.pi
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -355,8 +376,10 @@ class VoigtModel(Model):
     the full width at half maximum is approximately :math:`3.6013\sigma`.
 
     """
+
     fwhm_factor = 3.60131
     height_factor = 1./np.sqrt(2*np.pi)
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -395,6 +418,7 @@ class PseudoVoigtModel(Model):
     where :math:`\sigma_g = {\sigma}/{\sqrt{2\ln{2}}}` so that the full width
     at half maximum of each component and of the sum is :math:`2\sigma`. The
     :meth:`guess` function always sets the starting value for ``fraction`` at 0.5.
+
     """
 
     fwhm_factor = 2.0
@@ -428,9 +452,10 @@ class MoffatModel(Model):
         f(x; A, \mu, \sigma, \beta) = A \big[(\frac{x-\mu}{\sigma})^2+1\big]^{-\beta}
 
     the full width have maximum is :math:`2\sigma\sqrt{2^{1/\beta}-1}`.
-    :meth:`guess` function always sets the starting value for ``beta`` to 1.
+    The :meth:`guess` function always sets the starting value for ``beta`` to 1.
 
     Note that for (:math:`\beta=1`) the Moffat has a Lorentzian shape.
+
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
@@ -463,7 +488,9 @@ class Pearson7Model(Model):
     where :math:`\beta` is the beta function (see :scipydoc:`special.beta` in
     :mod:`scipy.special`).  The :meth:`guess` function always
     gives a starting value for ``exponent`` of 1.5.
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -491,7 +518,9 @@ class StudentsTModel(Model):
 
 
     where :math:`\Gamma(x)` is the gamma function.
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -515,7 +544,9 @@ class BreitWignerModel(Model):
     .. math::
 
         f(x; A, \mu, \sigma, q) = \frac{A (q\sigma/2 + x - \mu)^2}{(\sigma/2)^2 + (x - \mu)^2}
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -542,6 +573,7 @@ class LognormalModel(Model):
         f(x; A, \mu, \sigma) = \frac{A e^{-(\ln(x) - \mu)/ 2\sigma^2}}{x}
 
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -568,6 +600,7 @@ class DampedOscillatorModel(Model):
         f(x; A, \mu, \sigma) = \frac{A}{\sqrt{ [1 - (x/\mu)^2]^2 + (2\sigma x/\mu)^2}}
 
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -594,7 +627,9 @@ class DampedHarmonicOscillatorModel(Model):
 
         f(x; A, \mu, \sigma, \gamma) = \frac{A\sigma}{\pi [1 - \exp(-x/\gamma)]}
                 \Big[ \frac{1}{(x-\mu)^2 + \sigma^2} - \frac{1}{(x+\mu)^2 + \sigma^2} \Big]
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -627,6 +662,7 @@ class ExponentialGaussianModel(Model):
     where :func:`erfc` is the complimentary error function.
 
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -655,10 +691,12 @@ class SkewedGaussianModel(Model):
        \frac{\gamma(x-\mu)}{\sigma\sqrt{2}}
        \bigr] \Bigr\}
 
-
     where :func:`erf` is the error function.
+
     """
+
     fwhm_factor = 2.354820
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -685,7 +723,9 @@ class DonaichModel(Model):
 
         f(x; A, \mu, \sigma, \gamma) = A\frac{\cos\bigl[\pi\gamma/2 + (1-\gamma)
         \arctan{(x - \mu)}/\sigma\bigr]} {\bigr[1 + (x-\mu)/\sigma\bigl]^{(1-\gamma)/2}}
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -706,7 +746,9 @@ class PowerLawModel(Model):
     .. math::
 
         f(x; A, k) = A x^k
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -734,7 +776,9 @@ class ExponentialModel(Model):
     .. math::
 
         f(x; A, \tau) = A e^{-x/\tau}
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -782,7 +826,9 @@ class StepModel(Model):
         \end{eqnarray*}
 
     where :math:`\alpha  = (x - \mu)/{\sigma}`.
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -836,7 +882,9 @@ class RectangleModel(Model):
 
     where :math:`\alpha_1  = (x - \mu_1)/{\sigma_1}` and
     :math:`\alpha_2  = -(x - \mu_2)/{\sigma_2}`.
+
     """
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
@@ -877,25 +925,25 @@ class ExpressionModel(Model):
 
         Parameters
         ----------
-        expr:    string
-            mathematical expression for model.
-        independent_vars: list of strings or ``None``
-            variable names to use as independent variables
-        init_script: string or ``None``
-            initial script to run in asteval interpreter
-        missing:  string or ``None``
-            how to handle `nan` and missing values in data. One of:
+        expr : str
+            Mathematical expression for model.
+        independent_vars : list of strings or None, optional
+            Variable names to use as independent variables.
+        init_script : string or None, optional
+            Initial script to run in asteval interpreter.
+        missing : str or None, optional
+            How to handle NaN and missing values in data. One of:
 
-            - 'none' or ``None``: Do not check for null or missing values (default)
+            - 'none' or None: Do not check for null or missing values (default).
 
             - 'drop': Drop null or missing observations in data. if pandas is
               installed, `pandas.isnull` is used, otherwise `numpy.isnan` is used.
 
-            - 'raise': Raise a (more helpful) exception when data contains nullz
+            - 'raise': Raise a (more helpful) exception when data contains null
               or missing values.
 
-        kwargs : optional
-            keyword arguments to pass to :class:`Model`.
+        **kws : optional
+            Keyword arguments to pass to :class:`Model`.
 
         Notes
         -----

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -11,20 +11,24 @@ from .lineshapes import (breit_wigner, damped_oscillator, dho, donaich,
                          skewed_voigt, step, students_t, voigt)
 from .model import Model
 
+
 class DimensionalError(Exception):
     """TODO: class docstring."""
     pass
+
 
 def _validate_1d(independent_vars):
     if len(independent_vars) != 1:
         raise DimensionalError(
             "This model requires exactly one independent variable.")
 
+
 def index_of(arr, val):
     """Return index of array nearest to a value."""
     if val < min(arr):
         return 0
     return np.abs(arr-val).argmin()
+
 
 def fwhm_expr(model):
     """Return constraint expression for fwhm."""
@@ -114,6 +118,7 @@ COMMON_GUESS_DOC = """Guess starting values for the parameters of a model.
 
 COMMON_DOC = COMMON_INIT_DOC
 
+
 class ConstantModel(Model):
     """Constant model, with a single Parameter: ``c``.
 
@@ -128,6 +133,7 @@ class ConstantModel(Model):
                  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
+
         def constant(x, c):
             return c
         super(ConstantModel, self).__init__(constant, **kwargs)
@@ -138,7 +144,8 @@ class ConstantModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
+
 
 class ComplexConstantModel(Model):
     """Complex constant model, with wo Parameters: ``re``, and ``im``.
@@ -154,6 +161,7 @@ class ComplexConstantModel(Model):
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
+
         def constant(x, re, im):
             return re + 1j*im
         super(ComplexConstantModel, self).__init__(constant, **kwargs)
@@ -165,7 +173,8 @@ class ComplexConstantModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
+
 
 class LinearModel(Model):
     """Linear model, with two Parameters ``intercept`` and ``slope``.
@@ -194,7 +203,7 @@ class LinearModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class QuadraticModel(Model):
@@ -222,7 +231,8 @@ class QuadraticModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
+
 
 ParabolicModel = QuadraticModel
 
@@ -268,7 +278,8 @@ class PolynomialModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
+
 
 class GaussianModel(Model):
     r"""A model based on a Gaussian or normal distribution lineshape.
@@ -305,7 +316,8 @@ class GaussianModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
+
 
 class LorentzianModel(Model):
     r"""A model based on a Lorentzian or Cauchy-Lorentz distribution function
@@ -341,7 +353,7 @@ class LorentzianModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class VoigtModel(Model):
@@ -396,7 +408,7 @@ class VoigtModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class PseudoVoigtModel(Model):
@@ -438,7 +450,7 @@ class PseudoVoigtModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class MoffatModel(Model):
@@ -472,7 +484,7 @@ class MoffatModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class Pearson7Model(Model):
@@ -504,7 +516,7 @@ class Pearson7Model(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class StudentsTModel(Model):
@@ -532,7 +544,7 @@ class StudentsTModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class BreitWignerModel(Model):
@@ -559,7 +571,7 @@ class BreitWignerModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class LognormalModel(Model):
@@ -586,7 +598,7 @@ class LognormalModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class DampedOscillatorModel(Model):
@@ -613,7 +625,7 @@ class DampedOscillatorModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class DampedHarmonicOscillatorModel(Model):
@@ -643,7 +655,7 @@ class DampedHarmonicOscillatorModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class ExponentialGaussianModel(Model):
@@ -674,7 +686,7 @@ class ExponentialGaussianModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class SkewedGaussianModel(Model):
@@ -709,7 +721,7 @@ class SkewedGaussianModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class DonaichModel(Model):
@@ -737,7 +749,8 @@ class DonaichModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
+
 
 class PowerLawModel(Model):
     r"""A model based on a Power Law (see http://en.wikipedia.org/wiki/Power_law>),
@@ -765,7 +778,7 @@ class PowerLawModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class ExponentialModel(Model):
@@ -795,7 +808,7 @@ class ExponentialModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class StepModel(Model):
@@ -846,7 +859,8 @@ class StepModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
+
 
 class RectangleModel(Model):
     r"""A model based on a Step-up and Step-down function, with five
@@ -910,7 +924,7 @@ class RectangleModel(Model):
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC
-    guess.__doc__    = COMMON_GUESS_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
 
 
 class ExpressionModel(Model):

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -549,7 +549,7 @@ class Parameter(object):
         """
         self.name = name
         self._val = value
-        self.user_data = None
+        self.user_data = user_data
         self.init_value = value
         self.min = min
         self.max = max

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -52,6 +52,7 @@ def isclose(x, y, rtol=1e-5, atol=1e-8):
     else:
         return False
 
+
 class Parameters(OrderedDict):
     """An ordered dictionary of all the Parameter objects required to
     specify a fit model. All minimization and Model fitting routines in
@@ -409,7 +410,6 @@ class Parameters(OrderedDict):
                           for key in sym_unique}
         return json.dumps({'unique_symbols': unique_symbols,
                            'params': params}, **kws)
-
 
     def loads(self, s, **kws):
         """Load Parameters from a JSON string.

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -21,25 +21,24 @@ def check_ast_errors(expr_eval):
 def isclose(x, y, rtol=1e-5, atol=1e-8):
     """Check whether two numbers are the same within a tolerance.
 
-    i.e., abs(`x` - `y`) <= (`atol` + `rtol` * absolute(`y`))
+    abs(`x` - `y`) <= (`atol` + `rtol` * abs(`y`))
 
     Parameters
     ----------
     x, y : float
-        Input values
-    rtol : float
-        The relative tolerance parameter (see Notes).
-    atol : float
-        The absolute tolerance parameter (see Notes).
+        Input values.
+    rtol : float, optional
+        The relative tolerance parameter.
+    atol : float, optional
+        The absolute tolerance parameter.
 
     Returns
     -------
-    y : bool
-        Are `x` and `x` are equal within tolerance?
+    bool
+        True if `x` and `y` are the same within tolerance, otherwise False.
 
     """
     def within_tol(x, y, atol, rtol):
-        """TODO: function docstring."""
         return abs(x - y) <= atol + rtol * abs(y)
 
     xfin = isfinite(x)
@@ -55,11 +54,11 @@ def isclose(x, y, rtol=1e-5, atol=1e-8):
 
 class Parameters(OrderedDict):
     """An ordered dictionary of all the Parameter objects required to
-    specify a fit model.  All minimization and Model fitting routines in
+    specify a fit model. All minimization and Model fitting routines in
     lmfit will use exactly one Parameters object, typically given as the
     first argument to the objective function.
 
-    All keys of a Parameters() instance must be strings, and valid Python
+    All keys of a Parameters() instance must be strings and valid Python
     symbol names, so that the name must match ``[a-z_][a-z0-9_]*`` and
     cannot be a Python reserved word.
 
@@ -70,15 +69,21 @@ class Parameters(OrderedDict):
 
     Parameters() support copying and pickling, and have methods to convert
     to and from serializations using json strings.
+
     """
 
     def __init__(self, asteval=None, *args, **kwds):
         """
         Arguments
-        ----------
-        asteval : ``None`` or instance of asteval.Interpreter
-            instance of Interpretr to use for constraint expressions.
-            If ``None``, a new interpreter will be created.
+        ---------
+        asteval : :class:`asteval.Interpreter`, optional
+            Instance of the asteval Interpreter to use for constraint
+            expressions. If None, a new interpreter will be created.
+        *args : optional
+            Arguments.
+        **kwds : optional
+            Keyword arguments.
+
         """
         super(Parameters, self).__init__(self)
         self._asteval = asteval
@@ -96,9 +101,8 @@ class Parameters(OrderedDict):
         self.__deepcopy__(memo)
 
     def __deepcopy__(self, memo):
-        """Parameters deepcopy needs to make sure that asteval is available and
-        that all individula parameter objects are copied.
-        """
+        """Parameters.deepcopy() needs to make sure that asteval is available
+        and that all individual Parameter objects are copied."""
         _pars = Parameters(asteval=None)
 
         # find the symbols that were added by users, not during construction
@@ -158,11 +162,11 @@ class Parameters(OrderedDict):
         return self
 
     def __array__(self):
-        """Parameters to array."""
+        """Convert Parameters to array."""
         return array([float(k) for k in self.values()])
 
     def __reduce__(self):
-        """Required to pickle a Parameters instance."""
+        """Reduce Parameters instance such that it can be pickled."""
         # make a list of all the parameters
         params = [self[k] for k in self]
 
@@ -208,8 +212,8 @@ class Parameters(OrderedDict):
         def _update_param(name):
             """Update a parameter value, including setting bounds.
 
-            For a constrained parameter (one with an expr defined), this
-            first updates (recursively) all parameters on which the
+            For a constrained parameter (one with an `expr` defined),
+            this first updates (recursively) all parameters on which the
             parameter depends (using the 'deps' field).
 
             """
@@ -226,7 +230,20 @@ class Parameters(OrderedDict):
             _update_param(name)
 
     def pretty_repr(self, oneline=False):
-        """TODO: add method docstring."""
+        """Return a pretty representation of a Parameters class.
+
+        Parameters
+        ----------
+        oneline : bool, optional
+            If True prints a one-line parameters representation (default is
+            False).
+
+        Returns
+        -------
+        s: str
+           Parameters representation.
+
+        """
         if oneline:
             return super(Parameters, self).__repr__()
         s = "Parameters({\n"
@@ -238,22 +255,22 @@ class Parameters(OrderedDict):
     def pretty_print(self, oneline=False, colwidth=8, precision=4, fmt='g',
                      columns=['value', 'min', 'max', 'stderr', 'vary', 'expr',
                               'brute_step']):
-        """Pretty-print parameters data.
+        """Pretty-print of parameters data.
 
         Parameters
         ----------
-        oneline : boolean
-            If True prints a one-line parameters representation. Default False.
-        colwidth : int
-            Column width for all except the first (i.e. name) column.
-        precision : int
+        oneline : bool, optional
+            If True prints a one-line parameters representation (default is
+            False).
+        colwidth : int, optional
+            Column width for all columns specified in :attr:`columns`.
+        precision : int, optional
             Number of digits to be printed after floating point.
-        fmt : string
-            Single-char numeric formatter. Valid values: 'f' floating point,
-            'g' floating point and exponential, 'e' exponential.
-        columns : list of strings
-            List of columns names to print. All values must be valid
-            :class:`Parameter` attributes.
+        fmt : {'g', 'e', 'f'}, optional
+            Single-character numeric formatter. Valid values are: 'f' floating
+            point, 'g' floating point and exponential, or 'e' exponential.
+        columns : :obj:`list` of :obj:`str`, optional
+            List of :class:`Parameter` attribute names to print.
 
         """
         if oneline:
@@ -286,23 +303,23 @@ class Parameters(OrderedDict):
             brute_step=None):
         """Add a Parameter.
 
-        Arguments
-        ---------
-        name : string
-            name of parameter.  Must match ``[a-z_][a-z0-9_]*`` and
-            cannot be a Python reserved word.
-        value : ``None`` or float
-            floating point value for parameter, typically the *initial value*.
-        vary : bool (default ``True``)
-            whether the parameter should be varied in the fit.
-        min : float (default ``-np.inf``)
-            lower bound for parameter value.
-        max : float (default ``np.inf``)
-            upper bound for parameter value.
-        expr : ``None`` or string
-            expression in terms of other parameter names to constrain value.
-        brute_step : ``None``
-            size of step to take when using the `brute()` method.
+        Parameters
+        ----------
+        name : str
+            Name of parameter.  Must match ``[a-z_][a-z0-9_]*`` and cannot be
+            a Python reserved word.
+        value : float, optional
+            Numerical Parameter value, typically the *initial value*.
+        vary : bool, optional
+            Whether the Parameter is varied during a fit (default is True).
+        min : float, optional
+            Lower bound for value (default is `-numpy.inf`, no lower bound).
+        max : float, optional
+            Upper bound for value (default is `numpy.inf`, no upper bound).
+        expr : str, optional
+            Mathematical expression used to constrain the value during the fit.
+        brute_step : float, optional
+            Step size for grid points in the `brute` method.
 
         Examples
         --------
@@ -327,12 +344,13 @@ class Parameters(OrderedDict):
     def add_many(self, *parlist):
         """Add many parameters, using a sequence of tuples.
 
-        Arguments
+        Parameters
         ----------
-        parlist : sequence of tuples
-            A sequence of tuples, or a sequence of `Parameter` instances. If it
-            is a sequence of tuples, then each tuple must contain at least the
-            name. The order in each tuple must be `(name, value, vary, min, max, expr, brute_step)`
+        parlist : :obj:`sequence` of :obj:`tuple` or :class:`Parameter`
+            A sequence of tuples, or a sequence of `Parameter` instances. If
+            it is a sequence of tuples, then each tuple must contain at least
+            the name. The order in each tuple must be `(name, value, vary,
+            min, max, expr, brute_step)`.
 
         Examples
         --------
@@ -346,6 +364,7 @@ class Parameters(OrderedDict):
         >>> f = Parameter('par_f', 100)
         >>> g = Parameter('par_g',  2.)
         >>> params.add_many(f, g)
+
         """
         for para in parlist:
             if isinstance(para, Parameter):
@@ -359,29 +378,31 @@ class Parameters(OrderedDict):
 
         Returns
         -------
-        vals : ordered dict
-           An ordered dictionary of name:value pairs for each Parameter.
-           This is distinct from the Parameters itself, as it has values of
-           the Parameter *values*, not the full Parameter object.
+        OrderedDict
+           An ordered dictionary of :attr:`name`::attr:`value` pairs for each
+           Parameter.
+
         """
         return OrderedDict(((p.name, p.value) for p in self.values()))
 
     def dumps(self, **kws):
         """Represent Parameters as a JSON string.
 
-        all keyword arguments are passed to `json.dumps()`
+        Parameters
+        ----------
+        **kws : optional
+            Keyword arguments that are passed to `json.dumps()`.
 
         Returns
         -------
-        s : string
-           json string representation of Parameters
+        str
+           JSON string representation of Parameters.
 
         See Also
         --------
         dump(), loads(), load(), json.dumps()
 
         """
-
         params = [p.__getstate__() for p in self.values()]
         sym_unique = self._asteval.user_defined_symbols()
         unique_symbols = {key: deepcopy(self._asteval.symtable[key])
@@ -393,14 +414,20 @@ class Parameters(OrderedDict):
     def loads(self, s, **kws):
         """Load Parameters from a JSON string.
 
-        current Parameters will be cleared before loading.
-
-        all keyword arguments are passed to `json.loads()`
+        Parameters
+        ----------
+        **kws : optional
+            Keyword arguments that are passed to `json.loads()`.
 
         Returns
         -------
-        ``None``
-           Parameters are updated as a side-effect
+        :class:`Parameters`
+           Updated Parameters from the JSON string.
+
+        Notes
+        -----
+        Current Parameters will be cleared before loading the data from the
+        JSON string.
 
         See Also
         --------
@@ -420,18 +447,20 @@ class Parameters(OrderedDict):
         return self
 
     def dump(self, fp, **kws):
-        """Write JSON representation of Parameters to a file or file-like
-        object (must have a `write()` method).
+        """Write JSON representation of Parameters to a file-like object.
 
-        Arguments
-        ---------
-        fp         open file-like object with `write()` method.
-
-        all keyword arguments are passed to `dumps()`
+        Parameters
+        ----------
+        fp : file-like object
+            An open and ``.write()``-supporting file-like object.
+        **kws : optional
+            Keyword arguments that are passed to `dumps()`.
 
         Returns
         -------
-        return value from `fp.write()`
+        None or int
+            Return value from `fp.write()`. None for Python 2.7 and the
+            number of characters written in Python 3.
 
         See Also
         --------
@@ -441,19 +470,19 @@ class Parameters(OrderedDict):
         return fp.write(self.dumps(**kws))
 
     def load(self, fp, **kws):
-        """Load JSON representation of Parameters from a file or file-like
-        object (must have a `read()` method).
+        """Load JSON representation of Parameters from a file-like object.
 
-        Arguments
-        ---------
-        fp         open file-like object with `read()` method.
-
-        all keyword arguments are passed to `loads()`
+        Parameters
+        ----------
+        fp : file-like object
+            An open and ``.read()``-supporting file-like object.
+        **kws : optional
+            Keyword arguments that are passed to `loads()`.
 
         Returns
         -------
-        ``None``.
-           Parameters are updated as a side-effect
+        :class:`Parameters`
+           Updated Parameters loaded from `fp`.
 
         See Also
         --------
@@ -464,10 +493,9 @@ class Parameters(OrderedDict):
 
 
 class Parameter(object):
-
     """A Parameter is an object that can be varied in a fit, or one of the
     controlling variables in a model. It is a central component of lmfit,
-    and all minimization and modelling methods use Parameter objects.
+    and all minimization and modeling methods use Parameter objects.
 
     A Parameter has a `name` attribute, and a scalar floating point
     `value`.  It also has a `vary` attribute that describes whether the
@@ -475,8 +503,8 @@ class Parameter(object):
     placed on the Parameter's value by setting its `min` and/or `max`
     attributes.  A Parameter can also have its value determined by a
     mathematical expression of other Parameter values held in the `expr`
-    attrribute.  Addition attributes include `brute_step` used as the step
-    size to use in a brute-force minimization, and `user_data` reserved
+    attrribute.  Additional attributes include `brute_step` used as the step
+    size in a brute-force minimization, and `user_data` reserved
     exclusively for user's need.
 
     After a minimization, a Parameter may also gain other attributes,
@@ -485,37 +513,39 @@ class Parameter(object):
     with other Parameters used in the minimization.
 
     """
+
     def __init__(self, name=None, value=None, vary=True, min=-inf, max=inf,
                  expr=None, brute_step=None, user_data=None):
         """
         Parameters
         ----------
         name : str, optional
-            Name of the parameter.
+            Name of the Parameter.
         value : float, optional
             Numerical Parameter value.
         vary : bool, optional
-            Whether the Parameter is fixed during a fit.
+            Whether the Parameter is varied during a fit (default is True).
         min : float, optional
-            Lower bound for value (-inf means no lower bound).
+            Lower bound for value (default is `-numpy.inf`, no lower bound).
         max : float, optional
-            Upper bound for value (inf means no upper bound).
+            Upper bound for value (default is `numpy.inf`, no upper bound).
         expr : str, optional
             Mathematical expression used to constrain the value during the fit.
         brute_step : float, optional
-            Step size for grid points in brute force method (use `0` for no step size).
+            Step size for grid points in the `brute` method.
         user_data : optional
-            user-definable extra attribute used for a parameter.
+            User-definable extra attribute used for a Parameter.
 
         Attributes
         ----------
         stderr : float
             The estimated standard error for the best-fit value.
         correl : dict
-            A dictionary of the correlation with the other fitted Parameter
-            after a fit, of the form::
+            A dictionary of the correlation with the other fitted Parameters
+            of the form::
 
             `{'decay': 0.404, 'phase': -0.020, 'frequency': 0.102}`
+
         """
         self.name = name
         self._val = value
@@ -544,34 +574,35 @@ class Parameter(object):
         value : float, optional
             Numerical Parameter value.
         vary : bool, optional
-            Whether the Parameter is fixed during a fit.
+            Whether the Parameter is varied during a fit.
         min : float, optional
-            Lower bound for value. To remove a lower bound you must use -np.inf
+            Lower bound for value. To remove a lower bound you must use
+            `-numpy.inf`.
         max : float, optional
-            Upper bound for value. To remove an upper bound you must use np.inf
+            Upper bound for value. To remove an upper bound you must use
+            `numpy.inf`.
         expr : str, optional
             Mathematical expression used to constrain the value during the fit.
             To remove a constraint you must supply an empty string.
         brute_step : float, optional
-            Step size for grid points in brute force method. To remove the step
-            size you must supply 0 ("zero").
+            Step size for grid points in the `brute` method. To remove the
+            step size you must use ``0``.
 
         Notes
         -----
+        Each argument to `set()` has a default value of `None`, which will
+        leave the current value for the attribute unchanged.  Thus, to lift a
+        lower or upper bound, passing in `None` will not work.  Instead,
+        you must set these to `-numpy.inf` or `numpy.inf`, as with::
 
-        Each argument to `set()` has a default value of ``None``, which
-        will the current value for the attribute unchanged.  Thus, to lift
-        a lower or upper bound, passing in ``None`` will not work.  Instead,
-        you must set these to ``np.inf`` or ``-np.inf``, as with::
-
-            par.set(min=None)     # no, will leave lower bound unchanged
-            par.set(min=-np.inf)  # yes.
+            par.set(min=None)        # leaves lower bound unchanged
+            par.set(min=-numpy.inf)  # removes lower bound
 
         Similarly, to clear an expression, pass a blank string, (not
         ``None``!) as with::
 
-            par.set(expr=None)    # leaves expression unchanged.
-            par.set(expr='')      # removes expression
+            par.set(expr=None)  # leaves expression unchanged
+            par.set(expr='')    # removes expression
 
         Explicitly setting a value or setting `vary=True` will also
         clear the expression.
@@ -580,8 +611,8 @@ class Parameter(object):
 
             par.set(brute_step=None)  # leaves brute_step unchanged
             par.set(brute_step=0)     # removes brute_step
-        """
 
+        """
         if value is not None:
             self.value = value
             self.__set_expression('')
@@ -645,7 +676,7 @@ class Parameter(object):
         self._init_bounds()
 
     def __repr__(self):
-        """TODO: add magic method docstring."""
+        """Returns printable representation of a Parameter object."""
         s = []
         if self.name is not None:
             s.append("'%s'" % self.name)
@@ -668,7 +699,7 @@ class Parameter(object):
 
         As a side-effect, this also defines the self.from_internal method
         used to re-calculate self.value from the internal value, applying
-        the inverse Minuit-style transformation.  This method should be
+        the inverse Minuit-style transformation. This method should be
         called prior to passing a Parameter to the user-defined objective
         function.
 
@@ -676,9 +707,10 @@ class Parameter(object):
 
         Returns
         -------
-        The internal value for parameter from self.value (which holds
-        the external, user-expected value).   This internal value should
-        actually be used in a fit.
+        _val : float
+            The internal value for parameter from self.value (which holds
+            the external, user-expected value). This internal value should
+            actually be used in a fit.
 
         """
         if self.min is None:
@@ -703,10 +735,16 @@ class Parameter(object):
     def scale_gradient(self, val):
         """Return scaling factor for gradient.
 
+        Parameters
+        ----------
+        val: float
+            Numerical Parameter value.
+
         Returns
         -------
-        scaling factor for gradient the according to Minuit-style
-        transformation.
+        float
+            Scaling factor for gradient the according to Minuit-style
+            transformation.
 
         """
         if self.min == -inf and self.max == inf:
@@ -720,7 +758,6 @@ class Parameter(object):
 
     def _getval(self):
         """Get value, with bounds applied."""
-
         # Note assignment to self._val has been changed to self.value
         # The self.value property setter makes sure that the
         # _expr_eval.symtable is kept updated.
@@ -760,7 +797,7 @@ class Parameter(object):
 
     @property
     def value(self):
-        """The numerical value of the Parameter, with bounds applied."""
+        """Return the numerical value of the Parameter, with bounds applied."""
         return self._getval()
 
     @value.setter
@@ -774,14 +811,14 @@ class Parameter(object):
 
     @property
     def expr(self):
-        """The mathematical expression used to constrain the value during the
-        fit."""
+        """Return the mathematical expression used to constrain the value
+        during the fit."""
         return self._expr
 
     @expr.setter
     def expr(self, val):
-        """The mathematical expression used to constrain the value during the
-        fit.
+        """Set the mathematical expression used to constrain the value during
+        the fit.
 
         To remove a constraint you must supply an empty string.
 
@@ -804,39 +841,39 @@ class Parameter(object):
             self._expr_deps = get_ast_names(self._expr_ast)
 
     def __array__(self):
-        """array."""
+        """array"""
         return array(float(self._getval()))
 
     def __str__(self):
-        """string."""
+        """string"""
         return self.__repr__()
 
     def __abs__(self):
-        """abs."""
+        """abs"""
         return abs(self._getval())
 
     def __neg__(self):
-        """neg."""
+        """neg"""
         return -self._getval()
 
     def __pos__(self):
-        """positive."""
+        """positive"""
         return +self._getval()
 
     def __nonzero__(self):
-        """not zero."""
+        """not zero"""
         return self._getval() != 0
 
     def __int__(self):
-        """int."""
+        """int"""
         return int(self._getval())
 
     def __float__(self):
-        """float."""
+        """float"""
         return float(self._getval())
 
     def __trunc__(self):
-        """trunc."""
+        """trunc"""
         return self._getval().__trunc__()
 
     def __add__(self, other):

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -28,8 +28,8 @@ def getfloat_attr(obj, attr, fmt='%.3f'):
 def gformat(val, length=11):
     """Format a number with '%g'-like format.
 
-    The return will be length ``length`` (default=12) and have at least
-    length-6 significant digits.
+    The return will be length ``length`` (default is 12) and have at
+    least length-6 significant digits.
 
     """
     length = max(length, 7)
@@ -68,24 +68,24 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
     Parameters
     ----------
     inpars  : Parameters
-       input Parameters from fit or MinimizerResult returned from a fit.
-    modelpars : optional
-       known Model Parameters
-    show_correl : bool, default ``True``
-       whether to show list of sorted correlations
-    min_correl : float, default 0.1
-       smallest correlation absolute value to show.
-    sort_pars : bool, default ``False``, or callable
-       whether to show parameter names sorted in alphanumerical order.  If
-       ``False``, then the parameters will be listed in the order they were
-       added to the Parameters dictionary. If callable, then this (one
+       Input Parameters from fit or MinimizerResult returned from a fit.
+    modelpars : Parameters, optional
+       Known Model Parameters.
+    show_correl : bool, optional
+       Whether to show list of sorted correlations (default is True).
+    min_correl : float, optional
+       Smallest correlation in absolute value to show (default is 0.1).
+    sort_pars : bool or callable, optional
+       Whether to show parameter names sorted in alphanumerical order. If
+       False (default), then the parameters will be listed in the order they
+       were added to the Parameters dictionary. If callable, then this (one
        argument) function is used to extract a comparison key from each
        list element.
 
     Returns
     -------
-    text : string
-       multi-line text of fit report
+    string
+       Multi-line text of fit report.
 
     """
     if isinstance(inpars, Parameters):
@@ -172,12 +172,12 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
 
 
 def report_errors(params, **kws):
-    """Print a report for fitted params:  see error_report()."""
+    """Print a report for fitted params: see error_report()."""
     print(fit_report(params, **kws))
 
 
 def report_fit(params, **kws):
-    """Print a report for fitted params:  see error_report()."""
+    """Print a report for fitted params: see error_report()."""
     print(fit_report(params, **kws))
 
 
@@ -186,13 +186,14 @@ def ci_report(ci, with_offset=True, ndigits=5):
 
     Parameters
     ----------
-    with_offset : bool (default `True`)
-        Whether to subtract best value from all other values.
-    ndigits : int (default 5)
-        Number of significant digits to show.
+    with_offset : bool, optional
+        Whether to subtract best value from all other values (default is True).
+    ndigits : int, optional
+        Number of significant digits to show (default is 5).
 
     Returns
     -------
+    str
        Text of formatted report on confidence intervals.
 
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-numpy>=1.5
+numpy>=1.5.1
 scipy>=0.15


### PR DESCRIPTION
As discussed in #402 here are some updates to docs and docstrings. I tried to make them a bit more consistent and hopefully followed the numpydoc / napoleon conventions... Probably the file `lineshapes.py` could use some work, I haven't touched that one.

In addition to docs/docstrings, this PR contains the following other changes:
-  correct initialization of `user_data` in the Parameter class
- updating Travis to the newest SciPy version
- some minor style fixes

I am sure that there is more room for improvement, but this is probably as much as will happen from my side before the release of 0.96. @newville, please let me know what you think and if there is anything else you'd like to happen!