### PR TITLE
use 'self' for ModelResult fit_report(), add test for componets in fi…

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1145,7 +1145,7 @@ class ModelResult(Minimizer):
         :func:`fit_report()`
 
         """
-        report = fit_report(self.params, modelpars=modelpars,
+        report = fit_report(self, modelpars=modelpars,
                             show_correl=show_correl,
                             min_correl=min_correl, sort_pars=sort_pars)
         modname = self.model._reprstring(long=True)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -135,6 +135,18 @@ class CommonTests(object):
         if hasattr(short_eval, '__len__'):
             self.assertEqual(len(short_eval), 3)
 
+    def test_result_report(self):
+        pars = self.model.make_params(**self.guess())
+        result = self.model.fit(self.data, pars, x=self.x)
+        report = result.fit_report()
+        assert("[[Model]]" in report)
+        assert("[[Variables]]" in report)
+        assert("[[Fit Statistics]]" in report)
+        assert(" # function evals   =" in report)
+        assert(" Akaike " in report)
+        assert(" chi-square " in report)
+
+
     def test_data_alignment(self):
         _skip_if_no_pandas()
         from pandas import Series


### PR DESCRIPTION
This address #407  changing `ModelResult.fit_report()` (back?) to use `self` as first argument in its call to `printfuncs.fit_report()`, so that the fit statistics are included.   

Tests added.