### PR TITLE
use inspect.getfullargspec() in Python 3, otherwise inspect.getargspec()

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -203,9 +203,14 @@ class Model(object):
                 kw_args[name] = defval
             keywords_ = list(kw_args.keys())
         else:
-            argspec = inspect.getargspec(self.func)
-            pos_args = argspec.args[:]
-            keywords_ = argspec.keywords
+            try:  # PY3
+                argspec = inspect.getfullargspec(self.func)
+                keywords_ = argspec.varkw
+            except AttributeError:  # PY2
+                argspec = inspect.getargspec(self.func)
+                keywords_ = argspec.keywords
+
+            pos_args = argspec.args
             kw_args = {}
             if argspec.defaults is not None:
                 for val in reversed(argspec.defaults):


### PR DESCRIPTION
This PR addresses Issue #397: inspect.getargspec() is deprecated in Python 3. 

According to [the documentation](https://docs.python.org/3/library/inspect.html), the function `inspect.getfullargspec()` will not be removed and it's advertised as a drop-in replacement for `inspect.getargspec()`.

This PR changes the logic in `model.py` such that it will first try `inspect.getfullargspec()` (present in PY3) and otherwise will fallback on `inspect.getargspec()`. The only difference in the return values we care about (see [the documentation](https://docs.python.org/3/library/inspect.html)) is that `keywords` (for argspec) has been renamed to `varkw` (for getfullargspec). 

No tests were changed or added since the current tests will already checks whether proper results are obtained from "inspecting" the function. In addition this change is very small, but for completeness, an example of the new and old functions are given for Python 3 (since only there both functions are currently still present).

```
>>> import inspect
>>> from lmfit.lineshapes import gaussian
>>>
>>> argspec = inspect.getargspec(gaussian)
>>> fullargspec = inspect.getfullargspec(gaussian)
>>>
>>> print(argspec)
ArgSpec(args=['x', 'amplitude', 'center', 'sigma'], varargs=None, keywords=None, defaults=(1.0, 0.0, 1.0))
>>> print(fullargspec)
FullArgSpec(args=['x', 'amplitude', 'center', 'sigma'], varargs=None, varkw=None, defaults=(1.0, 0.0, 1.0), kwonlyargs=[], kwonlydefaults=None, annotations={})
>>>
>>> argspec.args == fullargspec.args
True
>>> argspec.keywords == fullargspec.varkw
True
>>> argspec.defaults == fullargspec.defaults
True
```



