### PR TITLE
Updates to brute force method

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -67,6 +67,8 @@ try:
 except ImportError:
     pass
 
+# define the namedtuple here so pickle will work with the MinimizerResult
+Candidate = namedtuple('Candidate', ['params', 'score'])
 
 def asteval_with_uncertainties(*vals, **kwargs):
     """Calculate object value, given values for variables.
@@ -1545,7 +1547,6 @@ class Minimizer(object):
         grid_result_sorted = grid_result[grid_result.argsort(order='score')]
 
         result.candidates = []
-        candidate = namedtuple('Candidate', ['params', 'score'])
 
         if keep == 'all':
             keep_candidates = len(grid_result_sorted)
@@ -1556,7 +1557,7 @@ class Minimizer(object):
             pars = deepcopy(self.params)
             for i, par in enumerate(result.var_names):
                 pars[par].value = data[0][i]
-            result.candidates.append(candidate(params=pars, score=data[1]))
+            result.candidates.append(Candidate(params=pars, score=data[1]))
 
         result.params = result.candidates[0].params
         result.chisqr = ret[1]

--- a/tests/test_brute_method.py
+++ b/tests/test_brute_method.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import pickle
 import numpy as np
 from numpy.testing import (assert_, decorators, assert_raises,
                            assert_almost_equal, assert_equal,
@@ -226,6 +227,9 @@ def test_brute():
     assert(len(resbrute_lmfit.candidates) == 10)
 
     assert(isinstance(resbrute_lmfit.candidates[0].params, lmfit.Parameters))
+
+    # TEST 5: make sure the MinimizerResult can be pickle'd
+    pkl = pickle.dumps(resbrute_lmfit)
 
 test_brute_lmfit_vs_scipy()
 test_brute()


### PR DESCRIPTION
This PR includes two updates to the brute force method:

1) fix the issue that pickle doesn't work with the `MinimizerResult` when the brute force method is used (related to the use of a `namedtuple`).

2) add a function to visualize the result of the grid search (inspired by the way the `corner` package can be used to visualize the results of the `emcee` method). Comments and suggestions on the actual code are welcome, as well as where to put it; right now I added it into a file called `plotfuncs.py`.

Before a possible merge, it will need some updates to the documentation. Example has been updated together with the resulting output file (`examples/results_brute.pdf`), and no tests were added or changed.