### PR TITLE
param_names in ExpressionModel should be list

### DIFF
--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -992,7 +992,7 @@ class ExpressionModel(Model):
         for name in sym_names:
             if name in independent_vars:
                 idvar_found[independent_vars.index(name)] = True
-            elif name not in self.asteval.symtable:
+            elif name not in param_names and name not in self.asteval.symtable:
                 param_names.append(name)
 
         # make sure we have all independent parameters
@@ -1019,7 +1019,7 @@ class ExpressionModel(Model):
         # set in _parse_params(), which will be short-circuited.
         self.independent_vars = independent_vars
         self._func_allargs = independent_vars + param_names
-        self._param_names = set(param_names)
+        self._param_names = param_names
         self._func_haskeywords = True
         self.def_vals = {}
 

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1013,6 +1013,8 @@ class ExpressionModel(Model):
                 self.asteval.symtable[name] = val
             return self.asteval.run(self.astcode)
 
+        kws["missing"] = missing
+
         super(ExpressionModel, self).__init__(_eval, **kws)
 
         # set param names here, and other things normally


### PR DESCRIPTION
Currently the ExpressionModel cannot be part of a CompositeModel as the merging logic of param_names rejects to add lists and sets. This change would fix this issue.