### PR TITLE
 feat(params): utility methods for setting parm-attrs en-mass / use pandas instead of Parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,16 @@ install:
     - python setup.py install
 
 script:
-    - cd tests
-    - nosetests
+    -   nosetests tests
+    - |
+        if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
+            nosetests lmfit/ README.rst \
+                -e .*ui.* \
+                -e lmfit.model \
+                -e lmfit.confidence \
+                -e .*uncertainties.* \
+                --with-doctest \
+                --doctest-options=+NORMALIZE_WHITESPACE,+ELLIPSIS,+REPORT_NDIFF,+IGNORE_EXCEPTION_DETAIL \
+                --doctest-extension=rst
+
+        fi

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -354,13 +354,13 @@ class Parameters(OrderedDict):
 
         Examples
         --------
-        >>>  params = Parameters()
-        # add with tuples: (NAME VALUE VARY MIN  MAX  EXPR  BRUTE_STEP)
+        >>> params = Parameters()
+        >>> # add with tuples: (NAME VALUE VARY MIN  MAX  EXPR  BRUTE_STEP)
         >>> params.add_many(('amp',   10, True, None, None, None, None),
         ...                 ('cen',   4, True,  0.0, None, None, None),
         ...                 ('wid',   1, False, None, None, None, None),
         ...                 ('frac', 0.5))
-        # add a sequence of Parameters
+        >>> # add a sequence of Parameters
         >>> f = Parameter('par_f', 100)
         >>> g = Parameter('par_g',  2.)
         >>> params.add_many(f, g)

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -373,6 +373,100 @@ class Parameters(OrderedDict):
                 param = Parameter(*para)
                 self.__setitem__(param.name, param)
 
+    def _set_pattr(self, attr_name, attr_val, pnames, pvmap):
+        """The private workhorse of all ``set_XXXs()`` methods. """
+        if pnames:
+            pv = dict.fromkeys(pnames, attr_val)
+            pv.update(pvmap)
+        elif pvmap:
+            pv = pvmap
+        else:
+            pv = dict.fromkeys(self, attr_val)
+
+        try:
+            for pname, val in pv.items():
+                setattr(self[pname], attr_name, val)
+        except KeyError as ex:
+            raise KeyError("%s not in %s" % (ex, list(self.keys())))
+
+    def set_values(self, attr_val=None, *pnames, **pvmap):
+        """Utility method to modify subsets of parameters at once.
+
+        Parameters
+        ----------
+        attr_val : set this value as "value" attribute on affected parameters;
+             if undefined, set them to default-value: None.
+             The affected parameters are `pnames` if not empty, or all, except
+             those contained in `pvmap`.  Non-existent names will scream as Inde
+        pnames : subset of parameter names to affect.
+        pvmap : A mapping of parameter-names --> attr_values to set as "value"
+            attribute.
+
+        :raise:
+            KeyError if `pnames` or `pvmap` specify non-existent parameters.
+
+        If both `pnames` and `pvmap` are empty, set all parameters to
+        `attr_val`.
+        If both `pvmap` and `pvmap` specify a parameter, `pvmap` wins.
+
+        Examples
+        --------
+        >>> params = Parameters(**{p: Parameter() for p in 'abcd'})
+        >>> list(params.keys())
+        ['a', 'b', 'c', 'd']
+
+        ## Set a value to all:
+        >>> params.set_values(1)
+        >>> params.valuesdict()
+        OrderedDict([('a', 1), ('b', 1), ('c', 1), ('d', 1)])
+
+        ## Specify a subset of parameters:
+        >>> params.set_values(2, 'b', 'c')
+        >>> params.valuesdict()
+        OrderedDict([('a', 1), ('b', 2), ('c', 2), ('d', 1)])
+
+        ## Specify key-values on top of the subset:
+        >>> params.set_values(3, *'bc', c=4, d=4)
+        >>> params.valuesdict()
+        OrderedDict([('a', 1), ('b', 3), ('c', 4), ('d', 4)])
+
+        ## Assign to a single parameter:
+        >>> params.set_values(a=5)
+        >>> params.valuesdict()
+        OrderedDict([('a', 5), ('b', 3), ('c', 4), ('d', 4)])
+
+        ## Back to defaults for all:
+        >>> params.set_values()
+        >>> params.valuesdict()
+        OrderedDict([('a', None), ('b', None), ('c', None), ('d', None)])
+
+        ## Unknown parameters, raise:
+        >>> params.set_values(k=1)
+        Traceback (most recent call last):
+        KeyError: "'l' not in ['a', 'b', 'c', 'd']"
+        """
+        self._set_pattr('value', attr_val, pnames, pvmap)
+
+    def set_varys(self, attr_val=True, *pnames, **pvmap):
+        """See :method:`set_values()`, default-value: True."""
+        self._set_pattr('vary', attr_val, pnames, pvmap)
+
+    def set_mins(self, attr_val=-inf, *pnames, **pvmap):
+        """See :method:`set_values()`, default-value: -inf."""
+        self._set_pattr('min', attr_val, pnames, pvmap)
+
+    def set_maxs(self, attr_val=inf, *pnames, **pvmap):
+        """See :method:`set_values()`, default-value: inf."""
+        self._set_pattr('max', attr_val, pnames, pvmap)
+
+    def set_exprs(self, attr_val=None, *pnames, **pvmap):
+        """See :method:`set_values()`, default-value: None."""
+        self._set_pattr('expr', attr_val, pnames, pvmap)
+
+    def set_brute_steps(self, attr_val=None, *pnames, **pvmap):
+        """See :method:`set_values()`, default-value: None."""
+        self._set_pattr('brute_step', attr_val, pnames, pvmap)
+
     def valuesdict(self):
         """Return an ordered dictionary of parameter values.
 
@@ -720,15 +814,17 @@ class Parameter(object):
             self.from_internal = lambda val: val
             _val = self._val
         elif self.max == inf:
-            self.from_internal = lambda val: self.min - 1.0 + sqrt(val*val + 1)
+            self.from_internal = lambda val: self.min - \
+                1.0 + sqrt(val * val + 1)
             _val = sqrt((self._val - self.min + 1.0)**2 - 1)
         elif self.min == -inf:
-            self.from_internal = lambda val: self.max + 1 - sqrt(val*val + 1)
+            self.from_internal = lambda val: self.max + 1 - sqrt(val * val + 1)
             _val = sqrt((self.max - self._val + 1.0)**2 - 1)
         else:
             self.from_internal = lambda val: self.min + (sin(val) + 1) * \
-                                 (self.max - self.min) / 2.0
-            _val = arcsin(2*(self._val - self.min)/(self.max - self.min) - 1)
+                (self.max - self.min) / 2.0
+            _val = arcsin(2 * (self._val - self.min) /
+                          (self.max - self.min) - 1)
         return _val
 
     def scale_gradient(self, val):
@@ -749,9 +845,9 @@ class Parameter(object):
         if self.min == -inf and self.max == inf:
             return 1.0
         elif self.max == inf:
-            return val / sqrt(val*val + 1)
+            return val / sqrt(val * val + 1)
         elif self.min == -inf:
-            return -val / sqrt(val*val + 1)
+            return -val / sqrt(val * val + 1)
         else:
             return cos(val) * (self.max - self.min) / 2.0
 

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -373,43 +373,26 @@ class Parameters(OrderedDict):
                 param = Parameter(*para)
                 self.__setitem__(param.name, param)
 
-    def _set_pattr(self, attr_name, attr_val, pnames, pvmap):
+    def _set_pattr(self, attr_name, **pvmap):
         """The private workhorse of all ``set_XXXs()`` methods. """
-        if pnames:
-            pv = dict.fromkeys(pnames, attr_val)
-            pv.update(pvmap)
-        elif pvmap:
-            pv = pvmap
-        else:
-            pv = dict.fromkeys(self, attr_val)
-
-        bad_keys = set(pv) - set(self)
+        bad_keys = set(pvmap) - set(self)
         if bad_keys:
             raise KeyError("%s not in %s" % (list(bad_keys), list(self)))
 
-        for pname, val in pv.items():
+        for pname, val in pvmap.items():
             setattr(self[pname], attr_name, val)
 
-    def set_values(self, attr_val=None, *pnames, **pvmap):
+    def set_values(self, **pvmap):
         """Utility method to modify subsets of parameters at once.
 
         Parameters
         ----------
-        attr_val : set this value as "value" attribute on affected parameters;
-             if undefined, set them to default-value: None.
-             The affected parameters are `pnames` if not empty, or all, except
-             those contained in `pvmap`.  Non-existent names will scream as Inde
-        pnames : subset of parameter names to affect.
-        pvmap : A mapping of parameter-names --> attr_values to set as "value"
+        pvmap : A mapping of parameter-names --> attr_values to set their "value"
             attribute.
 
         :raise KeyError:
             if any `pvmap` key specify a non-existent parameter; does not
             modify params in that case.
-
-        If both `pnames` and `pvmap` are empty, set all parameters to
-        `attr_val`.
-        If both `pvmap` and `pvmap` specify a parameter, `pvmap` wins.
 
         Examples
         --------
@@ -417,57 +400,42 @@ class Parameters(OrderedDict):
         >>> list(params.keys())
         ['a', 'b', 'c', 'd']
 
-        ## Set a value to all:
-        >>> params.set_values(1)
+        ## Set all parameter values at once:
+        >>> params.set_values(**dict.fromkeys(params, 1))
         >>> params.valuesdict()
         OrderedDict([('a', 1), ('b', 1), ('c', 1), ('d', 1)])
 
         ## Specify a subset of parameters:
-        >>> params.set_values(2, 'b', 'c')
+        >>> params.set_values(b=2, c=3)
         >>> params.valuesdict()
-        OrderedDict([('a', 1), ('b', 2), ('c', 2), ('d', 1)])
-
-        ## Specify key-values on top of the subset:
-        >>> params.set_values(3, *'bc', c=4, d=4)
-        >>> params.valuesdict()
-        OrderedDict([('a', 1), ('b', 3), ('c', 4), ('d', 4)])
-
-        ## Assign to a single parameter:
-        >>> params.set_values(a=5)
-        >>> params.valuesdict()
-        OrderedDict([('a', 5), ('b', 3), ('c', 4), ('d', 4)])
-
-        ## Back to defaults for all:
-        >>> params.set_values()
-        >>> params.valuesdict()
-        OrderedDict([('a', None), ('b', None), ('c', None), ('d', None)])
+        OrderedDict([('a', 1), ('b', 2), ('c', 3), ('d', 1)])
 
         ## Unknown parameters, raise:
         >>> params.set_values(k=1)
         Traceback (most recent call last):
-        KeyError: "'l' not in ['a', 'b', 'c', 'd']"
+        KeyError: "['k'] not in ['a', 'b', 'c', 'd']"
         """
-        self._set_pattr('value', attr_val, pnames, pvmap)
+        self._set_pattr('value', **pvmap)
 
-    def set_varys(self, attr_val=True, *pnames, **pvmap):
-        """See :method:`set_values()`, default-value: True."""
-        self._set_pattr('vary', attr_val, pnames, pvmap)
+    def set_varys(self, **pvmap):
+        """See :method:`set_values(). """
+        self._set_pattr('vary', **pvmap)
 
-    def set_mins(self, attr_val=-inf, *pnames, **pvmap):
-        """See :method:`set_values()`, default-value: -inf."""
-        self._set_pattr('min', attr_val, pnames, pvmap)
+    def set_mins(self, **pvmap):
+        """See :method:`set_values(). """
+        self._set_pattr('min', **pvmap)
 
-    def set_maxs(self, attr_val=inf, *pnames, **pvmap):
-        """See :method:`set_values()`, default-value: inf."""
-        self._set_pattr('max', attr_val, pnames, pvmap)
+    def set_maxs(self, **pvmap):
+        """See :method:`set_values(). """
+        self._set_pattr('max', **pvmap)
 
-    def set_exprs(self, attr_val=None, *pnames, **pvmap):
-        """See :method:`set_values()`, default-value: None."""
-        self._set_pattr('expr', attr_val, pnames, pvmap)
+    def set_exprs(self, **pvmap):
+        """See :method:`set_values(). """
+        self._set_pattr('expr', **pvmap)
 
-    def set_brute_steps(self, attr_val=None, *pnames, **pvmap):
-        """See :method:`set_values()`, default-value: None."""
-        self._set_pattr('brute_step', attr_val, pnames, pvmap)
+    def set_brute_steps(self, **pvmap):
+        """See :method:`set_values(). """
+        self._set_pattr('brute_step', **pvmap)
 
     def _get_pattr(self, attr_name, pnames):
         """The private workhorse of all ``get_XXXs()`` methods. """
@@ -480,7 +448,7 @@ class Parameters(OrderedDict):
 
     def get_values(self, *pnames):
         """
-        Like :method:`valuesdict()` optionally for a subset or parameter. 
+        Like :method:`valuesdict()` optionally for a subset or parameter.
 
         Examples:
         ---------

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -383,11 +383,12 @@ class Parameters(OrderedDict):
         else:
             pv = dict.fromkeys(self, attr_val)
 
-        try:
-            for pname, val in pv.items():
-                setattr(self[pname], attr_name, val)
-        except KeyError as ex:
-            raise KeyError("%s not in %s" % (ex, list(self.keys())))
+        bad_keys = set(pv) - set(self)
+        if bad_keys:
+            raise KeyError("%s not in %s" % (list(bad_keys), list(self)))
+
+        for pname, val in pv.items():
+            setattr(self[pname], attr_name, val)
 
     def set_values(self, attr_val=None, *pnames, **pvmap):
         """Utility method to modify subsets of parameters at once.
@@ -402,8 +403,9 @@ class Parameters(OrderedDict):
         pvmap : A mapping of parameter-names --> attr_values to set as "value"
             attribute.
 
-        :raise:
-            KeyError if `pnames` or `pvmap` specify non-existent parameters.
+        :raise KeyError:
+            if any `pvmap` key specify a non-existent parameter; does not
+            modify params in that case.
 
         If both `pnames` and `pvmap` are empty, set all parameters to
         `attr_val`.

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -137,7 +137,7 @@ class Parameters(OrderedDict):
         if key not in self:
             if not valid_symbol_name(key):
                 raise KeyError("'%s' is not a valid Parameters name" % key)
-        if par is not None and not isinstance(par, Parameter):
+        if not isinstance(par, Parameter):
             raise ValueError("'%s' is not a Parameter" % par)
         OrderedDict.__setitem__(self, key, par)
         par.name = key

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -467,6 +467,61 @@ class Parameters(OrderedDict):
         """See :method:`set_values()`, default-value: None."""
         self._set_pattr('brute_step', attr_val, pnames, pvmap)
 
+    def _get_pattr(self, attr_name, pnames):
+        """The private workhorse of all ``get_XXXs()`` methods. """
+        try:
+            return OrderedDict((p.name, getattr(p, attr_name))
+                               for p in self.values()
+                               if not pnames or p.name in pnames)
+        except KeyError as ex:
+            raise KeyError("%s not in %s" % (ex, list(self.keys())))
+
+    def get_values(self, *pnames):
+        """
+        Like :method:`valuesdict()` optionally for a subset or parameter. 
+
+        Examples:
+        ---------
+
+        >>> params = Parameters()
+        >>> params.add_many(('amp',   10, True, None, None, None, None),
+        ...                 ('cen',   4, True,  0.0, None, None, None),
+        ...                 ('wid',   1, False, None, None, None, None),
+        ...                 ('frac', 0.5))
+        >>> params.get_values()
+        OrderedDict([('amp', 10), ('cen', 4), ('wid', 1), ('frac', 0.5)])
+
+        >>> params.get_varys('amp', 'wid') == {'amp': True, 'wid': False}
+        True
+
+        >>> params.get_mins('amp', 'cen') == {'amp': -inf, 'cen': 0.0}
+        True
+
+        >>> params.get_maxs()
+        OrderedDict([('amp', inf), ('cen', inf), ('wid', inf), ('frac', inf)])
+        """
+        return self._get_pattr('value', pnames)
+
+    def get_varys(self, *pnames):
+        """Like :method:`valuesdict()` optionally for a subset or parameter. """
+        return self._get_pattr('vary', pnames)
+
+    def get_mins(self, *pnames):
+        """Like :method:`valuesdict()` optionally for a subset or parameter. """
+        return self._get_pattr('min', pnames)
+
+    def get_maxs(self, *pnames):
+        """Like :method:`valuesdict()` optionally for a subset or parameter. """
+        return self._get_pattr('max', pnames)
+
+    def get_exprs(self, *pnames):
+        """Like :method:`valuesdict()` optionally for a subset or parameter. """
+        return self._get_pattr('expr', pnames)
+
+    def get_brute_steps(self, *pnames):
+        """Like :method:`valuesdict()` optionally for a subset or parameter. """
+        return self._get_pattr('brute_step', pnames)
+
     def valuesdict(self):
         """Return an ordered dictionary of parameter values.
 

--- a/lmfit/ui/basefitter.py
+++ b/lmfit/ui/basefitter.py
@@ -22,28 +22,29 @@ _COMMON_EXAMPLES_DOC = """
 
     Examples
     --------
+    >>> from lmfit import Fitter
     >>> fitter = Fitter(data, model=SomeModel, x=x)
 
     >>> fitter.model
-    # This property can be changed, to try different models on the same
-    # data with the same independent vars.
-    # (This is especially handy in the notebook.)
+    >>> # This property can be changed, to try different models on the same
+    >>> # data with the same independent vars.
+    >>> # (This is especially handy in the notebook.)
 
     >>> fitter.current_params
-    # This copy of the model's Parameters is updated after each fit.
+    >>> # This copy of the model's Parameters is updated after each fit.
 
     >>> fitter.fit()
-    # Perform a fit using fitter.current_params as a guess.
-    # Optionally, pass a params argument or individual keyword arguments
-    # to override current_params.
+    >>> # Perform a fit using fitter.current_params as a guess.
+    >>> # Optionally, pass a params argument or individual keyword arguments
+    >>> # to override current_params.
 
     >>> fitter.current_result
-    # This is the result of the latest fit. It contain the usual
-    # copies of the Parameters, in the attributes params and init_params.
+    >>> # This is the result of the latest fit. It contain the usual
+    >>> # copies of the Parameters, in the attributes params and init_params.
 
     >>> fitter.data = new_data
-    # If this property is updated, the `current_params` are retained an used
-    # as an initial guess if fit() is called again.
+    >>> # If this property is updated, the `current_params` are retained an used
+    >>> # as an initial guess if fit() is called again.
     """
 
 
@@ -56,6 +57,7 @@ class BaseFitter(object):
     model : lmfit.Model
         optional initial Model to use, maybe be set or changed later
     """ + _COMMON_EXAMPLES_DOC
+
     def __init__(self, data, model=None, **kwargs):
         self._data = data
         self.kwargs = kwargs
@@ -167,7 +169,7 @@ class BaseFitter(object):
                 self.namefinder.generic_visit(par.ast)
                 for symname in self.namefinder.names:
                     if (symname in self.current_params and
-                        symname not in par.deps):
+                            symname not in par.deps):
                         par.deps.append(symname)
                 self.asteval.symtable[name] = par.value
                 if par.name is None:
@@ -224,8 +226,9 @@ class MPLFitter(BaseFitter):
         line
     **kwargs : independent variables or extra arguments, passed like `x=x`
         """ + _COMMON_EXAMPLES_DOC
+
     def __init__(self, data, model=None, axes_style={},
-                data_style={}, init_style={}, best_style={}, **kwargs):
+                 data_style={}, init_style={}, best_style={}, **kwargs):
         self.axes_style = axes_style
         self.data_style = data_style
         self.init_style = init_style
@@ -267,16 +270,16 @@ class MPLFitter(BaseFitter):
                               "that does not depend on matplotlib.")
 
         # Configure style
-        _axes_style= dict()  # none, but this is here for possible future use
+        _axes_style = dict()  # none, but this is here for possible future use
         _axes_style.update(self.axes_style)
         _axes_style.update(axes_style)
-        _data_style= dict(color='blue', marker='o', linestyle='none')
+        _data_style = dict(color='blue', marker='o', linestyle='none')
         _data_style.update(**_normalize_kwargs(self.data_style, 'line2d'))
         _data_style.update(**_normalize_kwargs(data_style, 'line2d'))
         _init_style = dict(color='gray')
         _init_style.update(**_normalize_kwargs(self.init_style, 'line2d'))
         _init_style.update(**_normalize_kwargs(init_style, 'line2d'))
-        _best_style= dict(color='red')
+        _best_style = dict(color='red')
         _best_style.update(**_normalize_kwargs(self.best_style, 'line2d'))
         _best_style.update(**_normalize_kwargs(best_style, 'line2d'))
 


### PR DESCRIPTION
Add utility setters/getters on Parameters class to modify (optionally subsets of) contained parameter instances at once.

The setters are particular handy because they allow the following usage pattern [edit: HAS CHANGED]:
```
>>> params = Parameters(**{p: Parameter() for p in 'abcd'})

## Set a value to all:
>>> params.set_values(1)
>>> params.valuesdict()
OrderedDict([('a', 1), ('b', 1), ('c', 1), ('d', 1)])

## Specify a subset of parameters:
>>> params.set_values(2, 'b', 'c')
>>> params.valuesdict()
OrderedDict([('a', 1), ('b', 2), ('c', 2), ('d', 1)])

## Specify key-values on top of the subset:
>>> params.set_values(3, *'bc', c=4, d=4)
>>> params.valuesdict()
OrderedDict([('a', 1), ('b', 3), ('c', 4), ('d', 4)])

## Assign to a single parameter:
>>> params.set_values(a=5)
>>> params.valuesdict()
OrderedDict([('a', 5), ('b', 3), ('c', 4), ('d', 4)])

## Back to defaults for all:
>>> params.set_values()
>>> params.valuesdict()
OrderedDict([('a', None), ('b', None), ('c', None), ('d', None)])

## Unknown parameters, raise:
>>> params.set_values(k=1)
Traceback (most recent call last):
KeyError: "'l' not in ['a', 'b', 'c', 'd']"
```

Actually the API has been simplified to accept `**kwds` only, like this:
```
params.set_values(a=2.72, c=3.14)
```

If you want to do imitate the above tricks, use this pattern:
```
newvalues = dict.fromkeys(['a', 'b', 'c'], 3.14)
newvalues.update(d=2.718)
params.set_values(**newvalues)
```