### PR TITLE
rationalizing Model "missing" and "nan_policy"

### DIFF
--- a/doc/model.rst
+++ b/doc/model.rst
@@ -232,14 +232,16 @@ function as a fitting model.
 
    List of strings for names of the independent variables.
 
-.. attribute:: missing
+.. attribute:: nan_policy
 
-   Describes what to do for missing values.  The choices are:
+   Describes what to do for NaNs and missing values.  The choices are:
 
-    * None: Do not check for null or missing values (default).
-    * 'none': Do not check for null or missing values.
-    * 'drop': Drop null or missing observations in data.  If pandas is installed, :func:`pandas.isnull` is used, otherwise :func:`numpy.isnan` is used.
-    * 'raise': Raise a (more helpful) exception when data contains null or missing values.
+    * 'raise': Raise a ValueError (default)
+    * 'propagate': Do not check for NaNs or missing values. The fit will
+      try to ignore them.
+    * 'omit': Remove NaNs or missing observations in data. If pandas is
+      installed, :func:`pandas.isnull` is used, otherwise
+      :func:`numpy.isnan` is used.
 
 .. attribute:: name
 

--- a/examples/doc_model_with_nan_policy.py
+++ b/examples/doc_model_with_nan_policy.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+#<examples/doc_model_with_nan_policy.py>
+import numpy as np
+
+from lmfit.models import  GaussianModel
+
+import matplotlib.pyplot as plt
+
+data = np.loadtxt('model1d_gauss.dat')
+x = data[:, 0]
+y = data[:, 1]
+
+y[44] = np.nan
+y[65] = np.nan
+
+gmodel = GaussianModel()
+result = gmodel.fit(y, x=x, amplitude=5, center=6, sigma=1,
+                    nan_policy='propagate') # 'omit')
+
+print(result.fit_report())
+
+plt.plot(x, y,         'bo')
+plt.plot(x, result.init_fit, 'k--')
+plt.plot(x, result.best_fit, 'r-')
+plt.show()
+#<end examples/doc_model_with_nan_policy.py>

--- a/examples/doc_model_with_nan_policy.py
+++ b/examples/doc_model_with_nan_policy.py
@@ -23,8 +23,13 @@ result = gmodel.fit(y, x=x, amplitude=5, center=6, sigma=1,
 
 print(result.fit_report())
 
-plt.plot(x, y,         'bo')
-plt.plot(x, result.init_fit, 'k--')
-plt.plot(x, result.best_fit, 'r-')
+# make sure nans are removed for plotting:
+
+x_ = x[np.where(np.isfinite(y))]
+y_ = y[np.where(np.isfinite(y))]
+
+plt.plot(x_, y_,         'bo')
+plt.plot(x_, result.init_fit, 'k--')
+plt.plot(x_, result.best_fit, 'r-')
 plt.show()
 #<end examples/doc_model_with_nan_policy.py>

--- a/examples/doc_model_with_nan_policy.py
+++ b/examples/doc_model_with_nan_policy.py
@@ -13,9 +13,13 @@ y = data[:, 1]
 y[44] = np.nan
 y[65] = np.nan
 
+# nan_policy = 'raise'
+# nan_policy = 'propagate'
+nan_policy = 'omit'
+
 gmodel = GaussianModel()
 result = gmodel.fit(y, x=x, amplitude=5, center=6, sigma=1,
-                    nan_policy='propagate') # 'omit')
+                    nan_policy=nan_policy)
 
 print(result.fit_report())
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1801,8 +1801,10 @@ def validate_nan_policy(policy):
         policy = 'propagate'
 
     policy = policy.lower()
-    if policy == 'drop':  policy = 'omit'
-    if policy == 'none':  policy = 'propagate'
+    if policy == 'drop':
+        policy = 'omit'
+    if policy == 'none':
+        policy = 'propagate'
     if policy not in VALID_NAN_POLICIES:
         raise ValueError("nan_policy must be 'propagate', 'omit', or 'raise'.")
     return policy

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -31,6 +31,11 @@ from scipy.stats import cauchy as cauchy_dist
 from scipy.stats import norm as norm_dist
 import six
 
+try:
+    from pandas import isnull
+except ImportError:
+    isnull = np.isnan
+
 # use locally modified version of uncertainties package
 from . import uncertainties
 from .parameter import Parameter, Parameters
@@ -1783,17 +1788,34 @@ def _make_random_gen(seed):
                      ' instance' % seed)
 
 
-def _nan_policy(a, nan_policy='raise', handle_inf=True):
+VALID_NAN_POLICIES = ('propagate', 'omit', 'raise')
+def validate_nan_policy(policy):
+    """validate, rationalize nan_policy, for back compatibility
+    and compatibility with Pandas missing convention
+    """
+    if policy in VALID_NAN_POLICIES:
+        return policy
+    if policy is None:
+        policy = 'propagate'
+
+    policy = policy.lower()
+    if policy == 'drop':  policy = 'omit'
+    if policy == 'none':  policy = 'propagate'
+    if policy not in VALID_NAN_POLICIES:
+        raise ValueError("nan_policy must be 'propagate', 'omit', or 'raise'.")
+    return policy
+
+def _nan_policy(arr, nan_policy='raise', handle_inf=True):
     """Specify behaviour when an array contains numpy.nan or numpy.inf.
 
     Parameters
     ----------
-    a : array_like
+    arr : array_like
         Input array to consider.
     nan_policy : str, optional
         One of:
 
-        'raise' - raise a `ValueError` if `a` contains NaN
+        'raise' - raise a `ValueError` if `arr` contains NaN (default)
         'propagate' - propagate NaN
         'omit' - filter NaN from input array
     handle_inf : bool, optional
@@ -1809,41 +1831,36 @@ def _nan_policy(a, nan_policy='raise', handle_inf=True):
     scipy/stats/stats.py/_contains_nan
 
     """
-    policies = ['propagate', 'raise', 'omit']
+    nan_policy = validate_nan_policy(nan_policy)
 
     if handle_inf:
-        handler_func = lambda a: ~np.isfinite(a)
+        handler_func = lambda x: ~np.isfinite(x)
     else:
-        handler_func = np.isnan
+        handler_func = isnull
 
-    if nan_policy == 'propagate':
-        # nan values are ignored.
-        return a
-    elif nan_policy == 'raise':
+    if nan_policy == 'omit':
+        # mask locates any values to remove
+        mask = ~handler_func(arr)
+        if not np.all(mask):  # there are some NaNs/infs/missing values
+            return arr[mask]
+    if nan_policy == 'raise':
         try:
             # Calling np.sum to avoid creating a huge array into memory
             # e.g. np.isnan(a).any()
             with np.errstate(invalid='ignore'):
-                contains_nan = handler_func(np.sum(a))
+                contains_nan = handler_func(np.sum(arr))
         except TypeError:
             # If the check cannot be properly performed we fallback to omiting
             # nan values and raising a warning. This can happen when attempting to
             # sum things that are not numbers (e.g. as in the function `mode`).
             contains_nan = False
-            warnings.warn("The input array could not be properly checked for nan "
-                          "values. nan values will be ignored.", RuntimeWarning)
+            warnings.warn("The input array could not be checked for NaNs. "
+                          "NaNs will be ignored.", RuntimeWarning)
 
         if contains_nan:
             raise ValueError("The input contains nan values")
-        return a
+    return arr
 
-    elif nan_policy == 'omit':
-        # nans are filtered
-        mask = handler_func(a)
-        return a[~mask]
-    else:
-        raise ValueError("nan_policy must be one of {%s}" %
-                         ', '.join("'%s'" % s for s in policies))
 
 
 def minimize(fcn, params, method='leastsq', args=None, kws=None,

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -491,15 +491,17 @@ class Minimizer(object):
         self.result.nfev += 1
 
         out = self.userfcn(params, *self.userargs, **self.userkws)
-        out = _nan_policy(out, nan_policy=self.nan_policy)
 
         if callable(self.iter_cb):
             abort = self.iter_cb(params, self.result.nfev, out,
                                  *self.userargs, **self.userkws)
             self._abort = self._abort or abort
         self._abort = self._abort and self.result.nfev > len(fvars)
+
         if not self._abort:
-            return np.asarray(out).ravel()
+            return _nan_policy(np.asarray(out).ravel(),
+                               nan_policy=self.nan_policy)
+
 
     def __jacobian(self, fvars):
         """Reuturn analytical jacobian to be used with Levenberg-Marquardt.

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -79,7 +79,7 @@ class Model(object):
             Names of arguments to func that are to be made into parameters
             (default is None).
         nan_policy : str, optional
-            How to handle NaN and missing values in data. Must one of
+            How to handle NaN and missing values in data. Must be one of
             'raise' (default), 'propagate', or 'omit'. See Note below.
         missing : str, optional
             Synonym for 'nan_policy' for backward compatibility
@@ -129,6 +129,10 @@ class Model(object):
 
         >>> print(gmodel.param_names, gmodel.independent_vars)
         ['amp', 'cen', 'wid'], ['x']
+
+        .. note:: the `missing` argument is deprecated in lmfit 0.9.8 and will
+                  be removed in a later version. Use `nan_policy`, which is
+                  consistent with the Minimizer class, instead.
 
         """
         self.func = func
@@ -716,8 +720,10 @@ class Model(object):
 
         # If independent_vars and data are alignable (pandas), align them,
         # and apply the mask from above if there is one.
+
         for var in self.independent_vars:
             if not np.isscalar(kwargs[var]):
+                print("Model fit align ind dep ", var, mask.sum())
                 kwargs[var] = _align(kwargs[var], mask, data)
 
         if fit_kws is None:

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -67,8 +67,8 @@ class Model(object):
     _forbidden_args = ('data', 'weights', 'params')
     _invalid_ivar = "Invalid independent variable name ('%s') for function %s"
     _invalid_par = "Invalid parameter name ('%s') for function %s"
-    _invalid_missing = "missing must be None, 'none', 'drop', or 'raise'."
-    _valid_missing = (None, 'none', 'drop', 'raise')
+    _invalid_missing = "missing must be None, 'none', 'propagate', 'omit', 'drop', or 'raise'."
+    _valid_missing = (None, 'none', 'propagate', 'omit', 'drop', 'raise')
 
     _invalid_hint = "unknown parameter hint '%s' for param '%s'"
     _hint_names = ('value', 'vary', 'min', 'max', 'expr')
@@ -88,9 +88,9 @@ class Model(object):
         missing : str, optional
             How to handle NaN and missing values in data. One of:
 
-            - 'none' or None : Do not check for null or missing values (default).
+            - 'propagate', 'none' or None : Do not check for null or missing values (default).
 
-            - 'drop' : Drop null or missing observations in data. If pandas is
+            - 'omit' : (was 'drop') Drop null or missing observations in data. If pandas is
               installed, `pandas.isnull` is used, otherwise `numpy.isnan` is used.
             - 'raise' : Raise a (more helpful) exception when data contains
               null or missing values.
@@ -500,7 +500,7 @@ class Model(object):
         if self.missing == 'raise':
             if np.any(isnull(data)):
                 raise ValueError("Data contains a null value.")
-        elif self.missing == 'drop':
+        elif self.missing in ('omit', 'drop'):
             mask = ~isnull(data)
             if np.all(mask):
                 return None  # short-circuit this -- no missing values
@@ -624,6 +624,8 @@ class Model(object):
         verbose: bool, optional
              Whether to print a message when a new parameter is added because
              of a hint (default is True).
+        nan_policy : str, optional, one of 'raise' (default), 'propagate', or 'omit'.
+             What to do when encountering NaNs when fitting Model
         fit_kws: dict, optional
              Options to pass to the minimizer being used.
         **kwargs: optional
@@ -906,6 +908,8 @@ class ModelResult(Minimizer):
             Function to call on each iteration of fit.
         scale_covar : bool, optional
             Whether to scale covariance matrix for uncertainty evaluation.
+        nan_policy : str, optional, one of 'raise' (default), 'propagate', or 'omit'.
+            What to do when encountering NaNs when fitting Model
         **fit_kws : optional
             Keyword arguments to send to minimization routine.
         """
@@ -934,6 +938,8 @@ class ModelResult(Minimizer):
             Weights to multiply (data-model) for fit residual.
         method : str, optional
             Name of minimization method to use (default is `'leastsq'`).
+        nan_policy : str, optional, one of 'raise' (default), 'propagate', or 'omit'.
+            What to do when encountering NaNs when fitting Model
         **kwargs : optional
             Keyword arguments to send to minimization routine.
 

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -602,7 +602,7 @@ class Model(object):
 
     def fit(self, data, params=None, weights=None, method='leastsq',
             iter_cb=None, scale_covar=True, verbose=False, fit_kws=None,
-            **kwargs):
+            nan_policy='raise', **kwargs):
         """Fit the model to the data using the supplied Parameters.
 
         Parameters
@@ -733,7 +733,7 @@ class Model(object):
         output = ModelResult(self, params, method=method, iter_cb=iter_cb,
                              scale_covar=scale_covar, fcn_kws=kwargs,
                              **fit_kws)
-        output.fit(data=data, weights=weights)
+        output.fit(data=data, weights=weights, nan_policy=nan_policy)
         output.components = self.components
         return output
 
@@ -883,7 +883,8 @@ class ModelResult(Minimizer):
 
     def __init__(self, model, params, data=None, weights=None,
                  method='leastsq', fcn_args=None, fcn_kws=None,
-                 iter_cb=None, scale_covar=True, **fit_kws):
+                 iter_cb=None, scale_covar=True, nan_policy='raise',
+                 **fit_kws):
         """
         Parameters
         ----------
@@ -912,13 +913,15 @@ class ModelResult(Minimizer):
         self.data = data
         self.weights = weights
         self.method = method
+        self.nan_policy = nan_policy
         self.ci_out = None
         self.init_params = deepcopy(params)
         Minimizer.__init__(self, model._residual, params, fcn_args=fcn_args,
                            fcn_kws=fcn_kws, iter_cb=iter_cb,
                            scale_covar=scale_covar, **fit_kws)
 
-    def fit(self, data=None, params=None, weights=None, method=None, **kwargs):
+    def fit(self, data=None, params=None, weights=None, method=None,
+            nan_policy='raise', **kwargs):
         """Re-perform fit for a Model, given data and params.
 
         Parameters
@@ -943,6 +946,9 @@ class ModelResult(Minimizer):
             self.weights = weights
         if method is not None:
             self.method = method
+        if nan_policy is not None:
+            self.nan_policy = nan_policy
+
         self.ci_out = None
         self.userargs = (self.data, self.weights)
         self.userkws.update(kwargs)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -724,7 +724,7 @@ class Model(object):
 
         for var in self.independent_vars:
             if not np.isscalar(kwargs[var]):
-                print("Model fit align ind dep ", var, mask.sum())
+                # print("Model fit align ind dep ", var, mask.sum())
                 kwargs[var] = _align(kwargs[var], mask, data)
 
         if fit_kws is None:

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -108,6 +108,10 @@ class Model(object):
 
            -  'omit' : (was 'drop') drop missing data.
 
+        4. The `missing` argument is deprecated in lmfit 0.9.8 and will be
+        removed in a later version. Use `nan_policy instead, as it is
+        consistent with the Minimizer class.
+
 
         Examples
         --------
@@ -130,9 +134,6 @@ class Model(object):
         >>> print(gmodel.param_names, gmodel.independent_vars)
         ['amp', 'cen', 'wid'], ['x']
 
-        .. note:: the `missing` argument is deprecated in lmfit 0.9.8 and will
-                  be removed in a later version. Use `nan_policy`, which is
-                  consistent with the Minimizer class, instead.
 
         """
         self.func = func

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -231,11 +231,10 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
     def test_lists_become_arrays(self):
         # smoke test
         self.model.fit([1, 2, 3], x=[1, 2, 3], **self.guess())
-        self.model.fit([1, 2, None, 3], x=[1, 2, 3, 4],  **self.guess())
         assert_raises(ValueError,
                       self.model.fit,
                       [1, 2, None, 3],
-                      x=[1, 2, 3, 4], nan_policy='raise',
+                      x=[1, 2, 3, 4],
                       **self.guess())
 
     def test_missing_param_raises_error(self):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -231,10 +231,11 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
     def test_lists_become_arrays(self):
         # smoke test
         self.model.fit([1, 2, 3], x=[1, 2, 3], **self.guess())
+        self.model.fit([1, 2, None, 3], x=[1, 2, 3, 4],  **self.guess())
         assert_raises(ValueError,
                       self.model.fit,
                       [1, 2, None, 3],
-                      x=[1, 2, 3, 4],
+                      x=[1, 2, 3, 4], nan_policy='raise',
                       **self.guess())
 
     def test_missing_param_raises_error(self):


### PR DESCRIPTION
This is an attempt to resolve #423.  

Here, `Model` gets a `nan_policy` argument, that matches that for `Minimizer`.  The older 'missing' options are still supported, but `nan_policy` should be preferred.   

In addition, `nan_policy` can now be specified at `Model.fit()` (or `ModelResult.fit()`) time, instead of only when creating a Model. 

The check for pandas and use of 'pandas.isnull` vs `numpy.isnan` is now moved to `minimize.py`, and used for all `minimize` uses.  There is still a sort-of-question of how to handle the difference of `~np.isfinite` and `np.isnan` when dealing with pandas Series.   So, this PR also makes a subtle change to `Minimizer._residual()` that the nan policy is applied after the user-callback, and after doing "np.asarray()" and "ravel()".  I believe that will work for pandas Series, but I don't think we have enough tests of that.
