### PR TITLE
Add fwhm and height parameters to Pearson7 model

### DIFF
--- a/lmfit/asteval.py
+++ b/lmfit/asteval.py
@@ -28,6 +28,12 @@ try:
 except ImportError:
     print("Warning: numpy not available... functionality will be limited.")
 
+HAS_SCIPY = False
+try:
+    import scipy.special
+    HAS_SCIPY = True
+except ImportError:
+    print("Warning: scipy not available... gamma function for pearson7 not available.")
 
 class Interpreter:
     """Mathematical expression compiler and interpreter.
@@ -86,6 +92,7 @@ class Interpreter:
         self.retval = None
         self.lineno = 0
         self.use_numpy = HAS_NUMPY and use_numpy
+        self.use_scipy = HAS_SCIPY
 
         symtable['print'] = self._printer
 
@@ -102,6 +109,11 @@ class Interpreter:
         math_symtable = dict((sym, getattr(math, sym)) for sym in FROM_MATH
                              if hasattr(math, sym))
         symtable.update(math_symtable)
+
+        # add scipy symbols
+        if self.use_scipy:
+            scipy_symtable = {"gamfcn": getattr(scipy.special, "gamma")}
+            symtable.update(scipy_symtable)
 
         # add numpy symbols
         if self.use_numpy:

--- a/lmfit/astutils.py
+++ b/lmfit/astutils.py
@@ -55,7 +55,7 @@ FROM_MATH = ('acos', 'acosh', 'asin', 'asinh', 'atan', 'atan2', 'atanh',
              'fabs', 'factorial', 'floor', 'fmod', 'frexp', 'fsum',
              'hypot', 'isinf', 'isnan', 'ldexp', 'log', 'log10', 'log1p',
              'modf', 'pi', 'pow', 'radians', 'sin', 'sinh', 'sqrt', 'tan',
-             'tanh', 'trunc')
+             'tanh', 'trunc', 'gamma')
 
 FROM_NUMPY = ('Inf', 'NAN', 'abs', 'add', 'alen', 'all', 'amax', 'amin',
               'angle', 'any', 'append', 'arange', 'arccos', 'arccosh',

--- a/lmfit/astutils.py
+++ b/lmfit/astutils.py
@@ -55,7 +55,7 @@ FROM_MATH = ('acos', 'acosh', 'asin', 'asinh', 'atan', 'atan2', 'atanh',
              'fabs', 'factorial', 'floor', 'fmod', 'frexp', 'fsum',
              'hypot', 'isinf', 'isnan', 'ldexp', 'log', 'log10', 'log1p',
              'modf', 'pi', 'pow', 'radians', 'sin', 'sinh', 'sqrt', 'tan',
-             'tanh', 'trunc', 'gamma')
+             'tanh', 'trunc')
 
 FROM_NUMPY = ('Inf', 'NAN', 'abs', 'add', 'alen', 'all', 'amax', 'amin',
               'angle', 'any', 'append', 'arange', 'arccos', 'arccosh',

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -503,12 +503,19 @@ class Pearson7Model(Model):
 
     """
 
+    fwhm_factor = 1.0
+
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
                  name=None,  **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(Pearson7Model, self).__init__(pearson7, **kwargs)
         self.set_param_hint('expon', value=1.5)
+        self.set_param_hint('fwhm', expr=fwhm_expr(self))
+
+        fmt = ("{prefix:s}amplitude * gamma({prefix:s}expon)/"
+               "(gamma(0.5)*gamma({prefix:s}expon-0.5)*{prefix:s}sigma)")
+        self.set_param_hint('height', expr=fmt.format(prefix=self.prefix))
 
     def guess(self, data, x=None, negative=False, **kwargs):
         pars = guess_from_peak(self, data, x, negative)

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -490,7 +490,7 @@ class MoffatModel(Model):
 class Pearson7Model(Model):
     r"""A model based on a Pearson VII distribution (see
     http://en.wikipedia.org/wiki/Pearson_distribution#The_Pearson_type_VII_distribution),
-    with four parameers: ``amplitude`` (:math:`A`), ``center``
+    with four parameters: ``amplitude`` (:math:`A`), ``center``
     (:math:`\mu`), ``sigma`` (:math:`\sigma`), and ``exponent`` (:math:`m`) in
 
     .. math::
@@ -499,7 +499,9 @@ class Pearson7Model(Model):
 
     where :math:`\beta` is the beta function (see :scipydoc:`special.beta` in
     :mod:`scipy.special`).  The :meth:`guess` function always
-    gives a starting value for ``exponent`` of 1.5.
+    gives a starting value for ``exponent`` of 1.5.  In addition, parameters
+    ``fwhm`` and ``height`` are included as constraints to report full width
+    at half maximum and maximum peak height, respectively.
 
     """
 

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -513,8 +513,8 @@ class Pearson7Model(Model):
         self.set_param_hint('expon', value=1.5)
         self.set_param_hint('fwhm', expr=fwhm_expr(self))
 
-        fmt = ("{prefix:s}amplitude * gamma({prefix:s}expon)/"
-               "(gamma(0.5)*gamma({prefix:s}expon-0.5)*{prefix:s}sigma)")
+        fmt = ("{prefix:s}amplitude * gamfcn({prefix:s}expon)/"
+               "(gamfcn(0.5)*gamfcn({prefix:s}expon-0.5)*{prefix:s}sigma)")
         self.set_param_hint('height', expr=fmt.format(prefix=self.prefix))
 
     def guess(self, data, x=None, negative=False, **kwargs):


### PR DESCRIPTION
Add fwhm and height parameters to Pearson7 model.

This requires adding gamfcn to asteval which has been implemented similarly to the numpy attribute importing.