### PR TITLE
Add limit to Pearson7 expon to prevent nan error when approaching normal distribution

### DIFF
--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -508,7 +508,7 @@ class Pearson7Model(Model):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(Pearson7Model, self).__init__(pearson7, **kwargs)
-        self.set_param_hint('expon', value=1.5)
+        self.set_param_hint('expon', value=1.5, max=100)
 
     def guess(self, data, x=None, negative=False, **kwargs):
         pars = guess_from_peak(self, data, x, negative)


### PR DESCRIPTION
Add limit to Pearson7 expon to prevent nan error when approaching normal distribution

On my system a max above 171 creates a nan error when fitting a normal distribution such as:
`from lmfit.models import Pearson7Model
from scipy.stats import norm
mu = 0
variance = 1
sigma = np.sqrt(variance)
x = np.linspace(mu - 6*sigma, mu + 6*sigma, 100)
y = norm.pdf(x, mu, 1)
mod = Pearson7Model()
pars = mod.guess(y, x=x)
out = mod.fit(y, pars, x=x)
`
So, limit is set to 100 to keep things nice and even.