### PR TITLE
Tuple assignment fixed bug causing crash in examples, and some minor changes.

### DIFF
--- a/examples/benchmark_fit.py
+++ b/examples/benchmark_fit.py
@@ -31,12 +31,12 @@ def run_fit(nruns=100):
         params.add('shift', value= 0.0, min=-np.pi/2., max=np.pi/2)
         params.add('omega', value= 1.0, min=-10.0, max=10.0)
         out = minimize(fcn2min, params, args=(x, data))
-        # print out.params['amp']
+        # print(out.params['amp'])
         assert out.params['amp'].value < 5.5
         assert out.params['amp'].value > 4.5
         assert out.params['omega'].value < 2.25
         assert out.params['omega'].value > 1.75
-        # print out.params['amp']
+        # print(out.params['amp'])
 
 def show_profile(filename):
     stats = pstats.Stats(filename)

--- a/examples/example_derivfunc.py
+++ b/examples/example_derivfunc.py
@@ -49,7 +49,7 @@ min2 = Minimizer(func, params2, fcn_args=(x,), fcn_kws={'data':data})
 out2 = min2.leastsq(Dfun=dfunc, col_deriv=1)
 fit2 = func(out2.params, x)
 
-print '''Comparison of fit to exponential decay
+print('''Comparison of fit to exponential decay
 with and without analytic derivatives, to
    model = a*exp(-b*x) + c
 for a = %.2f, b = %.2f, c = %.2f
@@ -67,7 +67,7 @@ Chi-square         |   %.4f    |   %.4f  |
         out1.chisqr, out2.chisqr,
         out1.params['a'], out2.params['a'],
         out1.params['b'], out2.params['b'],
-        out1.params['c'], out2.params['c'] )
+        out1.params['c'], out2.params['c'] ))
 
 
 if HASPYLAB:

--- a/examples/example_lbfgsb.py
+++ b/examples/example_lbfgsb.py
@@ -45,9 +45,9 @@ fit = residual(out.params, x)
 
 for name, par in out.params.items():
     nout = "%s:%s" % (name, ' '*(20-len(name)))
-    print "%s: %s (true=%s) " % (nout, par.value, p_true[name].value)
+    print("%s: %s (true=%s) " % (nout, par.value, p_true[name].value))
 
-#print out.chisqr, out.redchi, out.nfree
+#print(out.chisqr, out.redchi, out.nfree)
 #
 #report_fit(fit_params)
 

--- a/examples/fit_with_analytic_jacobian.py
+++ b/examples/fit_with_analytic_jacobian.py
@@ -1,5 +1,4 @@
 import matplotlib
-matplotlib.use('Qt4Agg')
 import matplotlib.pyplot as plt
 from lmfit.models import *
 from lmfit.lineshapes import *

--- a/examples/fit_with_analytic_jacobian.py
+++ b/examples/fit_with_analytic_jacobian.py
@@ -31,9 +31,9 @@ def dfunc_lorentzian(params, *ys, **xs):
 if __name__ == '__main__':
     xs = np.linspace(-4, 4, 100)
 
-    print '**********************************'
-    print '***** Test Gaussian **************'
-    print '**********************************'
+    print('**********************************')
+    print('***** Test Gaussian **************')
+    print('**********************************')
     ys = gaussian(xs, 2.5, 0, 0.5)
     yn = ys + 0.1*np.random.normal(size=len(xs))
 
@@ -41,19 +41,19 @@ if __name__ == '__main__':
     pars = mod.guess(yn, xs)
     out  = mod.fit(yn, pars, x=xs)
     out2 = mod.fit(yn, pars,  x=xs, fit_kws={'Dfun': dfunc_gaussian, 'col_deriv': 1})
-    print 'lmfit without dfunc **************'
-    print 'number of function calls: ', out.nfev
-    print 'params', out.best_values
-    print 'lmfit with dfunc *****************'
-    print 'number of function calls: ', out2.nfev
-    print 'params', out2.best_values
-    print '\n \n'
+    print('lmfit without dfunc **************')
+    print('number of function calls: ', out.nfev)
+    print('params', out.best_values)
+    print('lmfit with dfunc *****************')
+    print('number of function calls: ', out2.nfev)
+    print('params', out2.best_values)
+    print('\n \n')
     out2.plot(datafmt='.')
 
 
-    print '**********************************'
-    print '***** Test Lorentzian ************'
-    print '**********************************'
+    print('**********************************')
+    print('***** Test Lorentzian ************')
+    print('**********************************')
     ys = lorentzian(xs, 2.5, 0, 0.5)
     yn = ys + 0.1*np.random.normal(size=len(xs))
 
@@ -61,13 +61,13 @@ if __name__ == '__main__':
     pars = mod.guess(yn, xs)
     out  = mod.fit(yn, pars, x=xs )
     out2 = mod.fit(yn, pars,  x=xs, fit_kws={'Dfun': dfunc_lorentzian, 'col_deriv': 1})
-    print 'lmfit without dfunc **************'
-    print 'number of function calls: ', out.nfev
-    print 'params', out.best_values
-    print 'lmfit with dfunc *****************'
-    print 'number of function calls: ', out2.nfev
-    print 'params', out2.best_values
-    print '\n \n'
+    print('lmfit without dfunc **************')
+    print('number of function calls: ', out.nfev)
+    print('params', out.best_values)
+    print('lmfit with dfunc *****************')
+    print('number of function calls: ', out2.nfev)
+    print('params', out2.best_values)
+    print('\n \n')
     out2.plot(datafmt='.')
 
     plt.show()

--- a/examples/fit_with_bounds.py
+++ b/examples/fit_with_bounds.py
@@ -43,13 +43,13 @@ out = minimize(residual, fit_params, args=(x,), kws={'data':data})
 
 fit = residual(out.params, x)
 
-print '# N_func_evals, N_free = ', out.nfev, out.nfree
-print '# chi-square, reduced chi-square = % .7g, % .7g' % (out.chisqr, out.redchi)
+print('# N_func_evals, N_free = ', out.nfev, out.nfree)
+print('# chi-square, reduced chi-square = % .7g, % .7g' % (out.chisqr, out.redchi))
 
 report_fit(out.params, show_correl=True, modelpars=p_true)
 
-print 'Raw (unordered, unscaled) Covariance Matrix:'
-print out.covar
+print('Raw (unordered, unscaled) Covariance Matrix:')
+print(out.covar)
 
 if HASPYLAB:
     pylab.plot(x, data, 'ro')

--- a/examples/plot_fit.py
+++ b/examples/plot_fit.py
@@ -14,7 +14,7 @@ model = lmfit.models.GaussianModel()
 model.guess(y, x=x)
 fit = model.fit(y, x=x, weights=1/noise**2)
 
-fig = fit.plot()
+fig, gridspec = fit.plot()
 
 # customize plot post-factum
 ax_residuals, ax_fit = fig.get_axes()

--- a/examples/plot_fit2.py
+++ b/examples/plot_fit2.py
@@ -15,11 +15,11 @@ model_gaussian.guess(y, x=x)
 fit_gaussian = model_gaussian.fit(y, x=x, weights=1/noise**2)
 
 # plot the with with customization
-fig = fit_gaussian.plot(fig_kws=dict(figsize=[8,7]),
-                        ax_fit_kws=dict(title='The gaussian fit'),
-                        initfmt='k:', datafmt='ks',
-                        fit_kws=dict(lw=2, color='red'),
-                        data_kws=dict(ms=8, markerfacecolor='white'))
+fig, gridspec = fit_gaussian.plot(fig_kws=dict(figsize=[8,7]),
+                                  ax_fit_kws=dict(title='The gaussian fit'),
+                                  initfmt='k:', datafmt='ks',
+                                  fit_kws=dict(lw=2, color='red'),
+                                  data_kws=dict(ms=8, markerfacecolor='white'))
 
 fig.set_tight_layout(True)
 plt.show()


### PR DESCRIPTION
The example files didn't work because it assumed that `fit.plot()` returns a Matplotlib `Figure`, bit it returns a tuple with the Matplotlib objects (´Figure´, ´Gridspec´).
This pullrequest simply assign the ´Gridspec´ to the variable ´gridspec´, and ´Figure´ to the variable ´fig´, so that the examples work again.

Also replace print-statements with print-functions, since they work in both Python 2 and 3.

Finally I removed the backend-setting, since the Qt4Agg is not available in all installations.