### PR TITLE
Documentation updates

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -6,14 +6,11 @@ To install the lmfit python module, use::
    python setup.py build
    python setup.py install
 
-For lmfit 0.9.4, the following versions are required:
-  Python: 2.6, 2.7, 3.3, 3.4, or 3.5
-  Numpy:  1.5 or higher
-  Scipy:  0.13 or higher
-
-Note that Python 2.6 and scipy 0.13 are deprecated, and
-support and testing with them will be dropped in 0.9.5.
-
+For lmfit 0.9.7, the following versions are required:
+  Python: 2.7, 3.3, 3.4, 3.5, or 3.6
+  NumPy: 1.9.1 or higher
+  SciPy: 0.15 or higher
+  six: 1.10 or higher
 
 Matt Newville <newville@cars.uchicago.edu>
-Last Update:  2016-July-1
+Last Update:  2017-October-30

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Overview
 LMfit-py provides a Least-Squares Minimization routine and class with a
 simple, flexible approach to parameterizing a model for fitting to data.
 
-LMfit is a pure python package, and so easy to install from source or with
+LMfit is a pure Python package, and so easy to install from source or with
 ``pip install lmfit``.
 
 For questions, comments, and suggestions, please use the LMfit mailing
@@ -61,7 +61,7 @@ and additional positional and keyword arguments as desired::
 
 For each call of this function, the values for the params may have changed,
 subject to the bounds and constraint settings for each Parameter.  The function
-should return the residual (ie, data-model) array to be minimized.
+should return the residual (i.e., data-model) array to be minimized.
 
 The advantage here is that the function to be minimized does not have to be
 changed if different bounds or constraints are placed on the fitting
@@ -76,10 +76,10 @@ To perform the fit, the user calls::
 
     result = minimize(myfunc, fit_params, args=(x, data), kws={'someflag':True}, ....)
 
-After the fit, each real variable in the ``fit_params`` dictionary is updated
-to have best-fit values, estimated standard deviations, and correlations
-with other variables in the fit, while the results dictionary holds fit
-statistics and information.
+After the fit, a ``MinimizerResult`` class is returned that holds the
+results the fit (e.g., fitting statistics, and optimized parameters). The
+dictionary ``result.params`` contains the best-fit values, estimated
+standard deviations, and correlations with other variables in the fit.
 
 By default, the underlying fit algorithm is the Levenberg-Marquart
 algorithm with numerically-calculated derivatives from MINPACK's lmdif

--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -26,7 +26,7 @@ example, a Lorentzian plus a linear background might be represented as::
 
     >>> from lmfit.models import LinearModel, LorentzianModel
     >>> peak = LorentzianModel()
-    >>> background  = LinearModel()
+    >>> background = LinearModel()
     >>> model = peak + background
 
 All the models listed below are one dimensional, with an independent
@@ -296,7 +296,7 @@ built-in default values.  We will simply use::
      mod = GaussianModel()
 
      pars = mod.guess(y, x=x)
-     out  = mod.fit(y, pars, x=x)
+     out = mod.fit(y, pars, x=x)
      print(out.fit_report(min_correl=0.25))
 
 
@@ -615,11 +615,12 @@ this, and by defining an :func:`index_of` function to limit the data range.
 That is, with::
 
     def index_of(arrval, value):
-        "return index of array *at or below* value "
-        if value < min(arrval):  return 0
-        return max(np.where(arrval<=value)[0])
+        """Return index of array *at or below* value."""
+        if value < min(arrval):
+            return 0
+        return max(np.where(arrval <= value)[0])
 
-    ix1 = index_of(x,  75)
+    ix1 = index_of(x, 75)
     ix2 = index_of(x, 135)
     ix3 = index_of(x, 175)
 

--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -6,20 +6,20 @@ Built-in Fitting Models in the :mod:`models` module
 
 .. module:: lmfit.models
 
-Lmfit provides several builtin fitting models in the :mod:`models` module.
-These pre-defined models each subclass from the :class:`model.Model` class of the
+Lmfit provides several built-in fitting models in the :mod:`models` module.
+These pre-defined models each subclass from the :class:`~lmfit.model.Model` class of the
 previous chapter and wrap relatively well-known functional forms, such as
 Gaussians, Lorentzian, and Exponentials that are used in a wide range of
-scientific domains.  In fact, all the models are all based on simple, plain
-Python functions defined in the :mod:`lineshapes` module.  In addition to
-wrapping a function into a :class:`model.Model`, these models also provide a
-:meth:`guess` method that is intended to give a reasonable
+scientific domains.  In fact, all the models are based on simple, plain
+Python functions defined in the :mod:`~lmfit.lineshapes` module.  In addition to
+wrapping a function into a :class:`~lmfit.model.Model`, these models also provide a
+:meth:`~lmfit.model.Model.guess` method that is intended to give a reasonable
 set of starting values from a data array that closely approximates the
 data to be fit.
 
-As shown in the previous chapter, a key feature of the :class:`mode.Model` class
+As shown in the previous chapter, a key feature of the :class:`~lmfit.model.Model` class
 is that models can easily be combined to give a composite
-:class:`model.CompositeModel`. Thus, while some of the models listed here may
+:class:`~lmfit.model.CompositeModel`. Thus, while some of the models listed here may
 seem pretty trivial (notably, :class:`ConstantModel` and :class:`LinearModel`),
 the main point of having these is to be able to use them in composite models. For
 example, a Lorentzian plus a linear background might be represented as::
@@ -41,7 +41,7 @@ width.  Many peak shapes also have a parameter ``fwhm`` (constrained by
 (constrained by ``sigma`` and ``amplitude``) to give the maximum peak
 height.
 
-After a list of builtin models, a few examples of their use is given.
+After a list of built-in models, a few examples of their use are given.
 
 Peak-like models
 -------------------
@@ -138,7 +138,7 @@ Linear and Polynomial Models
 These models correspond to polynomials of some degree.  Of course, lmfit is
 a very inefficient way to do linear regression (see :numpydoc:`polyfit`
 or :scipydoc:`stats.linregress`), but these models may be useful as one
-of many components of composite model.
+of many components of a composite model.
 
 :class:`ConstantModel`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -221,10 +221,10 @@ supplied, the determination of what are the parameter names for the model
 happens when the model is created.  To do this, the expression is parsed,
 and all symbol names are found.  Names that are already known (there are
 over 500 function and value names in the asteval namespace, including most
-Python builtins, more than 200 functions inherited from NumPy, and more
+Python built-ins, more than 200 functions inherited from NumPy, and more
 than 20 common lineshapes defined in the :mod:`lineshapes` module) are not
-converted to parameters.  Unrecognized name are expected to be names either
-of parameters or independent variables.  If `independent_vars` is the
+converted to parameters.  Unrecognized names are expected to be names of either
+parameters or independent variables.  If `independent_vars` is the
 default value of None, and if the expression contains a variable named
 `x`, that will be used as the independent variable.  Otherwise,
 `independent_vars` must be given.
@@ -276,7 +276,7 @@ and `wid`, and build a model that can be used to fit data.
 
 
 
-Example 1: Fit Peaked data to Gaussian, Lorentzian, and  Voigt profiles
+Example 1: Fit Peak data to Gaussian, Lorentzian, and  Voigt profiles
 ------------------------------------------------------------------------
 
 Here, we will fit data to three similar line shapes, in order to decide which
@@ -339,7 +339,7 @@ good. A plot of the fit:
   Fit to peak with Gaussian (left) and Lorentzian (right) models.
 
 shows a decent match to the data -- the fit worked with no explicit setting
-of initial parameter values.  Looking more closing, the fit is not perfect,
+of initial parameter values.  Looking more closely, the fit is not perfect,
 especially in the tails of the peak, suggesting that a different peak
 shape, with longer tails, should be used.  Perhaps a Lorentzian would be
 better?  To do this, we simply replace ``GaussianModel`` with
@@ -478,7 +478,7 @@ Example 2: Fit data to a Composite Model with pre-defined models
 ------------------------------------------------------------------
 
 Here, we repeat the point made at the end of the last chapter that
-instances of :class:`model.Model` class can be added together to make a
+instances of :class:`~lmfit.model.Model` class can be added together to make a
 *composite model*.  By using the large number of built-in models available,
 it is therefore very simple to build models that contain multiple peaks and
 various backgrounds.  An example of a simple fit to a noisy step function
@@ -536,7 +536,7 @@ Example 3: Fitting Multiple Peaks -- and using Prefixes
 As shown above, many of the models have similar parameter names.  For
 composite models, this could lead to a problem of having parameters for
 different parts of the model having the same name.  To overcome this, each
-:class:`model.Model` can have a ``prefix`` attribute (normally set to a blank
+:class:`~lmfit.model.Model` can have a ``prefix`` attribute (normally set to a blank
 string) that will be put at the beginning of each parameter name.  To
 illustrate, we fit one of the classic datasets from the `NIST StRD`_ suite
 involving a decaying exponential and two gaussians.

--- a/doc/confidence.rst
+++ b/doc/confidence.rst
@@ -125,8 +125,7 @@ covariance matrix, but the estimates for `a2` and especially for `t1`, and
 `t2` are very asymmetric and that going from 1 :math:`\sigma` (68%
 confidence) to 2 :math:`\sigma` (95% confidence) is not very predictable.
 
-Let plots mad of the confidence region are shown the figure on the left
-below for `a1` and `t2`, and for `a2` and `t2` on the right:
+Plots of the confidence region are shown in the figures below for `a1` and `t2` (left), and `a2` and `t2` (right):
 
 .. _figC1:
 

--- a/doc/confidence.rst
+++ b/doc/confidence.rst
@@ -30,7 +30,7 @@ within a certain confidence.
 
  F(P_{fix},N-P) = \left(\frac{\chi^2_f}{\chi^2_{0}}-1\right)\frac{N-P}{P_{fix}}
 
-`N` is the number of data points, `P` the number of parameters of the null model.
+`N` is the number of data points and `P` the number of parameters of the null model.
 :math:`P_{fix}` is the number of fixed parameters (or to be more clear, the
 difference of number of parameters between our null model and the alternate
 model).
@@ -62,9 +62,9 @@ starting point::
     >>> mini = lmfit.Minimizer(residual, pars)
     >>> result = mini.minimize()
     >>> print(lmfit.fit_report(result.params))
-    [Variables]]
-        a:   0.09943895 +/- 0.000193 (0.19%) (init= 0.1)
-        b:   1.98476945 +/- 0.012226 (0.62%) (init= 1)
+    [[Variables]]
+        a:   0.09963086 +/- 0.000216 (0.22%) (init= 0.1)
+        b:   1.97053799 +/- 0.013638 (0.69%) (init= 1)
     [[Correlations]] (unreported correlations are <  0.100)
         C(a, b)                      =  0.601
 
@@ -73,11 +73,11 @@ intervals::
 
     >>> ci = lmfit.conf_interval(mini, result)
     >>> lmfit.printfuncs.report_ci(ci)
-         99.70%    95.00%    67.40%     0.00%    67.40%    95.00%    99.70%
-    a   0.09886   0.09905   0.09925   0.09944   0.09963   0.09982   0.10003
-    b   1.94751   1.96049   1.97274   1.97741   1.99680   2.00905   2.02203
+          99.73%    95.45%    68.27%    _BEST_    68.27%    95.45%    99.73%
+     a:  -0.00066  -0.00044  -0.00022   0.09963  +0.00022  +0.00044  +0.00067
+     b:  -0.04200  -0.02764  -0.01371   1.97054  +0.01371  +0.02764  +0.04201
 
-This shows the best-fit values for the parameters in the `0.00%` column,
+This shows the best-fit values for the parameters in the `_BEST_` column,
 and parameter values that are at the varying confidence levels given by
 steps in :math:`\sigma`.  As we can see, the estimated error is almost the
 same, and the uncertainties are well behaved: Going from 1 :math:`\sigma`
@@ -112,12 +112,11 @@ which will report::
         C(a2, t1)                    = -0.925
         C(t1, t2)                    = -0.881
         C(a1, t1)                    = -0.599
-          95.00%    68.00%     0.00%    68.00%    95.00%
-    a1   2.71850   2.84525   2.98622   3.14874   3.34076
-    a2  -4.63180  -4.46663  -4.33526  -4.22883  -4.14178
-    t2  10.82699  11.33865  11.82404  12.28195  12.71094
-    t1   1.08014   1.18566   1.30994   1.45566   1.62579
-
+           95.45%    68.27%    _BEST_    68.27%    95.45%
+     a1:  -0.27286  -0.14165   2.98622  +0.16353  +0.36343
+     a2:  -0.30444  -0.13219  -4.33526  +0.10688  +0.19683
+     t1:  -0.23392  -0.12494   1.30994  +0.14660  +0.32369
+     t2:  -1.01943  -0.48820  11.82404  +0.46041  +0.90441
 
 Again we called :func:`conf_interval`, this time with tracing and only for
 1- and 2-:math:`\sigma`.  Comparing these two different estimates, we see
@@ -152,8 +151,8 @@ parameters::
     >>> x2, y2, prob2 = trace['t2']['t2'], trace['t2']['a1'],trace['t2']['prob']
     >>> plt.scatter(x, y, c=prob ,s=30)
     >>> plt.scatter(x2, y2, c=prob2, s=30)
-    >>> plt.gca().set_xlim((1, 5))
-    >>> plt.gca().set_ylim((5, 15))
+    >>> plt.gca().set_xlim((2.5, 3.5))
+    >>> plt.gca().set_ylim((11, 13))
     >>> plt.xlabel('a1')
     >>> plt.ylabel('t2')
     >>> plt.show()

--- a/doc/confidence.rst
+++ b/doc/confidence.rst
@@ -44,14 +44,14 @@ First we create an example problem::
 
     >>> import lmfit
     >>> import numpy as np
-    >>> x = np.linspace(0.3,10,100)
-    >>> y = 1/(0.1*x)+2+0.1*np.random.randn(x.size)
+    >>> x = np.linspace(0.3, 10, 100)
+    >>> y = 1/(0.1*x) + 2 + 0.1*np.random.randn(x.size)
     >>> pars = lmfit.Parameters()
     >>> pars.add_many(('a', 0.1), ('b', 1))
     >>> def residual(p):
     ...    a = p['a'].value
     ...    b = p['b'].value
-    ...    return 1/(a*x)+b-y
+    ...    return 1/(a*x) + b - y
 
 
 before we can generate the confidence intervals, we have to run a fit, so
@@ -146,8 +146,8 @@ array of corresponding probabilities for the corresponding cumulative
 variables.  This can be used to show the dependence between two
 parameters::
 
-    >>> x, y, prob = trace['a1']['a1'], trace['a1']['t2'],trace['a1']['prob']
-    >>> x2, y2, prob2 = trace['t2']['t2'], trace['t2']['a1'],trace['t2']['prob']
+    >>> x, y, prob = trace['a1']['a1'], trace['a1']['t2'], trace['a1']['prob']
+    >>> x2, y2, prob2 = trace['t2']['t2'], trace['t2']['a1'], trace['t2']['prob']
     >>> plt.scatter(x, y, c=prob ,s=30)
     >>> plt.scatter(x2, y2, c=prob2, s=30)
     >>> plt.gca().set_xlim((2.5, 3.5))

--- a/doc/constraints.rst
+++ b/doc/constraints.rst
@@ -114,9 +114,9 @@ freely varying parameter `x`.  Next, define a parameter
 define parameter `y` as `delta - x`::
 
     pars = Parameters()
-    pars.add('x',     value = 5, vary=True)
-    pars.add('delta', value = 5, max=10, vary=True)
-    pars.add('y',     expr='delta-x')
+    pars.add('x', value=5, vary=True)
+    pars.add('delta', value=5, max=10, vary=True)
+    pars.add('y', expr='delta-x')
 
 The essential point is that an inequality still implies
 that a variable (here, `delta`) is needed to describe the
@@ -156,7 +156,7 @@ for the constraints::
 
     def mylorentzian(x, amp, cen, wid):
         "lorentzian function: wid = half-width at half-max"
-        return (amp  / (1 + ((x-cen)/wid)**2))
+        return (amp / (1 + ((x-cen)/wid)**2))
 
     fitter = Minimizer()
     fitter.asteval.symtable['lorentzian'] = mylorentzian

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -76,9 +76,9 @@ precision floating point numbers. The simplest approach is to use
 
    import numpy as np
    def residual(params, x, data=None):
-        ....
-        resid = calculate_complex_residual()
-        return resid.view(np.float)
+       ....
+       resid = calculate_complex_residual()
+       return resid.view(np.float)
 
 
 Can I constrain values to have integer values?

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -20,7 +20,7 @@ The :func:`minimize` function is a wrapper around :class:`Minimizer` for
 running an optimization problem.  It takes an objective function (the
 function that calculates the array to be minimized), a :class:`Parameters`
 object, and several optional arguments.  See :ref:`fit-func-label` for
-details on writing the objective.
+details on writing the objective function.
 
 .. autofunction:: minimize
 
@@ -65,6 +65,7 @@ simple way to do this is with :meth:`Parameters.valuesdict`, as shown below::
 
 
     def residual(pars, x, data=None, eps=None):
+        from numpy import exp, sign, sin, pi
         # unpack parameters:
         #  extract .value attribute for each parameter
         parvals = pars.valuesdict()
@@ -91,7 +92,7 @@ In this example, `x` is a positional (required) argument, while the
 calculation if the data is neglected).  Also note that the model
 calculation will divide `x` by the value of the ``period`` Parameter.  It
 might be wise to ensure this parameter cannot be 0.  It would be possible
-to use the bounds on the :class:`Parameter` to do this::
+to use bounds on the :class:`Parameter` to do this::
 
     params['period'] = Parameter(value=2, min=1.e-10)
 
@@ -185,11 +186,11 @@ include several pieces of informational data such as status and error
 messages, fit statistics, and the updated parameters themselves.
 
 Importantly, the parameters passed in to :meth:`Minimizer.minimize`
-will be not be changed.  To to find the best-fit values, uncertainties
+will be not be changed.  To find the best-fit values, uncertainties
 and so on for each parameter, one must use the
 :attr:`MinimizerResult.params` attribute. For example, to print the
-fitted values, bounds and other parameters attributes in a
-well formatted text tables you can execute::
+fitted values, bounds and other parameter attributes in a
+well-formatted text tables you can execute::
 
     result.params.pretty_print()
 
@@ -243,7 +244,7 @@ that the returned residual function is scaled properly to the
 uncertainties in the data.  For these statistics to be meaningful, the
 person writing the function to be minimized **must** scale them properly.
 
-After a fit using using the :meth:`leastsq` method has completed
+After a fit using the :meth:`leastsq` method has completed
 successfully, standard errors for the fitted variables and correlations
 between pairs of fitted variables are automatically calculated from the
 covariance matrix.  The standard error (estimated :math:`1\sigma`
@@ -451,7 +452,7 @@ The values reported in the :class:`MinimizerResult` are the medians of the
 probability distributions and a 1 sigma quantile, estimated as half the
 difference between the 15.8 and 84.2 percentiles. The median value is not
 necessarily the same as the Maximum Likelihood Estimate. We'll get that as well.
-You can see that we recovered the right uncertainty level on the data.::
+You can see that we recovered the right uncertainty level on the data::
 
     >>> print("median of posterior probability distribution")
     >>> print('------------------------------------------')

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,7 +6,7 @@ Non-Linear Least-Squares Minimization and Curve-Fitting for Python
 .. _Levenberg-Marquardt:     http://en.wikipedia.org/wiki/Levenberg-Marquardt_algorithm
 .. _MINPACK-1:               http://en.wikipedia.org/wiki/MINPACK
 .. _scipy.optimize:      http://docs.scipy.org/doc/scipy/reference/optimize.html
-.. _lmfit github repository:   http://github.com/lmfit/lmfit-py
+.. _lmfit GitHub repository:   http://github.com/lmfit/lmfit-py
 
 Lmfit provides a high-level interface to non-linear optimization and curve
 fitting problems for Python. It builds on and extends many of the
@@ -44,7 +44,7 @@ enhancements to optimization and data fitting problems, including:
 
 The lmfit package is Free software, using an Open Source license.  The
 software and this document are works in progress.  If you are interested in
-participating in this effort please use the `lmfit github repository`_.
+participating in this effort please use the `lmfit GitHub repository`_.
 
 
 .. toctree::

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -21,7 +21,7 @@ The lmfit package requires `Python`_, `NumPy`_, and `SciPy`_.
 Lmfit works with Python versions 2.7, 3.3, 3.4, 3.5, and 3.6. Support for Python 2.6
 ended with lmfit version 0.9.4.  Scipy version 0.15 or higher is required,
 with 0.17 or higher recommended to be able to use the latest optimization
-features.  NumPy version 1.5.1 or higher is required.
+features.  NumPy version 1.9.1 or higher is required.
 
 In order to run the test suite, either the `nose`_ or `pytest`_ package is
 required.  Some functionality of lmfit requires the `emcee`_ package, some

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -57,7 +57,7 @@ To perform the minimization with :mod:`scipy.optimize`, one would do this::
     out = leastsq(residual, vars, args=(x, data, eps_data))
 
 Though it is wonderful to be able to use Python for such optimization
-problems, and the scipy library is robust and easy to use, the approach
+problems, and the SciPy library is robust and easy to use, the approach
 here is not terribly different from how one would do the same fit in C or
 Fortran.  There are several practical challenges to using this approach,
 including:
@@ -108,7 +108,7 @@ for the decaying sine wave as::
         freq = params['frequency']
         decay = params['decay']
 
-        model = amp * sin(x * freq  + pshift) * exp(-x*x*decay)
+        model = amp * sin(x * freq + pshift) * exp(-x*x*decay)
 
         return (data-model)/eps_data
 

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -46,9 +46,9 @@ sine wave, and so write an objective function like this::
         freq = vars[2]
         decay = vars[3]
 
-        model = amp * sin(x * freq  + phaseshift) * exp(-x*x*decay)
+        model = amp * sin(x*freq + phaseshift) * exp(-x*x*decay)
 
-        return (data-model)/eps_data
+        return (data-model) / eps_data
 
 To perform the minimization with :mod:`scipy.optimize`, one would do this::
 
@@ -108,9 +108,9 @@ for the decaying sine wave as::
         freq = params['frequency']
         decay = params['decay']
 
-        model = amp * sin(x * freq + pshift) * exp(-x*x*decay)
+        model = amp * sin(x*freq + pshift) * exp(-x*x*decay)
 
-        return (data-model)/eps_data
+        return (data-model) / eps_data
 
     params = Parameters()
     params.add('amp', value=10)

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -49,19 +49,19 @@ definition of the model function:
     >>> from numpy import sqrt, pi, exp, linspace, random
     >>>
     >>> def gaussian(x, amp, cen, wid):
-    ...    return amp * exp(-(x-cen)**2 /wid)
+    ...    return amp * exp(-(x-cen)**2 / wid)
 
 We want to use this function to fit to data :math:`y(x)` represented by the
 arrays `y` and `x`.  With :scipydoc:`optimize.curve_fit`, this would be::
 
     >>> from scipy.optimize import curve_fit
     >>>
-    >>> x = linspace(-10,10, 101)
+    >>> x = linspace(-10, 10, 101)
     >>> y = gaussian(x, 2.33, 0.21, 1.51) + random.normal(0, 0.2, len(x))
     >>>
-    >>> init_vals = [1, 0, 1]     # for [amp, cen, wid]
+    >>> init_vals = [1, 0, 1]  # for [amp, cen, wid]
     >>> best_vals, covar = curve_fit(gaussian, x, y, p0=init_vals)
-    >>> print best_vals
+    >>> print(best_vals)
 
 
 That is, we create data, make an initial guess of the model values, and run
@@ -96,20 +96,20 @@ the independent variable is and which function arguments should be identified
 as parameter names.
 
 The Parameters are *not* created when the model is created. The model knows
-what the parameters should be named, but not anything about the scale and
+what the parameters should be named, but nothing about the scale and
 range of your data.  You will normally have to make these parameters and
 assign initial values and other attributes.  To help you do this, each
 model has a :meth:`make_params` method that will generate parameters with
 the expected names:
 
-    >>> params = gmod.make_params()
+    >>> params = gmodel.make_params()
 
 This creates the :class:`~lmfit.parameter.Parameters` but does not
 automaticaly give them initial values since it has no idea what the scale
 should be.  You can set initial values for parameters with keyword
 arguments to :meth:`make_params`:
 
-    >>> params = gmod.make_params(cen=5, amp=200, wid=1)
+    >>> params = gmodel.make_params(cen=5, amp=200, wid=1)
 
 or assign them (and other parameter properties) after the
 :class:`~lmfit.parameter.Parameters` class has been created.
@@ -122,25 +122,25 @@ For example, one could use :meth:`eval` to calculate the predicted
 function::
 
     >>> x = linspace(0, 10, 201)
-    >>> y = gmod.eval(params, x=x)
+    >>> y = gmodel.eval(params, x=x)
 
 or with::
 
-    >>> y = gmod.eval(x=x, cen=6.5, amp=100, wid=2.0)
+    >>> y = gmodel.eval(x=x, cen=6.5, amp=100, wid=2.0)
 
 Admittedly, this a slightly long-winded way to calculate a Gaussian
 function, given that you could have called your `gaussian` function
 directly.  But now that the model is set up, we can use its
 :meth:`fit` method to fit this model to data, as with::
 
-    >>> result = gmod.fit(y, params, x=x)
+    >>> result = gmodel.fit(y, params, x=x)
 
 or with::
 
-    >>> result = gmod.fit(y, x=x, cen=6.5, amp=100, wid=2.0)
+    >>> result = gmodel.fit(y, x=x, cen=6.5, amp=100, wid=2.0)
 
-Putting everything together,  (included in the
-``examples`` folder with the source code) is:
+Putting everything together, included in the
+``examples`` folder with the source code, is:
 
 .. literalinclude:: ../examples/doc_model1.py
 
@@ -279,10 +279,10 @@ a :class:`~lmfit.parameter.Parameters` object, and names are inferred from the f
 arguments, and a residual function is automatically constructed.
 
 
-By default, the independent variable is take as the first argument to the
+By default, the independent variable is taken as the first argument to the
 function.  You can, of course, explicitly set this, and will need to do so
-if the independent variable is not first in the list, or if there are actually
-more than one independent variables.
+if the independent variable is not first in the list, or if there is actually
+more than one independent variable.
 
 If not specified, Parameters are constructed from all positional arguments
 and all keyword arguments that have a default value that is numerical, except
@@ -304,14 +304,14 @@ function is fairly easy. Let's try another one::
     ...    return N*np.exp(-t/tau)
     ...
     >>> decay_model = Model(decay)
-    >>> print decay_model.independent_vars
+    >>> print(decay_model.independent_vars)
     ['t']
     >>> params = decay_model.make_params()
-    >>> for pname in decay_model.param_names:
-    ...     print pname, params[pname]
+    >>> for pname, par in params.items():
+    ...     print(pname, par)
     ...
-    tau <Parameter 'tau', None, bounds=[None:None]>
-    N <Parameter 'N', None, bounds=[None:None]>
+    tau <Parameter 'tau', -inf, bounds=[-inf:inf]>
+    N <Parameter 'N', -inf, bounds=[-inf:inf]>
 
 Here, `t` is assumed to be the independent variable because it is the
 first argument to the function.  The other function arguments are used to
@@ -321,14 +321,14 @@ If you want `tau` to be the independent variable in the above example,
 you can say so::
 
     >>> decay_model = Model(decay, independent_vars=['tau'])
-    >>> print decay_model.independent_vars
+    >>> print(decay_model.independent_vars)
     ['tau']
     >>> params = decay_model.make_params()
-    >>> for pname in decay_model.param_names:
-    ...     print pname, params[pname]
+    >>> for pname, par in params.items():
+    ...     print(pname, par)
     ...
-    t <Parameter 't', None, bounds=[None:None]>
-    N <Parameter 'N', None, bounds=[None:None]>
+    t <Parameter 't', -inf, bounds=[-inf:inf]>
+    N <Parameter 'N', -inf, bounds=[-inf:inf]>
 
 
 You can also supply multiple values for multi-dimensional functions with
@@ -354,18 +354,19 @@ Parameters if the supplied default value was a valid number (but not
 None, True, or False).
 
     >>> def decay2(t, tau, N=10, check_positive=False):
-    ...    if check_small:
-    ...        arg = abs(t)/max(1.e-9, abs(tau))
-    ...    else:
-    ...        arg = t/tau
-    ...    return N*np.exp(arg)
+    ...     if check_small:
+    ...         arg = abs(t)/max(1.e-9, abs(tau))
+    ...     else:
+    ...         arg = t/tau
+    ...     return N*np.exp(arg)
     ...
     >>> mod = Model(decay2)
-    >>> for pname, par in mod.params.items():
-    ...     print pname, par
+    >>> params = mod.make_params()
+    >>> for pname, par in params.items():
+    ...     print(pname, par)
     ...
-    t <Parameter 't', None, bounds=[None:None]>
-    N <Parameter 'N', 10, bounds=[None:None]>
+    t <Parameter 't', -inf, bounds=[-inf:inf]>
+    N <Parameter 'N', 10, bounds=[-inf:inf]>
 
 Here, even though `N` is a keyword argument to the function, it is turned
 into a parameter, with the default numerical value as its initial value.
@@ -392,12 +393,13 @@ the same name.  To avoid this, we can add a `prefix` to the
     ...
 
     >>> mod = Model(myfunc, prefix='f1_')
-    >>> for pname, par in mod.params.items():
-    ...     print pname, par
+    >>> params = mod.make_params()
+    >>> for pname, par in params.items():
+    ...     print(pname, par)
     ...
-    f1_amplitude <Parameter 'f1_amplitude', None, bounds=[None:None]>
-    f1_center <Parameter 'f1_center', None, bounds=[None:None]>
-    f1_sigma <Parameter 'f1_sigma', None, bounds=[None:None]>
+    f1_amplitude <Parameter 'f1_amplitude', 1, bounds=[-inf:inf]>
+    f1_center <Parameter 'f1_center', 0, bounds=[-inf:inf]>
+    f1_sigma <Parameter 'f1_sigma', 1, bounds=[-inf:inf]>
 
 You would refer to these parameters as `f1_amplitude` and so forth, and
 the model will know to map these to the `amplitude` argument of `myfunc`.
@@ -478,7 +480,6 @@ is, as with :meth:`Model.make_params`, you can include values
 as keyword arguments to either the :meth:`Model.eval` or :meth:`Model.fit` methods::
 
    >>> y1 = mod.eval(x=x, a=7.0, b=-2.0)
-
    >>> out = mod.fit(x=x, pars, a=3.0, b=-0.0)
 
 These approaches to initialization provide many opportunities for setting
@@ -495,8 +496,6 @@ After a model has been created, you can give it hints for how to create
 parameters with :meth:`Model.make_params`.  This allows you to set not only a
 default initial value but also to set other parameter attributes
 controlling bounds, whether it is varied in the fit, or a constraint
-
-
 expression.   To set a parameter hint, you can use :meth:`Model.set_param_hint`,
 as with::
 
@@ -507,7 +506,7 @@ as with::
 Parameter hints are stored in a model's :attr:`param_hints` attribute,
 which is simply a nested dictionary::
 
-    >>> print mod.param_hints
+    >>> print(mod.param_hints)
     {'a': {'value': 1}, 'b': {'max': 1.0, 'value': 0.3, 'min': 0}}
 
 
@@ -852,7 +851,7 @@ provides a simple way to build up complex models.
 
 .. autoclass::  CompositeModel(left, right, op[, **kws])
 
-Note that when using builtin Python binary operators, a
+Note that when using built-in Python binary operators, a
 :class:`CompositeModel` will automatically be constructed for you. That is,
 doing::
 

--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -94,7 +94,7 @@ can be simplified using the :class:`Parameters` :meth:`valuesdict` method,
 which would make the objective function ``fcn2min`` above look like::
 
     def fcn2min(params, x, data):
-        """ model decaying sine wave, subtract data"""
+        """model decaying sine wave, subtract data"""
         v = params.valuesdict()
 
         model = v['amp'] * np.sin(x * v['omega'] + v['shift']) * np.exp(-x*x*v['decay'])

--- a/lmfit/confidence.py
+++ b/lmfit/confidence.py
@@ -30,7 +30,7 @@ def f_compare(ndata, nparas, new_chi, best_chi, nfix=1.):
 
 
 def copy_vals(params):
-    """Save the values and stderrs of params in temporary dict."""
+    """Save the values and stderrs of params in a temporary dict."""
     tmp_params = {}
     for para_key in params:
         tmp_params[para_key] = (params[para_key].value,
@@ -49,8 +49,8 @@ def conf_interval(minimizer, result, p_names=None, sigmas=(1, 2, 3),
     """Calculate the confidence interval for parameters.
 
     The parameter for which the ci is calculated will be varied, while
-    the remaining parameters are re-optimized for minimizing chi-square.
-    The resulting chi-square is used  to calculate the probability with
+    the remaining parameters are re-optimized to minimize chi-square.
+    The resulting chi-square is used to calculate the probability with
     a given statistic (e.g., F-test). This function uses a 1d-rootfinder
     from SciPy to find the values resulting in the searched confidence
     region.
@@ -348,7 +348,7 @@ def conf_interval2d(minimizer, result, x_name, y_name, nx=10, ny=10,
     ny : int, optional
         Number of points in the y direction.
     limits : tuple, optional
-        Should have the form ((x_upper, x_lower),(y_upper, y_lower)). If not
+        Should have the form ((x_upper, x_lower), (y_upper, y_lower)). If not
         given, the default is 5 std-errs in each direction.
     prob_func : None or callable, optional
         Function to calculate the probability from the optimized chi-square.

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -363,10 +363,11 @@ class Minimizer(object):
                 iter_cb(params, iter, resid, *fcn_args, **fcn_kws)
 
             where `params` will have the current parameter values, `iter`
-            the iteration, `resid` the current residual array, and `*fcn_args`
+            the iteration number, `resid` the current residual array, and `*fcn_args`
             and `**fcn_kws` are passed to the objective function.
         scale_covar : bool, optional
-            Whether to automatically scale the covariance matrix (`leastsq` only).
+            Whether to automatically scale the covariance matrix (default is True,
+            `leastsq` only).
         nan_policy : str, optional
             Specifies action if `userfcn` (or a Jacobian) returns NaN
             values. One of:
@@ -1611,7 +1612,7 @@ class Minimizer(object):
             same name from `scipy.optimize`, or use
             `scipy.optimize.minimize` with the same `method` argument.
             Thus '`leastsq`' will use `scipy.optimize.leastsq`, while
-            '`powell`' will use `scipy.optimize.minimizer(....,
+            '`powell`' will use `scipy.optimize.minimizer(...,
             method='powell')`
 
             For more details on the fitting methods please refer to the
@@ -1870,9 +1871,9 @@ def _nan_policy(arr, nan_policy='raise', handle_inf=True):
 def minimize(fcn, params, method='leastsq', args=None, kws=None,
              scale_covar=True, iter_cb=None, reduce_fcn=None, **fit_kws):
     """Perform a fit of a set of parameters by minimizing an objective (or
-    cost) function using one one of the several available methods.
+    cost) function using one of the several available methods.
 
-    The minimize function takes a objective function to be minimized,
+    The minimize function takes an objective function to be minimized,
     a dictionary (:class:`~lmfit.parameter.Parameters`) containing the model
     parameters, and several optional arguments.
 
@@ -1910,7 +1911,7 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
         name from `scipy.optimize`, or use `scipy.optimize.minimize` with
         the same `method` argument.  Thus '`leastsq`' will use
         `scipy.optimize.leastsq`, while '`powell`' will use
-        `scipy.optimize.minimizer(...., method='powell')`
+        `scipy.optimize.minimizer(..., method='powell')`
 
         For more details on the fitting methods please refer to the
         `SciPy docs <http://docs.scipy.org/doc/scipy/reference/optimize.html>`__.
@@ -1922,11 +1923,12 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     iter_cb : callable, optional
         Function to be called at each fit iteration. This function should
         have the signature `iter_cb(params, iter, resid, *args, **kws)`,
-        where where `params` will have the current parameter values, `iter`
-        the iteration, `resid` the current residual array, and `*args`
+        where `params` will have the current parameter values, `iter`
+        the iteration number, `resid` the current residual array, and `*args`
         and `**kws` as passed to the objective function.
     scale_covar : bool, optional
-        Whether to automatically scale the covariance matrix (`leastsq` only).
+        Whether to automatically scale the covariance matrix (default is True,
+        `leastsq` only).
     reduce_fcn : str or callable, optional
         Function to convert a residual array to a scalar value for the scalar
         minimizers. See notes in `Minimizer`.
@@ -1958,7 +1960,7 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
     data array, dependent variable, uncertainties in the data, and other
     data structures for the model calculation.
 
-    On output, `params` will be unchanged.  The best-fit values, and where
+    On output, `params` will be unchanged.  The best-fit values and, where
     appropriate, estimated uncertainties and correlations, will all be
     contained in the returned :class:`MinimizerResult`.  See
     :ref:`fit-results-label` for further details.

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1203,7 +1203,6 @@ class Minimizer(object):
            Return value changed to :class:`MinimizerResult`.
 
         """
-
         if not HAS_LEAST_SQUARES:
             raise NotImplementedError("SciPy with a version higher than 0.17 "
                                       "is needed for this method.")
@@ -1794,7 +1793,7 @@ def _make_random_gen(seed):
 VALID_NAN_POLICIES = ('propagate', 'omit', 'raise')
 def validate_nan_policy(policy):
     """validate, rationalize nan_policy, for back compatibility
-    and compatibility with Pandas missing convention
+    and compatibility with Pandas missing convention.
     """
     if policy in VALID_NAN_POLICIES:
         return policy

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -82,7 +82,7 @@ class Model(object):
             How to handle NaN and missing values in data. Must be one of
             'raise' (default), 'propagate', or 'omit'. See Note below.
         missing : str, optional
-            Synonym for 'nan_policy' for backward compatibility
+            Synonym for 'nan_policy' for backward compatibility.
         prefix : str, optional
             Prefix used for the model.
         name : str, optional
@@ -109,7 +109,7 @@ class Model(object):
            -  'omit' : (was 'drop') drop missing data.
 
         4. The `missing` argument is deprecated in lmfit 0.9.8 and will be
-        removed in a later version. Use `nan_policy instead, as it is
+        removed in a later version. Use `nan_policy` instead, as it is
         consistent with the Minimizer class.
 
 
@@ -618,7 +618,7 @@ class Model(object):
             Whether to print a message when a new parameter is added because
             of a hint (default is True).
         nan_policy : str, optional, one of 'raise' (default), 'propagate', or 'omit'.
-            What to do when encountering NaNs when fitting Model
+            What to do when encountering NaNs when fitting Model.
         fit_kws: dict, optional
             Options to pass to the minimizer being used.
         **kwargs: optional
@@ -907,7 +907,7 @@ class ModelResult(Minimizer):
         scale_covar : bool, optional
             Whether to scale covariance matrix for uncertainty evaluation.
         nan_policy : str, optional, one of 'raise' (default), 'propagate', or 'omit'.
-            What to do when encountering NaNs when fitting Model
+            What to do when encountering NaNs when fitting Model.
         **fit_kws : optional
             Keyword arguments to send to minimization routine.
         """
@@ -936,7 +936,7 @@ class ModelResult(Minimizer):
         method : str, optional
             Name of minimization method to use (default is `'leastsq'`).
         nan_policy : str, optional, one of 'raise' (default), 'propagate', or 'omit'.
-            What to do when encountering NaNs when fitting Model
+            What to do when encountering NaNs when fitting Model.
         **kwargs : optional
             Keyword arguments to send to minimization routine.
 
@@ -998,7 +998,7 @@ class ModelResult(Minimizer):
         params : Parameters, optional
             Parameters, defaults to ModelResult.params
         **kwargs : optional
-             Leyword arguments to pass to model function.
+             Keyword arguments to pass to model function.
 
         Returns
         -------

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -64,6 +64,7 @@ class Model(object):
     def __init__(self, func, independent_vars=None, param_names=None,
                  nan_policy='raise', missing=None, prefix='', name=None, **kws):
         """Create a model from a user-supplied model function.
+
         The model function will normally take an independent variable
         (generally, the first argument) and a series of arguments that are
         meant to be parameters for the model. It will return an array of
@@ -104,9 +105,9 @@ class Model(object):
 
            - 'raise' : Raise a ValueError (default)
 
-           - 'propagate' : do nothing.
+           - 'propagate' : do nothing
 
-           -  'omit' : (was 'drop') drop missing data.
+           -  'omit' : (was 'drop') drop missing data
 
         4. The `missing` argument is deprecated in lmfit 0.9.8 and will be
         removed in a later version. Use `nan_policy` instead, as it is
@@ -189,7 +190,7 @@ class Model(object):
         return self._param_names
 
     def __repr__(self):
-        """ Return representation of Model."""
+        """Return representation of Model."""
         return "<lmfit.Model: %s>" % (self.name)
 
     def copy(self, **kwargs):
@@ -288,7 +289,7 @@ class Model(object):
 
         Parameters
         ----------
-        name : string
+        name : str
             Parameter name.
 
         **kwargs : optional

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1,4 +1,4 @@
-"""TODO: module docstring."""
+"""Module containing built-in fitting models."""
 import numpy as np
 
 from . import lineshapes
@@ -123,8 +123,8 @@ class ConstantModel(Model):
     """Constant model, with a single Parameter: ``c``.
 
     Note that this is 'constant' in the sense of having no dependence on
-    the independent variable ``x``, not in the sense of being non-
-    varying. To be clear, ``c`` will be a Parameter that will be varied
+    the independent variable ``x``, not in the sense of being non-varying.
+    To be clear, ``c`` will be a Parameter that will be varied
     in the fit (by default, of course).
 
     """
@@ -282,8 +282,8 @@ class PolynomialModel(Model):
 
 
 class GaussianModel(Model):
-    r"""A model based on a Gaussian or normal distribution lineshape.
-    (see http://en.wikipedia.org/wiki/Normal_distribution), with three Parameters:
+    r"""A model based on a Gaussian or normal distribution lineshape (see
+    http://en.wikipedia.org/wiki/Normal_distribution), with three Parameters:
     ``amplitude``, ``center``, and ``sigma``.
     In addition, parameters ``fwhm`` and ``height`` are included as constraints
     to report full width at half maximum and maximum peak height, respectively.
@@ -358,9 +358,9 @@ class LorentzianModel(Model):
 
 class VoigtModel(Model):
     r"""A model based on a Voigt distribution function (see
-    http://en.wikipedia.org/wiki/Voigt_profile>), with four Parameters:
+    http://en.wikipedia.org/wiki/Voigt_profile), with four Parameters:
     ``amplitude``, ``center``, ``sigma``, and ``gamma``.  By default,
-    ``gamma`` is constrained to have value equal to ``sigma``, though it
+    ``gamma`` is constrained to have a value equal to ``sigma``, though it
     can be varied independently.  In addition, parameters ``fwhm`` and
     ``height`` are included as constraints to report full width at half
     maximum and maximum peak height, respectively.  The definition for the
@@ -380,7 +380,7 @@ class VoigtModel(Model):
             w(z) &=& e^{-z^2}{\operatorname{erfc}}(-iz)
         \end{eqnarray*}
 
-    and :func:`erfc` is the complimentary error function.  As above,
+    and :func:`erfc` is the complementary error function.  As above,
     ``amplitude`` corresponds to :math:`A`, ``center`` to
     :math:`\mu`, and ``sigma`` to :math:`\sigma`. The parameter ``gamma``
     corresponds  to :math:`\gamma`.
@@ -416,7 +416,7 @@ class VoigtModel(Model):
 class PseudoVoigtModel(Model):
     r"""A model based on a pseudo-Voigt distribution function
     (see http://en.wikipedia.org/wiki/Voigt_profile#Pseudo-Voigt_Approximation),
-    which is a weighted sum of a Gaussian and Lorentzian distribution functions
+    which is a weighted sum of a Gaussian and Lorentzian distribution function
     that share values for ``amplitude`` (:math:`A`), ``center`` (:math:`\mu`)
     and full width at half maximum ``fwhm`` (and so have  constrained values of
     ``sigma`` (:math:`\sigma`) and ``height`` (maximum peak height).
@@ -504,11 +504,11 @@ class Pearson7Model(Model):
 
         f(x; A, \mu, \sigma, m) = \frac{A}{\sigma{\beta(m-\frac{1}{2}, \frac{1}{2})}} \bigl[1 + \frac{(x-\mu)^2}{\sigma^2}  \bigr]^{-m}
 
-    where :math:`\beta` is the beta function (see :scipydoc:`special.beta` in
-    :mod:`scipy.special`).  The :meth:`guess` function always
-    gives a starting value for ``exponent`` of 1.5.  In addition, parameters
-    ``fwhm`` and ``height`` are included as constraints to report full width
-    at half maximum and maximum peak height, respectively.
+    where :math:`\beta` is the beta function (see :scipydoc:`special.beta`)
+    The :meth:`guess` function always gives a starting value for ``exponent``
+    of 1.5.  In addition, parameters ``fwhm`` and ``height`` are included as
+    constraints to report full width at half maximum and maximum peak height,
+    respectively.
 
     """
 
@@ -687,7 +687,7 @@ class ExponentialGaussianModel(Model):
         {\operatorname{erfc}}\Bigl(\frac{\mu + \gamma\sigma^2 - x}{\sqrt{2}\sigma}\Bigr)
 
 
-    where :func:`erfc` is the complimentary error function.
+    where :func:`erfc` is the complementary error function.
 
     """
 
@@ -769,7 +769,7 @@ class DonaichModel(Model):
 
 
 class PowerLawModel(Model):
-    r"""A model based on a Power Law (see http://en.wikipedia.org/wiki/Power_law>),
+    r"""A model based on a Power Law (see http://en.wikipedia.org/wiki/Power_law),
     with two Parameters: ``amplitude`` (:math:`A`), and ``exponent`` (:math:`k`), in:
 
     .. math::
@@ -951,7 +951,7 @@ class ExpressionModel(Model):
 
     def __init__(self, expr, independent_vars=None, init_script=None,
                  missing=None, **kws):
-        """Model from User-supplied expression.
+        """Generate a model from user-supplied expression.
 
         Parameters
         ----------

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -190,7 +190,7 @@ class LinearModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(LinearModel, self).__init__(linear, **kwargs)
@@ -218,7 +218,7 @@ class QuadraticModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(QuadraticModel, self).__init__(parabolic, **kwargs)
@@ -253,8 +253,8 @@ class PolynomialModel(Model):
     MAX_DEGREE = 7
     DEGREE_ERR = "degree must be an integer less than %d."
 
-    def __init__(self, degree, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+    def __init__(self, degree, independent_vars=['x'], prefix='',
+                 missing=None, **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         if not isinstance(degree, int) or degree > self.MAX_DEGREE:
@@ -303,7 +303,7 @@ class GaussianModel(Model):
     height_factor = 1./np.sqrt(2*np.pi)
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(GaussianModel, self).__init__(gaussian, **kwargs)
@@ -340,7 +340,7 @@ class LorentzianModel(Model):
     height_factor = 1./np.pi
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(LorentzianModel, self).__init__(lorentzian, **kwargs)
@@ -392,7 +392,7 @@ class VoigtModel(Model):
     fwhm_factor = 3.60131
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(VoigtModel, self).__init__(voigt, **kwargs)
@@ -438,7 +438,7 @@ class PseudoVoigtModel(Model):
     fwhm_factor = 2.0
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(PseudoVoigtModel, self).__init__(pvoigt, **kwargs)
@@ -478,7 +478,7 @@ class MoffatModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(MoffatModel, self).__init__(moffat, **kwargs)
@@ -515,7 +515,7 @@ class Pearson7Model(Model):
     fwhm_factor = 1.0
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(Pearson7Model, self).__init__(pearson7, **kwargs)
@@ -550,7 +550,7 @@ class StudentsTModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(StudentsTModel, self).__init__(students_t, **kwargs)
@@ -576,7 +576,7 @@ class BreitWignerModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(BreitWignerModel, self).__init__(breit_wigner, **kwargs)
@@ -603,7 +603,7 @@ class LognormalModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(LognormalModel, self).__init__(lognormal, **kwargs)
@@ -630,7 +630,7 @@ class DampedOscillatorModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(DampedOscillatorModel, self).__init__(damped_oscillator, **kwargs)
@@ -659,7 +659,7 @@ class DampedHarmonicOscillatorModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(DampedHarmonicOscillatorModel, self).__init__(dho,  **kwargs)
@@ -692,7 +692,7 @@ class ExponentialGaussianModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(ExponentialGaussianModel, self).__init__(expgaussian, **kwargs)
@@ -726,7 +726,7 @@ class SkewedGaussianModel(Model):
     fwhm_factor = 2.354820
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(SkewedGaussianModel, self).__init__(skewed_gaussian,  **kwargs)
@@ -755,7 +755,7 @@ class DonaichModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(DonaichModel, self).__init__(donaich,  **kwargs)
@@ -779,7 +779,7 @@ class PowerLawModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(PowerLawModel, self).__init__(powerlaw, **kwargs)
@@ -809,7 +809,7 @@ class ExponentialModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
+                 **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing,
                        'independent_vars': independent_vars})
         super(ExponentialModel, self).__init__(exponential, **kwargs)
@@ -857,7 +857,7 @@ class StepModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 form='linear', name=None, **kwargs):
+                 form='linear', **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing, 'form': form,
                        'independent_vars': independent_vars})
         super(StepModel, self).__init__(step, **kwargs)
@@ -913,7 +913,7 @@ class RectangleModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 form='linear', name=None, **kwargs):
+                 form='linear', **kwargs):
         kwargs.update({'prefix': prefix, 'missing': missing, 'form': form,
                        'independent_vars': independent_vars})
         super(RectangleModel, self).__init__(rectangle, **kwargs)

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -978,7 +978,9 @@ class ExpressionModel(Model):
         -----
         1. each instance of ExpressionModel will create and using its own
            version of an asteval interpreter.
-        2. prefix is **not supported** for ExpressionModel
+
+        2. prefix is **not supported** for ExpressionModel.
+
         3. nan_policy sets what to do when a NaN or missing value is seen in
         the data. Should be one of:
 
@@ -988,6 +990,7 @@ class ExpressionModel(Model):
 
         4. The `missing` argument is deprecated in lmfit 0.9.8 and will be
         removed in a later version. Use `nan_policy` instead, as it is
+        consistent with the Minimizer class.
 
         """
         # create ast evaluator, load custom functions

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -129,9 +129,9 @@ class ConstantModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
 
         def constant(x, c=0.0):
@@ -157,9 +157,9 @@ class ComplexConstantModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  name=None,  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
 
         def constant(x, re=0., im=0.):
@@ -189,9 +189,9 @@ class LinearModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(LinearModel, self).__init__(linear, **kwargs)
 
@@ -217,9 +217,9 @@ class QuadraticModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(QuadraticModel, self).__init__(parabolic, **kwargs)
 
@@ -254,8 +254,8 @@ class PolynomialModel(Model):
     DEGREE_ERR = "degree must be an integer less than %d."
 
     def __init__(self, degree, independent_vars=['x'], prefix='',
-                 missing=None, **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+                 nan_policy='raise', **kwargs):
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         if not isinstance(degree, int) or degree > self.MAX_DEGREE:
             raise TypeError(self.DEGREE_ERR % self.MAX_DEGREE)
@@ -302,9 +302,9 @@ class GaussianModel(Model):
     fwhm_factor = 2.354820
     height_factor = 1./np.sqrt(2*np.pi)
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(GaussianModel, self).__init__(gaussian, **kwargs)
         self.set_param_hint('sigma', min=0)
@@ -339,9 +339,9 @@ class LorentzianModel(Model):
     fwhm_factor = 2.0
     height_factor = 1./np.pi
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(LorentzianModel, self).__init__(lorentzian, **kwargs)
         self.set_param_hint('sigma', min=0)
@@ -391,9 +391,9 @@ class VoigtModel(Model):
 
     fwhm_factor = 3.60131
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(VoigtModel, self).__init__(voigt, **kwargs)
         self.set_param_hint('sigma', min=0)
@@ -437,9 +437,9 @@ class PseudoVoigtModel(Model):
 
     fwhm_factor = 2.0
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(PseudoVoigtModel, self).__init__(pvoigt, **kwargs)
         self.set_param_hint('sigma', min=0)
@@ -477,9 +477,9 @@ class MoffatModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(MoffatModel, self).__init__(moffat, **kwargs)
         self.set_param_hint('sigma', min=0)
@@ -514,9 +514,9 @@ class Pearson7Model(Model):
 
     fwhm_factor = 1.0
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(Pearson7Model, self).__init__(pearson7, **kwargs)
         self.set_param_hint('expon', value=1.5, max=100)
@@ -549,9 +549,9 @@ class StudentsTModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(StudentsTModel, self).__init__(students_t, **kwargs)
 
@@ -575,9 +575,9 @@ class BreitWignerModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(BreitWignerModel, self).__init__(breit_wigner, **kwargs)
 
@@ -602,9 +602,9 @@ class LognormalModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(LognormalModel, self).__init__(lognormal, **kwargs)
 
@@ -629,9 +629,9 @@ class DampedOscillatorModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(DampedOscillatorModel, self).__init__(damped_oscillator, **kwargs)
 
@@ -658,9 +658,9 @@ class DampedHarmonicOscillatorModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(DampedHarmonicOscillatorModel, self).__init__(dho,  **kwargs)
 
@@ -691,9 +691,9 @@ class ExponentialGaussianModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(ExponentialGaussianModel, self).__init__(expgaussian, **kwargs)
 
@@ -725,9 +725,9 @@ class SkewedGaussianModel(Model):
 
     fwhm_factor = 2.354820
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(SkewedGaussianModel, self).__init__(skewed_gaussian,  **kwargs)
         self.set_param_hint('sigma', min=0)
@@ -754,9 +754,9 @@ class DonaichModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(DonaichModel, self).__init__(donaich,  **kwargs)
 
@@ -778,9 +778,9 @@ class PowerLawModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(PowerLawModel, self).__init__(powerlaw, **kwargs)
 
@@ -808,9 +808,9 @@ class ExponentialModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(ExponentialModel, self).__init__(exponential, **kwargs)
 
@@ -856,10 +856,10 @@ class StepModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  form='linear', **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing, 'form': form,
-                       'independent_vars': independent_vars})
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
+                       'form': form, 'independent_vars': independent_vars})
         super(StepModel, self).__init__(step, **kwargs)
 
     def guess(self, data, x=None, **kwargs):
@@ -912,10 +912,10 @@ class RectangleModel(Model):
 
     """
 
-    def __init__(self, independent_vars=['x'], prefix='', missing=None,
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  form='linear', **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing, 'form': form,
-                       'independent_vars': independent_vars})
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
+                       'form': form, 'independent_vars': independent_vars})
         super(RectangleModel, self).__init__(rectangle, **kwargs)
 
         self.set_param_hint('center1')
@@ -947,7 +947,7 @@ class ExpressionModel(Model):
     no_prefix = "ExpressionModel does not support `prefix` argument"
 
     def __init__(self, expr, independent_vars=None, init_script=None,
-                 missing=None, **kws):
+                 nan_policy='raise', **kws):
         """Generate a model from user-supplied expression.
 
         Parameters
@@ -1026,7 +1026,7 @@ class ExpressionModel(Model):
                 self.asteval.symtable[name] = val
             return self.asteval.run(self.astcode)
 
-        kws["missing"] = missing
+        kws["nan_policy"] = nan_policy
 
         super(ExpressionModel, self).__init__(_eval, **kws)
 

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -565,7 +565,7 @@ class StudentsTModel(Model):
 
 class BreitWignerModel(Model):
     r"""A model based on a Breit-Wigner-Fano function (see
-    http://en.wikipedia.org/wiki/Fano_resonance>), with four Parameters:
+    http://en.wikipedia.org/wiki/Fano_resonance), with four Parameters:
     ``amplitude`` (:math:`A`), ``center`` (:math:`\mu`),
     ``sigma`` (:math:`\sigma`), and ``q`` (:math:`q`) in
 

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -829,20 +829,18 @@ class ExponentialModel(Model):
 
 class StepModel(Model):
     r"""A model based on a Step function, with three Parameters:
-    ``amplitude`` (:math:`A`), ``center`` (:math:`\mu`) and ``sigma`` (:math:`\sigma`)
-    and four choices for functional form:
+    ``amplitude`` (:math:`A`), ``center`` (:math:`\mu`) and ``sigma`` (:math:`\sigma`).
+
+    There are four choices for ``form``:
 
     - ``linear`` (the default)
-
     - ``atan`` or ``arctan`` for an arc-tangent function
-
     - ``erf`` for an error function
-
-    - ``logistic`` for a logistic function (see http://en.wikipedia.org/wiki/Logistic_function).
+    - ``logistic`` for a logistic function (see http://en.wikipedia.org/wiki/Logistic_function)
 
     The step function starts with a value 0, and ends with a value of
     :math:`A` rising to :math:`A/2` at :math:`\mu`, with :math:`\sigma`
-    setting the characteristic width. The forms are
+    setting the characteristic width. The functional forms are defined as:
 
     .. math::
         :nowrap:
@@ -859,8 +857,8 @@ class StepModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+                 form='linear', name=None, **kwargs):
+        kwargs.update({'prefix': prefix, 'missing': missing, 'form': form,
                        'independent_vars': independent_vars})
         super(StepModel, self).__init__(step, **kwargs)
 
@@ -882,22 +880,21 @@ class RectangleModel(Model):
     r"""A model based on a Step-up and Step-down function, with five
     Parameters: ``amplitude`` (:math:`A`), ``center1`` (:math:`\mu_1`),
     ``center2`` (:math:`\mu_2`), `sigma1`` (:math:`\sigma_1`) and
-    ``sigma2`` (:math:`\sigma_2`) and four choices for functional form
-    (which is used for both the Step up and the Step down:
+    ``sigma2`` (:math:`\sigma_2`).
+
+    There are four choices for ``form``, which is used for both the Step up
+    and the Step down:
 
     - ``linear`` (the default)
-
     - ``atan`` or ``arctan`` for an arc-tangent function
-
     - ``erf`` for an error function
-
-    - ``logistic`` for a logistic function (see http://en.wikipedia.org/wiki/Logistic_function).
+    - ``logistic`` for a logistic function (see http://en.wikipedia.org/wiki/Logistic_function)
 
     The function starts with a value 0, transitions to a value of
     :math:`A`, taking the value :math:`A/2` at :math:`\mu_1`, with :math:`\sigma_1`
     setting the characteristic width. The function then transitions again to
     the value :math:`A/2` at :math:`\mu_2`, with :math:`\sigma_2` setting the
-    characteristic width. The forms are
+    characteristic width. The functional forms are defined as:
 
     .. math::
         :nowrap:
@@ -916,8 +913,8 @@ class RectangleModel(Model):
     """
 
     def __init__(self, independent_vars=['x'], prefix='', missing=None,
-                 name=None,  **kwargs):
-        kwargs.update({'prefix': prefix, 'missing': missing,
+                 form='linear', name=None, **kwargs):
+        kwargs.update({'prefix': prefix, 'missing': missing, 'form': form,
                        'independent_vars': independent_vars})
         super(RectangleModel, self).__init__(rectangle, **kwargs)
 

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -81,23 +81,31 @@ def update_param_vals(pars, prefix, **kwargs):
 COMMON_INIT_DOC = """
     Parameters
     ----------
-    independent_vars: ['x']
+    independent_vars : ['x']
         Arguments to func that are independent variables.
-    prefix: string, optional
-       String to prepend to parameter names, needed to add two Models that
-       have parameter names in common.
-    missing:  str or None, optional
-        How to handle NaN and missing values in data. One of:
-
-        - 'none' or None: Do not check for null or missing values (default).
-
-        - 'drop': Drop null or missing observations in data. if pandas is
-          installed, `pandas.isnull` is used, otherwise `numpy.isnan` is used.
-
-        - 'raise': Raise a (more helpful) exception when data contains null
-          or missing values.
+    prefix : str, optional
+        String to prepend to parameter names, needed to add two Models that
+        have parameter names in common.
+    nan_policy : str, optional
+        How to handle NaN and missing values in data. Must be one of:
+        'raise' (default), 'propagate', or 'omit'. See Notes below.
+    missing : str, optional
+        Synonym for 'nan_policy' for backward compatibility.
     **kwargs : optional
         Keyword arguments to pass to :class:`Model`.
+
+    Notes
+    -----
+    1. nan_policy sets what to do when a NaN or missing value is seen in the
+    data. Should be one of:
+
+        - 'raise' : Raise a ValueError (default)
+        - 'propagate' : do nothing
+        - 'omit' : (was 'drop') drop missing data
+
+    2. The `missing` argument is deprecated in lmfit 0.9.8 and will be
+    removed in a later version. Use `nan_policy` instead, as it is
+    consistent with the Minimizer class.
 
     """
 
@@ -954,21 +962,15 @@ class ExpressionModel(Model):
         ----------
         expr : str
             Mathematical expression for model.
-        independent_vars : list of strings or None, optional
+        independent_vars : list of str or None, optional
             Variable names to use as independent variables.
-        init_script : string or None, optional
+        init_script : str or None, optional
             Initial script to run in asteval interpreter.
-        missing : str or None, optional
-            How to handle NaN and missing values in data. One of:
-
-            - 'none' or None: Do not check for null or missing values (default).
-
-            - 'drop': Drop null or missing observations in data. if pandas is
-              installed, `pandas.isnull` is used, otherwise `numpy.isnan` is used.
-
-            - 'raise': Raise a (more helpful) exception when data contains null
-              or missing values.
-
+        nan_policy : str, optional
+            How to handle NaN and missing values in data. Must be one of:
+            'raise' (default), 'propagate', or 'omit'. See Notes below.
+        missing : str, optional
+            Synonym for 'nan_policy' for backward compatibility.
         **kws : optional
             Keyword arguments to pass to :class:`Model`.
 
@@ -977,6 +979,15 @@ class ExpressionModel(Model):
         1. each instance of ExpressionModel will create and using its own
            version of an asteval interpreter.
         2. prefix is **not supported** for ExpressionModel
+        3. nan_policy sets what to do when a NaN or missing value is seen in
+        the data. Should be one of:
+
+            - 'raise' : Raise a ValueError (default)
+            - 'propagate' : do nothing
+            - 'omit' : (was 'drop') drop missing data
+
+        4. The `missing` argument is deprecated in lmfit 0.9.8 and will be
+        removed in a later version. Use `nan_policy` instead, as it is
 
         """
         # create ast evaluator, load custom functions

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -356,13 +356,13 @@ class Parameters(OrderedDict):
         --------
         >>>  params = Parameters()
         # add with tuples: (NAME VALUE VARY MIN  MAX  EXPR  BRUTE_STEP)
-        >>> params.add_many(('amp',   10, True, None, None, None, None),
-        ...                 ('cen',   4, True,  0.0, None, None, None),
-        ...                 ('wid',   1, False, None, None, None, None),
+        >>> params.add_many(('amp', 10, True, None, None, None, None),
+        ...                 ('cen', 4, True, 0.0, None, None, None),
+        ...                 ('wid', 1, False, None, None, None, None),
         ...                 ('frac', 0.5))
         # add a sequence of Parameters
         >>> f = Parameter('par_f', 100)
-        >>> g = Parameter('par_g',  2.)
+        >>> g = Parameter('par_g', 2.)
         >>> params.add_many(f, g)
 
         """

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -330,6 +330,10 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
             set_prefix_failed = None
         self.assertTrue(set_prefix_failed)
 
+    def test_model_name(self):
+        # test setting the name for built-in models
+        mod = models.GaussianModel(name='user_name')
+        self.assertEqual(mod.name, "Model(user_name)")
 
     def test_sum_of_two_gaussians(self):
         # two user-defined gaussians


### PR DESCRIPTION
In addition to #432, there were examples in the documentation that didn't work or where the output was -slightly- different with the current version of lmfit. In this PR, there are additional updates to the documentation and docstrings.

A few things that I am a bit confused about and that probably should be resolved in this PR before merging are the following:

In ```models.py``` in the ```__init__``` there is parameter ```name``` for most model classes, which therefore also shows up in the documentation. It seems to me however, that this will never be used as it is not updated in ```kwargs```. If that's indeed the case, should we just remove this?

In addition, all the models still use ```missing```, which is according to the documentation set to None - however it seems to me that with #424 that's not the case anymore. It will be set to ```raise``` if I am not mistaken (should we add here the new, and suggested ```nan_policy```?).

Finally, in StepModel and RectangleModel one should be able to specify ```form```, this doesn't show up in the call signature of the class in the documentation. I am not sure how to change this properly... 