### PR TITLE
update configuration for Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,14 @@ sudo: false
 
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
     - 3.6
 
-# test minium required and current version of scipy
+# test minium required and latest versions of SciPy and NumPy
 env:
-    - SCIPY_VERSION=0.15
-    - SCIPY_VERSION=0.19
-
-matrix:
-    exclude:
-        -  python: 3.3
-           env: SCIPY_VERSION=0.19
-        -  python: 3.4
-           env: SCIPY_VERSION=0.19
-        -  python: 3.5
-           env: SCIPY_VERSION=0.15
-        -  python: 3.6
-           env: SCIPY_VERSION=0.15
+    - version=minimum  # SciPy>=0.17 NumPy>=1.10
+    - version=latest
 
 before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -36,12 +24,13 @@ before_install:
     - conda info -a
 
 install:
-    - if [[ $SCIPY_VERSION == 0.15 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy=$SCIPY_VERSION libgfortran=1 pandas matplotlib nose; fi
-    - if [[ $SCIPY_VERSION != 0.15 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy=$SCIPY_VERSION pandas matplotlib nose; fi
+    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION != 3.6 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy=1.10 scipy=0.17 six=1.10 nose; fi
+    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION == 3.6 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy=1.11 scipy=0.18 six=1.10 nose; fi
+    - if [[ $version == latest ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy six pandas matplotlib dill nose; fi
     - source activate test_env
-    - conda install dill pytest six
     - pip install emcee
     - python setup.py install
+    - conda list
 
 script:
     - cd tests

--- a/INSTALL
+++ b/INSTALL
@@ -6,11 +6,11 @@ To install the lmfit python module, use::
    python setup.py build
    python setup.py install
 
-For lmfit 0.9.7, the following versions are required:
-  Python: 2.7, 3.3, 3.4, 3.5, or 3.6
-  NumPy: 1.9.1 or higher
-  SciPy: 0.15 or higher
+For lmfit 0.9.8, the following versions are required:
+  Python: 2.7, 3.4, 3.5, or 3.6
+  NumPy: 1.10 or higher
+  SciPy: 0.17 or higher
   six: 1.10 or higher
 
 Matt Newville <newville@cars.uchicago.edu>
-Last Update:  2017-October-30
+Last Update: 2017-November-19

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -12,28 +12,29 @@ Downloading and Installation
 .. _pandas:  http://pandas.pydata.org/
 .. _jupyter:  http://jupyter.org/
 .. _matplotlib:  http://matplotlib.org/
+.. _dill:  https://github.com/uqfoundation/dill
 
 Prerequisites
 ~~~~~~~~~~~~~~~
 
 The lmfit package requires `Python`_, `NumPy`_, and `SciPy`_.
 
-Lmfit works with Python versions 2.7, 3.3, 3.4, 3.5, and 3.6. Support for Python 2.6
-ended with lmfit version 0.9.4.  Scipy version 0.15 or higher is required,
-with 0.17 or higher recommended to be able to use the latest optimization
-features.  NumPy version 1.9.1 or higher is required.
+Lmfit works with Python versions 2.7, 3.4, 3.5, and 3.6. Support for Python 2.6
+and 3.3 ended with lmfit versions 0.9.4 and 0.9.8, respectively. Scipy version
+0.17 or higher, NumPy version 1.10 or higher, and six version 1.10 or higher are
+required.
 
 In order to run the test suite, either the `nose`_ or `pytest`_ package is
-required.  Some functionality of lmfit requires the `emcee`_ package, some
-functionality will make use of the `pandas`_, `Jupyter`_ or `matplotlib`_
-packages if available.  We highly recommend each of these
+required. Some functionality of lmfit requires the `emcee`_ package, some
+functionality will make use of the `pandas`_, `Jupyter`_, `matplotlib`_,
+or `dill`_ packages if available.  We highly recommend each of these
 packages.
 
 
 Downloads
 ~~~~~~~~~~~~~
 
-The latest stable version of lmfit is |release| is available from `PyPi
+The latest stable version of lmfit is |release| and is available from `PyPi
 <http://pypi.python.org/pypi/lmfit/>`_.
 
 Installation

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -25,6 +25,7 @@ from numpy.dual import inv
 from numpy.linalg import LinAlgError
 from scipy.optimize import brute as scipy_brute
 from scipy.optimize import leastsq as scipy_leastsq
+from scipy.optimize import least_squares
 from scipy.optimize import minimize as scipy_minimize
 from scipy.optimize import differential_evolution
 from scipy.stats import cauchy as cauchy_dist
@@ -41,20 +42,12 @@ from . import uncertainties
 from .parameter import Parameter, Parameters
 
 #  scipy version notes:
-#  currently scipy 0.15 is required.
+#  currently scipy 0.17 is required.
 #  feature           scipy version added
 #    minimize              0.11
 #    OptimizeResult        0.13
 #    diff_evolution        0.15
 #    least_squares         0.17
-
-# check for scipy.opitimize.least_squares
-HAS_LEAST_SQUARES = False
-try:
-    from scipy.optimize import least_squares
-    HAS_LEAST_SQUARES = True
-except ImportError:
-    pass
 
 # check for EMCEE
 HAS_EMCEE = False
@@ -1203,10 +1196,6 @@ class Minimizer(object):
            Return value changed to :class:`MinimizerResult`.
 
         """
-        if not HAS_LEAST_SQUARES:
-            raise NotImplementedError("SciPy with a version higher than 0.17 "
-                                      "is needed for this method.")
-
         result = self.prepare_fit(params)
         result.method = 'least_squares'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 six>1.10
-numpy>=1.9.1
-scipy>=0.15.1
+numpy>=1.10
+scipy>=0.17

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ import versioneer
 # Minimal Python version sanity check
 # taken from the Jupyter Notebook setup.py -- Modified BSD License
 v = sys.version_info
-if v[:2] < (2, 7) or (v[0] >= 3 and v[:2] < (3, 3)):
-    error = "ERROR: lmfit requires Python version 2.7 or 3.3 or above."
+if v[:2] < (2, 7) or (v[0] >= 3 and v[:2] < (3, 4)):
+    error = "ERROR: lmfit requires Python version 2.7 or 3.4 or above."
     print(error, file=sys.stderr)
     sys.exit(1)
 

--- a/tests/test_least_squares.py
+++ b/tests/test_least_squares.py
@@ -1,13 +1,10 @@
 from lmfit import Parameters, minimize, fit_report, Minimizer
-from lmfit.minimizer import HAS_LEAST_SQUARES
 from lmfit_testutils import assert_paramval, assert_paramattr
 
 from numpy import linspace, zeros, sin, exp, random, pi, sign
 import nose
 
 def test_bounds():
-    if not HAS_LEAST_SQUARES:
-        raise nose.SkipTest
     p_true = Parameters()
     p_true.add('amp', value=14.0)
     p_true.add('period', value=5.4321)


### PR DESCRIPTION
The commit in this PR does the following:

* remove testing for Python 3.3, which reached EOL

* test for current versions of SciPy/NumPy for all Python versions
This will install the latest version of scipy/numpy available in conda for a certain Python version. Currently, it uses numpy 1.13.3 and scipy 1.0.0 (PY27, PY35 and PY36) and numpy 1.11.3 and scipy 0.18.1 fo PY34.

* test for minimum required SciPy/NumPy for Python 2.7 and latest Python 3 version
To limit the number of builds I think it should be sufficient to test the minimum required version of numpy/scipy with PY27 and -ideally- the latest PY3 release. For PY27 we can do both builds with the minimum scipy/numpy versions, but for PY36 the requirements can only be satisfied for numpy. Therefore, the minimum scipy version is tested with PY34.