### PR TITLE
fix to dho() model, uniform "tiny" value for lineshapes

### DIFF
--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -10,6 +10,7 @@ log2 = log(2)
 s2pi = sqrt(2*pi)
 spi = sqrt(pi)
 s2 = sqrt(2.0)
+tiny = 1.e-13
 
 functions = ('gaussian', 'lorentzian', 'voigt', 'pvoigt', 'moffat', 'pearson7',
              'breit_wigner', 'damped_oscillator', 'dho', 'logistic', 'lognormal',
@@ -119,7 +120,7 @@ def damped_oscillator(x, amplitude=1.0, center=1., sigma=0.1):
         amplitude/sqrt( (1.0 - (x/center)**2)**2 + (2*sigma*x/center)**2))
 
     """
-    center = max(1.e-9, abs(center))
+    center = max(tiny, abs(center))
     return amplitude/sqrt((1.0 - (x/center)**2)**2 + (2*sigma*x/center)**2)
 
 
@@ -128,18 +129,18 @@ def dho(x, amplitude=1., center=0., sigma=1., gamma=1.0):
 
     Similar to version from PAN
     dho(x, amplitude, center, sigma, gamma) =
-        (amplitude*sigma*(bose/pi)* (lm - lp)
+        amplitude*sigma*pi * (lm - lp) / (1.0 - exp(-x/gamma))
 
     where
-        bose(x, gamma) =  1.0/ (1.0 - exp(-x/gamma))
         lm(x, center, sigma) = 1.0 / ((x-center)**2 + sigma**2)
         lp(x, center, sigma) = 1.0 / ((x+center)**2 + sigma**2)
 
     """
-    bose = 1.0/(1.0 - exp(-x/gamma))
+    bose = (1.0 - exp(-x/gamma))
+    bose[where(bose<tiny)] = tiny
     lm = 1.0/((x-center)**2 + sigma**2)
     lp = 1.0/((x+center)**2 + sigma**2)
-    return amplitude*sigma*pi*bose*(lm - lp)
+    return amplitude*sigma*pi*(lm - lp)/bose
 
 
 def logistic(x, amplitude=1., center=0., sigma=1.):
@@ -159,7 +160,7 @@ def lognormal(x, amplitude=1.0, center=0., sigma=1):
         = (amplitude/x) * exp(-(ln(x) - center)/ (2* sigma**2))
 
     """
-    x[where(x <= 1.e-19)] = 1.e-19
+    x[where(x <= tiny)] = tiny
     return (amplitude/(x*sigma*s2pi)) * exp(-(log(x)-center)**2 / (2*sigma**2))
 
 
@@ -275,8 +276,8 @@ def step(x, amplitude=1.0, center=0.0, sigma=1.0, form='linear'):
     where arg = (x - center)/sigma
 
     """
-    if abs(sigma) < 1.e-13:
-        sigma = 1.e-13
+    if abs(sigma) < tiny:
+        sigma = tiny
 
     out = (x - center)/sigma
     if form == 'erf':
@@ -307,10 +308,10 @@ def rectangle(x, amplitude=1.0, center1=0.0, sigma1=1.0,
     and   arg2 = -(x - center2)/sigma2
 
     """
-    if abs(sigma1) < 1.e-13:
-        sigma1 = 1.e-13
-    if abs(sigma2) < 1.e-13:
-        sigma2 = 1.e-13
+    if abs(sigma1) < tiny:
+        sigma1 = tiny
+    if abs(sigma2) < tiny:
+        sigma2 = tiny
 
     arg1 = (x - center1)/sigma1
     arg2 = (center2 - x)/sigma2


### PR DESCRIPTION
some simple fixes to dho() lineshape to avoid NaNs.   Also unifies the value used for "tiny" used to avoid divide-by-zero and related floating point errors.