### PR TITLE
set minimum on tau in expmodel to prevent overflow

### DIFF
--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -904,7 +904,7 @@ class ExponentialModel(Model):
         kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(ExponentialModel, self).__init__(exponential, **kwargs)
-        self.set_param_hint('decay', min=-15)
+        self.set_param_hint('decay', min=0)
 
     def guess(self, data, x=None, **kwargs):
         try:

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -904,6 +904,7 @@ class ExponentialModel(Model):
         kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
         super(ExponentialModel, self).__init__(exponential, **kwargs)
+        self.set_param_hint('decay', min=-15)
 
     def guess(self, data, x=None, **kwargs):
         try:


### PR DESCRIPTION
Ran into this today. Thought I would send along. At tau min = -20 it errs with my data but -15 seems ok. 