### PR TITLE
Evaluate uncertainty for arbitrary independent variable value

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1305,9 +1305,9 @@ class ModelResult(Minimizer):
 
         nvarys = self.nvarys
         # ensure fjac and df2 are correct size if independent var updated by kwargs
-        ndata = userkws[self.model.independent_vars[0]].size
+        ndata = self.model.eval(self.params, **userkws).size
         covar = self.covar / self.redchi
-        fjac = np.zeros(ndata*nvarys).reshape((nvarys, ndata))
+        fjac = np.zeros((nvarys, ndata))
         df2 = np.zeros(ndata)
 
         # find derivative by hand!

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1306,7 +1306,7 @@ class ModelResult(Minimizer):
         nvarys = self.nvarys
         # ensure fjac and df2 are correct size if independent var updated by kwargs
         ndata = self.model.eval(self.params, **userkws).size
-        covar = self.covar / self.redchi
+        covar = self.covar
         fjac = np.zeros((nvarys, ndata))
         df2 = np.zeros(ndata)
 
@@ -1334,7 +1334,7 @@ class ModelResult(Minimizer):
             prob = sigma
         else:
             prob = erf(sigma/np.sqrt(2))
-        return np.sqrt(df2*self.redchi) * t.ppf((prob+1)/2.0, self.ndata-nvarys)
+        return np.sqrt(df2) * t.ppf((prob+1)/2.0, self.ndata-nvarys)
 
     def conf_interval(self, **kwargs):
         """Calculate the confidence intervals for the variable parameters.

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1298,28 +1298,30 @@ class ModelResult(Minimizer):
            give the same results, within precision errors.
 
         """
-        self.userkws.update(kwargs)
+        userkws = self.userkws.copy()
+        userkws.update(kwargs)
         if params is None:
             params = self.params
 
         nvarys = self.nvarys
-        ndata = self.ndata
+        # ensure fjac and df2 are correct size if independent var updated by kwargs
+        ndata = userkws[self.model.independent_vars[0]].size
         covar = self.covar / self.redchi
         fjac = np.zeros(ndata*nvarys).reshape((nvarys, ndata))
         df2 = np.zeros(ndata)
 
         # find derivative by hand!
+        pars = self.params.copy()
         for i in range(nvarys):
             pname = self.var_names[i]
-            pars = self.params
             val0 = pars[pname].value
             dval = pars[pname].stderr/3.0
 
             pars[pname].value = val0 + dval
-            res1 = self.model.eval(pars, **self.userkws)
+            res1 = self.model.eval(pars, **userkws)
 
             pars[pname].value = val0 - dval
-            res2 = self.model.eval(pars, **self.userkws)
+            res2 = self.model.eval(pars, **userkws)
 
             pars[pname].value = val0
             fjac[i] = (res1 - res2) / (2*dval)
@@ -1332,7 +1334,7 @@ class ModelResult(Minimizer):
             prob = sigma
         else:
             prob = erf(sigma/np.sqrt(2))
-        return np.sqrt(df2*self.redchi) * t.ppf((prob+1)/2.0, ndata-nvarys)
+        return np.sqrt(df2*self.redchi) * t.ppf((prob+1)/2.0, self.ndata-nvarys)
 
     def conf_interval(self, **kwargs):
         """Calculate the confidence intervals for the variable parameters.


### PR DESCRIPTION
Hello, new contributor here.
I've extended the `eval_uncertainty` method in the `ModelResult` class to permit changes to the independent variables. The purpose is to be able to evaluate the uncertainty (confidence band) for the model at arbitrary values of the independent variable. Previously, only uncertainties at the original independent variable values would be evaluated.

Detailed changes:
* don't overwrite ModelResult.userkws
* ensure fjac ad df2 are correct size if independent variable is updated
* ensure original ModelResult.ndata is not changed for computing t.pp
