### PR TITLE
tests/test_height_fwhm.py, tests/test_saveload.py: use absolute paths

### DIFF
--- a/tests/test_height_fwhm.py
+++ b/tests/test_height_fwhm.py
@@ -8,6 +8,7 @@ from scipy.stats import norm
 from scipy.optimize import fsolve
 import sys
 
+import os
 
 # Turn off plotting if run by nosetests.
 WITHPLOT = True
@@ -76,7 +77,7 @@ def test_peak_like():
     # sigma = np.sqrt(variance)
     # x = np.linspace(mu - 20*sigma, mu + 20*sigma, 100.0)
     # y = norm.pdf(x, mu, 1)
-    data = np.loadtxt('../examples/test_peak.dat')
+    data = np.loadtxt(os.path.join(os.path.dirname(__file__), '..', 'examples', 'test_peak.dat'))
     x = data[:, 0]
     y = data[:, 1]
     check_height_fwhm(x, y, lineshapes.voigt, models.VoigtModel())

--- a/tests/test_saveload.py
+++ b/tests/test_saveload.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     DILL_AVAILABLE = False
 
-dat = np.loadtxt(os.path.join('..', 'examples', 'NIST_Gauss2.dat'))
+dat = np.loadtxt(os.path.join(os.path.dirname(__file__), '..', 'examples', 'NIST_Gauss2.dat'))
 XDAT = dat[:, 1]
 YDAT = dat[:, 0]
 


### PR DESCRIPTION
The testsuite fails (on my box), because numpy does not find the example data referenced by relative paths.
```
.................................../home/erich/eigeneSkripte/archPackages/python-lmfit/src/lmfit-py-0.9.8/lmfit/minimizer.py:1563: RuntimeWarning: invalid value encountered in log
  _neg2_log_likel = result.ndata * np.log(result.chisqr / result.ndata)
......E......S.........SS....S...S..........S.........S.........S.........S.........S.........S.............S.........................................capi_return is NULL
Call-back cb_calcfc_in__cobyla__user__routines failed.
.......................E..
======================================================================
ERROR: test_height_fwhm.test_peak_like
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/erich/eigeneSkripte/archPackages/python-lmfit/src/lmfit-py-0.9.8/tests/test_height_fwhm.py", line 79, in test_peak_like
    data = np.loadtxt('../examples/test_peak.dat')
  File "/usr/lib/python3.6/site-packages/numpy/lib/npyio.py", line 917, in loadtxt
    fh = np.lib._datasource.open(fname, 'rt', encoding=encoding)
  File "/usr/lib/python3.6/site-packages/numpy/lib/_datasource.py", line 260, in open
    return ds.open(path, mode, encoding=encoding, newline=newline)
  File "/usr/lib/python3.6/site-packages/numpy/lib/_datasource.py", line 614, in open
    encoding=encoding, newline=newline)
FileNotFoundError: [Errno 2] No such file or directory: '../examples/test_peak.dat'

======================================================================
ERROR: Failure: FileNotFoundError ([Errno 2] No such file or directory: '../examples/NIST_Gauss2.dat')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/usr/lib/python3.6/site-packages/nose/loader.py", line 417, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python3.6/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python3.6/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/usr/lib/python3.6/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib/python3.6/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/erich/eigeneSkripte/archPackages/python-lmfit/src/lmfit-py-0.9.8/tests/test_saveload.py", line 17, in <module>
    dat = np.loadtxt(os.path.join('..', 'examples', 'NIST_Gauss2.dat'))
  File "/usr/lib/python3.6/site-packages/numpy/lib/npyio.py", line 917, in loadtxt
    fh = np.lib._datasource.open(fname, 'rt', encoding=encoding)
  File "/usr/lib/python3.6/site-packages/numpy/lib/_datasource.py", line 260, in open
    return ds.open(path, mode, encoding=encoding, newline=newline)
  File "/usr/lib/python3.6/site-packages/numpy/lib/_datasource.py", line 614, in open
    encoding=encoding, newline=newline)
FileNotFoundError: [Errno 2] No such file or directory: '../examples/NIST_Gauss2.dat'

----------------------------------------------------------------------
Ran 211 tests in 9.368s
```
This patch fixes this issue. Simultanously, I took the liberty to replace `'path/to/file'` by `os.path.join('path', 'to', 'file')` in one file, which should increase portability.
