### PR TITLE
fix formatting error for values near 9.99e-5

### DIFF
--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -55,7 +55,8 @@ def gformat(val, length=11):
     prec = length - 7
     if abs(expon)> 99:
         prec -= 1
-    elif abs(expon) < (prec-1):
+    elif ((expon > 0 and expon < (prec+4)) or
+          (expon <= 0 and -expon < (prec-1))):
         form = 'f'
         prec += 4
         if expon > 0:

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -11,7 +11,6 @@ def alphanumeric_sort(s, _nsre=re.compile('([0-9]+)')):
     return [int(text) if text.isdigit() else text.lower()
             for text in re.split(_nsre, s)]
 
-
 def getfloat_attr(obj, attr, fmt='%.5f'):
     """Format an attribute of an object for printing."""
     val = getattr(obj, attr, None)
@@ -23,35 +22,46 @@ def getfloat_attr(obj, attr, fmt='%.5f'):
         return fmt % val
     return repr(val)
 
-
 def gformat(val, length=11):
-    """Format a number with '%g'-like format.
+    """Format a number with '%g'-like format, except that
 
-    The return will be length ``length`` (default is 12) and have at
-    least length-6 significant digits.
+        a) the length of the output string will be the requested length.
+        b) positive numbers will have a leading blank.
+        b) the precision will be as high as possible.
+        c) trailing zeros will not be trimmed.
+
+    The precision will typically be length-7.
+
+    Arguments
+    ---------
+    val       value to be formatted
+    length    length of output string
+
+    Returns
+    -------
+    string of specified length.
+
+    Notes
+    ------
+     Positive values will have leading blank.
 
     """
+    try:
+        expon = int(log10(abs(val)))
+    except:
+        expon = 0
     length = max(length, 7)
-    fmt = '{0: .%ig}' % (length-6)
-    if isinstance(val, int):
-        out = ('{0: .%ig}' % (length-2)).format(val)
-        if len(out) > length:
-            out = fmt.format(val)
-    else:
-        out = fmt.format(val)
-    if len(out) < length:
-        if 'e' in out:
-            ie = out.find('e')
-            if '.' not in out[:ie]:
-                out = out[:ie] + '.' + out[ie:]
-            out = out.replace('e', '0'*(length-len(out))+'e')
-        else:
-            fmt = '{0: .%ig}' % (length-5)
-            out = fmt.format(val)
-            if len(out) < length:
-                pad = '0' if '.' in out else ' '
-                out += pad*(length-len(out))
-    return out
+    form = 'e'
+    prec = length - 7
+    if abs(expon)> 99:
+        prec -= 1
+    elif abs(expon) < (prec-1):
+        form = 'f'
+        prec += 4
+        if expon > 0:
+            prec -= expon
+    fmt = '{0: %i.%i%s}' % (length, prec, form)
+    return fmt.format(val)
 
 
 CORREL_HEAD = '[[Correlations]] (unreported correlations are < % .3f)'

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -46,8 +46,8 @@ def gformat(val, length=11):
                 out = out[:ie] + '.' + out[ie:]
             out = out.replace('e', '0'*(length-len(out))+'e')
         else:
-            fmt = '{0: .%ig}' % (length-1)
-            out = fmt.format(val)[:length]
+            fmt = '{0: .%ig}' % (length-5)
+            out = fmt.format(val)
             if len(out) < length:
                 pad = '0' if '.' in out else ' '
                 out += pad*(length-len(out))

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 import re
-
+from math import log10
 from .parameter import Parameters
 
 
@@ -144,7 +144,7 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
             sval = 'Non Numeric Value?'
 
         if par.stderr is not None:
-            serr = gformat(par.stderr, length=9)
+            serr = gformat(par.stderr)
 
             try:
                 spercent = '({0:.2%})'.format(abs(par.stderr/par.value))


### PR DESCRIPTION
This (tries to) address #458 by fixing `printfuncs.gformat` for values near 1.e-4.
