### PR TITLE
Improve output of fit_report

### DIFF
--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -67,7 +67,7 @@ def gformat(val, length=11):
     return fmt.format(val)
 
 
-CORREL_HEAD = '[[Correlations]] (unreported correlations are < % .3f)'
+CORREL_HEAD = '[[Correlations]] (unreported correlations are < %.3f)'
 
 
 def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
@@ -134,13 +134,13 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
     add("[[Variables]]")
     for name in parnames:
         par = params[name]
-        space = ' '*(namelen+1-len(name))
+        space = ' '*(namelen-len(name))
         nout = "%s:%s" % (name, space)
-        inval = '(init= ?)'
+        inval = '(init = ?)'
         if par.init_value is not None:
-            inval = '(init=% .7g)' % par.init_value
+            inval = '(init = %.7g)' % par.init_value
         if modelpars is not None and name in modelpars:
-            inval = '%s, model_value =% .7g' % (inval, modelpars[name].value)
+            inval = '%s, model_value = %.7g' % (inval, modelpars[name].value)
         try:
             sval = gformat(par.value)
         except (TypeError, ValueError):
@@ -158,7 +158,7 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
         if par.vary:
             add("    %s %s %s" % (nout, sval, inval))
         elif par.expr is not None:
-            add("    %s %s  == '%s'" % (nout, sval, par.expr))
+            add("    %s %s == '%s'" % (nout, sval, par.expr))
         else:
             add("    %s % .7g (fixed)" % (nout, par.value))
 
@@ -178,8 +178,9 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
         sort_correl.reverse()
         if len(sort_correl) > 0:
             add(CORREL_HEAD % min_correl)
+            maxlen = max([len(k) for k in list(correls.keys())])
         for name, val in sort_correl:
-            lspace = max(1, 25 - len(name))
+            lspace = max(0, maxlen - len(name))
             add('    C(%s)%s = % .3f' % (name, (' '*30)[:lspace], val))
     return '\n'.join(buff)
 

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -11,6 +11,7 @@ def alphanumeric_sort(s, _nsre=re.compile('([0-9]+)')):
     return [int(text) if text.isdigit() else text.lower()
             for text in re.split(_nsre, s)]
 
+
 def getfloat_attr(obj, attr, fmt='%.5f'):
     """Format an attribute of an object for printing."""
     val = getattr(obj, attr, None)
@@ -21,6 +22,7 @@ def getfloat_attr(obj, attr, fmt='%.5f'):
     elif isinstance(val, float):
         return fmt % val
     return repr(val)
+
 
 def gformat(val, length=11):
     """Format a number with '%g'-like format, except that
@@ -48,12 +50,12 @@ def gformat(val, length=11):
     """
     try:
         expon = int(log10(abs(val)))
-    except:
+    except (OverflowError, ValueError):
         expon = 0
     length = max(length, 7)
     form = 'e'
     prec = length - 7
-    if abs(expon)> 99:
+    if abs(expon) > 99:
         prec -= 1
     elif ((expon > 0 and expon < (prec+4)) or
           (expon <= 0 and -expon < (prec-1))):


### PR DESCRIPTION
this PR makes some improvements to the output of ```fit_report``` (mainly regarding white spaces), in addition to a few PEP8 style changes. In particular, it improves how the ```Correlations``` are shown; it doesn't use a fixed-width anymore but takes into account the maximum length of the names of the correlated parameters. This will avoid the excessive whitespace to fill up to 25 characters and also align correctly when the label is actually larger than 25 characters.

If this seems like a worthwhile change, I can re-run the examples and update the output in the documentation.
