### PR TITLE
use gformat for fit statistics

### DIFF
--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -12,15 +12,15 @@ def alphanumeric_sort(s, _nsre=re.compile('([0-9]+)')):
             for text in re.split(_nsre, s)]
 
 
-def getfloat_attr(obj, attr, fmt='%.5f'):
+def getfloat_attr(obj, attr, length=11):
     """Format an attribute of an object for printing."""
     val = getattr(obj, attr, None)
     if val is None:
         return 'unknown'
     elif isinstance(val, int):
-        return '%d' % val
+        return ' %d' % val
     elif isinstance(val, float):
-        return fmt % val
+        return gformat(val, length=length)
     return repr(val)
 
 

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -18,9 +18,9 @@ def getfloat_attr(obj, attr, length=11):
     if val is None:
         return 'unknown'
     elif isinstance(val, int):
-        return ' %d' % val
+        return '%d' % val
     elif isinstance(val, float):
-        return gformat(val, length=length)
+        return gformat(val, length=length).strip()
     return repr(val)
 
 


### PR DESCRIPTION
this changes the fit report to use `gformat()`  for fit statistics.  

I regularly see reduced chi-squares that are very small for 'f' format, and seeing more than 2 digits would be nice. 
