### PR TITLE
consistent nfev

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -491,7 +491,7 @@ class Minimizer(object):
                                nan_policy=self.nan_policy)
 
     def __jacobian(self, fvars):
-        """Reuturn analytical jacobian to be used with Levenberg-Marquardt.
+        """Return analytical jacobian to be used with Levenberg-Marquardt.
 
         modified 02-01-2012 by Glenn Jones, Aberystwyth University
         modified 06-29-2015 M Newville to apply gradient scaling for

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1198,7 +1198,7 @@ class Minimizer(object):
             par = self.params[vname]
             start_vals.append(par.value)
             lower_bounds.append(replace_none(par.min, -1))
-            upper_bounds.append(replace_none(par.max, -1))
+            upper_bounds.append(replace_none(par.max, 1))
 
         ret = least_squares(self.__residual, start_vals,
                             bounds=(lower_bounds, upper_bounds),

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1209,7 +1209,7 @@ class Minimizer(object):
             setattr(result, attr, ret[attr])
 
         result.x = np.atleast_1d(result.x)
-        result.chisqr = result.residual = self.__residual(result.x, False)
+        result.chisqr = result.residual = ret.fun
         result.nvarys = len(result.var_names)
         result.ndata = 1
         result.nfree = 1

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -616,7 +616,6 @@ class Minimizer(object):
 
         # determine which parameters are actually variables
         # and which are defined expressions.
-
         result.var_names = []  # note that this *does* belong to self...
         result.init_vals = []
         result.params.update_constraints()
@@ -781,6 +780,7 @@ class Minimizer(object):
 
         result.x = np.atleast_1d(result.x)
         result.chisqr = result.residual = self.__residual(result.x)
+        result.nfev -= 1
         result.nvarys = len(variables)
         result.ndata = 1
         result.nfree = 1
@@ -1269,6 +1269,7 @@ class Minimizer(object):
         """
         result = self.prepare_fit(params=params)
         result.method = 'leastsq'
+        result.nfev -= 2  # correct for "pre-fit" initialization/checks
         variables = result.init_vals
         nvars = len(variables)
         lskws = dict(full_output=1, xtol=1.e-7, ftol=1.e-7, col_deriv=False,
@@ -1485,6 +1486,7 @@ class Minimizer(object):
         """
         result = self.prepare_fit(params=params)
         result.method = 'brute'
+        result.nfev -= 1  # correct for "pre-fit" initialization/checks
 
         brute_kws = dict(full_output=1, finish=None, disp=False)
 
@@ -1556,6 +1558,7 @@ class Minimizer(object):
         result.chisqr = ret[1]
         result.nvarys = len(result.var_names)
         result.residual = self.__residual(result.brute_x0, apply_bounds_transformation=False)
+        result.nfev -= 1
         result.ndata = len(result.residual)
         result.nfree = result.ndata - result.nvarys
         result.redchi = result.chisqr / result.nfree

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -505,7 +505,6 @@ class Minimizer(object):
             pars[name].value = pars[name].from_internal(val)
             grad_scale[ivar] = pars[name].scale_gradient(val)
 
-        self.result.nfev += 1
         pars.update_constraints()
 
         # compute the jacobian for "internal" unbounded variables,

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -23,7 +23,7 @@ def test_confidence1():
     out = minimizer.leastsq()
     # lmfit.report_fit(out)
 
-    assert(out.nfev >   5)
+    assert(out.nfev > 5)
     assert(out.nfev < 500)
     assert(out.chisqr < 3.0)
     assert(out.nvarys == 2)
@@ -60,7 +60,7 @@ def test_confidence2():
     out = minimizer.minimize(method='leastsq', params=out.params)
     # lmfit.report_fit(out)
 
-    assert(out.nfev >   5)
+    assert(out.nfev > 3)
     assert(out.nfev < 500)
     assert(out.chisqr < 3.0)
     assert(out.nvarys == 2)


### PR DESCRIPTION
continuing from the [mailinglist](https://groups.google.com/forum/#!topic/lmfit-py/Ywqx68tZ4zs).

this PR makes the reported number of function evaluations ```nfev``` consistent between ```lmfit``` and ```scipy.optimize.*```. Now in the methods that require it, the value of ```result.nfev``` is initialized with a value to correct for "pre-fit" calls to the objective function. In cases where we call the ```__residual``` function after the fit, it also correct for that. In addition, calls to ```__jacobian``` are not added to ```nfev``` anymore; consistent with the optimizers in ```scipy```. A small fix to a test is also included, since the current ```nfev``` count for ```leastsq``` is two smaller. For ```least_squares``` no correction is done, but it just takes the number reported by the optimizer [in ```lmfit``` we get the "real" number of function evaluations + 2*the evaluations for the Jacobian, there is no way to correct for this a priori].

Other fixes include:
- use ```.fun``` from the ```least_squares``` method instead of calculating it again in ```lmfit```  after the fit has finished.
- correct bug in upper-bounds for ```least_squares``` (not sure if a variable ever is ```None``` at that point in the code, but it doesn't hurt to check, provided that the check is correct).
- fixed typo in docstring.
 
Locally, the ```test_itercb.py``` test fails for me both with master as with this PR with a ```ValueError: The array returned by a function changed size between calls```, which seems correct to me as once the callback function halts the fit the return from ```___residual``` is ```None```. It might have to do with recent changes in ```scipy```... as it did pass on Travis with the last PR - I am not sure. How to stop the fit with an ```iter_cb``` callback might need some rethinking, but I haven't looked at this carefully yet.
