### PR TITLE
Raise an AbortFitException when fit is aborted by user callback

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1214,16 +1214,23 @@ class Minimizer(object):
             lower_bounds.append(replace_none(par.min, -1))
             upper_bounds.append(replace_none(par.max, 1))
 
-        ret = least_squares(self.__residual, start_vals,
-                            bounds=(lower_bounds, upper_bounds),
-                            kwargs=dict(apply_bounds_transformation=False),
-                            **kws)
+        try:
+            ret = least_squares(self.__residual, start_vals,
+                                bounds=(lower_bounds, upper_bounds),
+                                kwargs=dict(apply_bounds_transformation=False),
+                                **kws)
+        except AbortFitException:
+            pass
 
-        for attr in ret:
-            setattr(result, attr, ret[attr])
+        if not result.aborted:
+            for attr in ret:
+                setattr(result, attr, ret[attr])
 
-        result.x = np.atleast_1d(result.x)
-        result.chisqr = result.residual = ret.fun
+            result.x = np.atleast_1d(result.x)
+            result.chisqr = result.residual = ret.fun
+        else:
+            result.chisqr = result.residual
+
         result.nvarys = len(result.var_names)
         result.ndata = 1
         result.nfree = 1


### PR DESCRIPTION
The test ```test_itercb.py``` fails with the newest version of ```scipy``` with the exception  ```ValueError: The array returned by a function changed size between calls.``` (as discussed in #465).

This PR attempts to address this by raising an AbortFitException instead of returning ```None``` when a fit is aborted by the callback function. Currently this exception is only handled in the ```leastsq``` function (and the test passes now), but can easily be extended to the other minimizers. However, before doing so I'd like to get some feedback to make sure whether this is the preferred solution to the problem and if I am missing something with this approach.