### PR TITLE
Add support for scipy.basinhopping

### DIFF
--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -364,7 +364,7 @@ The Minimizer object has a few public methods:
 
 .. automethod:: Minimizer.brute
 
-For more information, check the examples in ``examples/lmfit_brute.py``.
+For more information, check the examples in ``examples/lmfit_brute_example.ipynb``.
 
 .. automethod:: Minimizer.emcee
 

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -154,6 +154,8 @@ class as listed in the :ref:`Table of Supported Fitting Methods
  +-----------------------+------------------------------------------------------------------+
  | Brute force method    |  ``brute``                                                       |
  +-----------------------+------------------------------------------------------------------+
+ | Basinhopping          |  ``basinhopping``                                                |
+ +-----------------------+------------------------------------------------------------------+
 
 
 .. note::
@@ -365,6 +367,8 @@ The Minimizer object has a few public methods:
 .. automethod:: Minimizer.brute
 
 For more information, check the examples in ``examples/lmfit_brute_example.ipynb``.
+
+.. automethod:: Minimizer.basinhopping
 
 .. automethod:: Minimizer.emcee
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -4,12 +4,21 @@
 Release Notes
 =====================
 
-.. _lmfit github repository:   https://github.com/lmfit/lmfit-py
+.. _lmfit GitHub repository:   https://github.com/lmfit/lmfit-py
 
 This section discusses changes between versions, especially changes
 significant to the use and behavior of the library.  This is not meant
 to be a comprehensive list of changes.  For such a complete record,
-consult the `lmfit github repository`_.
+consult the `lmfit GitHub repository`_.
+
+
+.. _whatsnew_0910_label:
+
+Version 0.9.10 Release Notes
+==========================================
+Basinhopping was added as a global optimization algorithm - see
+:func:`~lmfit.minimizer.Minimizer.basinhopping` and :scipydoc:`optimize.basinhopping` for
+more information.
 
 
 .. _whatsnew_099_label:

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -544,34 +544,16 @@ class Minimizer(object):
             to sum-of-squares, but can be replaced by other options.
 
         """
-        r = self.__residual(fvars)
+        if self.result.method in ['basinhopping', 'brute']:
+            apply_bounds_transformation = False
+        else:
+            apply_bounds_transformation = True
+
+        r = self.__residual(fvars, apply_bounds_transformation)
         if isinstance(r, ndarray) and r.size > 1:
             r = self.reduce_fcn(r)
             if isinstance(r, ndarray) and r.size > 1:
                 r = r.sum()
-        return r
-
-    def penalty_brute(self, fvars):
-        """Penalty function for brute force method.
-
-        Parameters
-        ----------
-        fvars : numpy.ndarray
-            Array of values for the variable parameters
-
-        Returns
-        -------
-        r : float
-            The  evaluated user-supplied objective function.
-
-            If the objective function is an array of size greater than 1,
-            use the scalar returned by `self.reduce_fcn`.  This defaults
-            to sum-of-squares, but can be replaced by other options.
-
-        """
-        r = self.__residual(fvars, apply_bounds_transformation=False)
-        if isinstance(r, ndarray) and r.size > 1:
-            r = (r*r).sum()
         return r
 
     def prepare_fit(self, params=None):
@@ -1495,8 +1477,7 @@ class Minimizer(object):
         x0 = np.asarray([i.value for i in self.params.values()])[varying]
 
         try:
-            ret = scipy_basinhopping(self.penalty_brute, x0,
-                                     **basinhopping_kws)
+            ret = scipy_basinhopping(self.penalty, x0, **basinhopping_kws)
         except AbortFitException:
             pass
 
@@ -1636,7 +1617,7 @@ class Minimizer(object):
             ranges.append(par_range)
 
         try:
-            ret = scipy_brute(self.penalty_brute, tuple(ranges), Ns=Ns, **brute_kws)
+            ret = scipy_brute(self.penalty, tuple(ranges), Ns=Ns, **brute_kws)
         except AbortFitException:
             pass
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -29,6 +29,7 @@ from scipy.optimize import leastsq as scipy_leastsq
 from scipy.optimize import minimize as scipy_minimize
 from scipy.stats import cauchy as cauchy_dist
 from scipy.stats import norm as norm_dist
+from scipy.version import version as scipy_version
 import six
 
 # use locally modified version of uncertainties package
@@ -1464,6 +1465,13 @@ class Minimizer(object):
 
         basinhopping_kws.update(self.kws)
         basinhopping_kws.update(kws)
+
+        # FIXME - remove after requirement for scipy >= 0.19
+        major, minor, micro = np.array(scipy_version.split('.'), dtype='int')
+        if major < 1 and minor < 19:
+            _ = basinhopping_kws.pop('seed')
+            print("Warning: basinhopping doesn't support argument 'seed' for "
+                  "scipy versions below 0.19!")
 
         varying = np.asarray([par.vary for par in self.params.values()])
         replace_none = lambda x, sign: sign*np.inf if x is None else x

--- a/tests/test_basinhopping.py
+++ b/tests/test_basinhopping.py
@@ -1,0 +1,142 @@
+import numpy as np
+from numpy.testing import assert_allclose
+
+from scipy.optimize import basinhopping
+from scipy.version import version as scipy_version
+
+import lmfit
+
+
+def test_basinhopping():
+    """Test basinhopping in lmfit versus scipy."""
+
+    # SciPy
+    def func(x):
+        return np.cos(14.5*x - 0.3) + (x+0.2) * x
+
+    minimizer_kwargs = {'method': 'L-BFGS-B'}
+    x0 = [1.]
+
+    # FIXME - remove after requirement for scipy >= 0.19
+    major, minor, micro = np.array(scipy_version.split('.'), dtype='int')
+    if major < 1 and minor < 19:
+        ret = basinhopping(func, x0, minimizer_kwargs=minimizer_kwargs)
+    else:
+        ret = basinhopping(func, x0, minimizer_kwargs=minimizer_kwargs, seed=7)
+
+    # lmfit
+    def residual(params):
+        x = params['x'].value
+        return np.cos(14.5*x - 0.3) + (x+0.2) * x
+
+    pars = lmfit.Parameters()
+    pars.add_many(('x', 1.))
+    kws = {'minimizer_kwargs': {'method': 'L-BFGS-B'}, 'seed': 7}
+    mini = lmfit.Minimizer(residual, pars)
+    out = mini.minimize(method='basinhopping', **kws)
+
+    assert_allclose(out.chisqr, ret.fun)
+    assert_allclose(out.params['x'].value, ret.x)
+
+
+def test_basinhopping_2d():
+    """Test basinhopping in lmfit versus scipy."""
+
+    # SciPy
+    def func2d(x):
+        return np.cos(14.5*x[0] - 0.3) + (x[1]+0.2) * x[1] + (x[0]+0.2) * x[0]
+
+    minimizer_kwargs = {'method': 'L-BFGS-B'}
+    x0 = [1.0, 1.0]
+
+    # FIXME - remove after requirement for scipy >= 0.19
+    major, minor, micro = np.array(scipy_version.split('.'), dtype='int')
+    if major < 1 and minor < 19:
+        ret = basinhopping(func2d, x0, minimizer_kwargs=minimizer_kwargs)
+    else:
+        ret = basinhopping(func2d, x0, minimizer_kwargs=minimizer_kwargs, seed=7)
+
+    # lmfit
+    def residual_2d(params):
+        x0 = params['x0'].value
+        x1 = params['x1'].value
+        return np.cos(14.5*x0 - 0.3) + (x1+0.2) * x1 + (x0+0.2) * x0
+
+    pars = lmfit.Parameters()
+    pars.add_many(('x0', 1.), ('x1', 1.))
+
+    mini = lmfit.Minimizer(residual_2d, pars)
+    kws = {'minimizer_kwargs': {'method': 'L-BFGS-B'}, 'seed': 7}
+    out = mini.minimize(method='basinhopping', **kws)
+
+    assert_allclose(out.chisqr, ret.fun)
+    assert_allclose(out.params['x0'].value, ret.x[0])
+    assert_allclose(out.params['x1'].value, ret.x[1], rtol=1e-5)
+
+
+def test_basinhopping_Alpine02():
+    """Test basinhopping on Alpine02 function."""
+
+    global_optimum = [7.91705268, 4.81584232]
+    fglob = -6.12950
+
+    # SciPy
+    def Alpine02(x):
+        x0 = x[0]
+        x1 = x[1]
+        return np.prod(np.sqrt(x0) * np.sin(x0)) * np.prod(np.sqrt(x1) *
+                                                           np.sin(x1))
+
+    def basinhopping_accept(f_new, f_old, x_new, x_old):
+        """Does the new candidate vector lie inbetween the bounds?
+
+        Returns
+        -------
+        accept_test : bool
+            The candidate vector lies inbetween the bounds
+        """
+        if np.any(x_new < np.array([0.0, 0.0])):
+            return False
+        if np.any(x_new > np.array([10.0, 10.0])):
+            return False
+        return True
+
+    minimizer_kwargs = {'method': 'L-BFGS-B', 'bounds': [(0.0, 10.0),
+                                                         (0.0, 10.0)]}
+    x0 = [1.0, 1.0]
+
+    # FIXME - remove after requirement for scipy >= 0.19
+    major, minor, micro = np.array(scipy_version.split('.'), dtype='int')
+    if major < 1 and minor < 19:
+        ret = basinhopping(Alpine02, x0, minimizer_kwargs=minimizer_kwargs,
+                           accept_test=basinhopping_accept)
+    else:
+        ret = basinhopping(Alpine02, x0, minimizer_kwargs=minimizer_kwargs,
+                           accept_test=basinhopping_accept, seed=7)
+
+    # lmfit
+    def residual_Alpine02(params):
+        x0 = params['x0'].value
+        x1 = params['x1'].value
+        return np.prod(np.sqrt(x0) * np.sin(x0)) * np.prod(np.sqrt(x1) *
+                                                           np.sin(x1))
+
+    pars = lmfit.Parameters()
+    pars.add_many(('x0', 1., True, 0.0, 10.0),
+                  ('x1', 1., True, 0.0, 10.0))
+
+    mini = lmfit.Minimizer(residual_Alpine02, pars)
+    kws = {'minimizer_kwargs': {'method': 'L-BFGS-B'}, 'seed': 7}
+    out = mini.minimize(method='basinhopping', **kws)
+    out_x = np.array([out.params['x0'].value, out.params['x1'].value])
+
+    assert_allclose(out.chisqr, fglob, rtol=1e-5)
+    assert_allclose(min(out_x), min(global_optimum))
+    assert_allclose(max(out_x), max(global_optimum))
+    assert(out.chisqr <= ret.fun)
+
+
+if __name__ == '__main__':
+    test_basinhopping()
+    test_basinhopping_2d()
+    test_basinhopping_Alpine02()


### PR DESCRIPTION
As discussed in #440, including some more global optimization algorithms wouldn't hurt. This PR adds support for the ```basinhopping``` algorithm as implemented in ```scipy```. 

It passes bounds to the underlying optimizer (i.e., the default optimizer is now ```L-BFGS-B``` since we're using bounds) and it uses the ```accept_test``` callable to accept only steps that stay within the parameter bounds.

In addition, one test is included to make sure that the implementation in ```lmfit``` gives the same results as directly calling ```scipy.optimize.basinhopping```. And just because I noticed, I also update the name of the example for the ```brute``` method.