### PR TITLE
update handling of installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,8 @@
 # from distutils.core import setup
 from __future__ import print_function
 
-import sys
-
 from setuptools import setup
 import versioneer
-
-# Minimal Python version sanity check
-# taken from the Jupyter Notebook setup.py -- Modified BSD License
-v = sys.version_info
-if v[:2] < (2, 7) or (v[0] >= 3 and v[:2] < (3, 4)):
-    error = "ERROR: lmfit requires Python version 2.7 or 3.4 or above."
-    print(error, file=sys.stderr)
-    sys.exit(1)
 
 long_desc = """A library for least-squares minimization and data fitting in
 Python.  Built on top of scipy.optimize, lmfit provides a Parameter object
@@ -44,6 +34,7 @@ setup(name='lmfit',
       url='https://lmfit.github.io/lmfit-py/',
       download_url='https://lmfit.github.io//lmfit-py/',
       install_requires=install_reqs,
+      python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       license='BSD',
       description="Least-Squares Minimization with Bounds and Constraints",
       long_description=long_desc,


### PR DESCRIPTION
Upon reading some of the Python documentation it seems to me that we can handle the installation requirements in a bit smarter way. 

Since ```pip``` version 9 and ```setuptools``` version 24.0 (both released more than 2 years ago, so it should be safe to rely on that) one can use ```python_requires``` to  say which Python versions are supported. 
In addition, the way we were using ```install_requires``` did specify the required packages for installation in ```setup.py``` but not the minimum versions. They were listed in ```requirements.txt```, but that file is only used when doing explicitly ```pip install -r```. With this change one only need to update the ```requirements.txt``` file and those packages and version information will be used in ```setup.py```. 

This could explains the question on [stackoverflow](https://stackoverflow.com/questions/49905556/lmfit-package-importerror-cannot-import-name-differential-evolution/49914044#49914044), where potentially updating ```lmfit``` did not upgrade dependencies. Not sure if that was the problem there, but this PR would avoid such a possibility.