### PR TITLE
tolerate nearly any exception when trying to import matplotlib

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -40,7 +40,7 @@ def _align(var, mask, data):
 try:
     from matplotlib import pyplot as plt
     _HAS_MATPLOTLIB = True
-except ImportError:
+except Exception:
     _HAS_MATPLOTLIB = False
 
 


### PR DESCRIPTION
This addresses #470 by allowing (nearly) any exception from trying to import matplotlib.