### PR TITLE
add function to calculate fitting statistics

### DIFF
--- a/tests/test_ampgo.py
+++ b/tests/test_ampgo.py
@@ -24,7 +24,7 @@ def test_ampgo_Alpine02():
     out = mini.minimize(method='ampgo')
     out_x = np.array([out.params['x0'].value, out.params['x1'].value])
 
-    assert_allclose(out.chisqr, fglob, rtol=1e-5)
+    assert_allclose(out.residual, fglob, rtol=1e-5)
     assert_allclose(min(out_x), min(global_optimum), rtol=1e-3)
     assert_allclose(max(out_x), max(global_optimum), rtol=1e-3)
     assert('global' in out.ampgo_msg)

--- a/tests/test_basinhopping.py
+++ b/tests/test_basinhopping.py
@@ -35,7 +35,7 @@ def test_basinhopping():
     mini = lmfit.Minimizer(residual, pars)
     out = mini.minimize(method='basinhopping', **kws)
 
-    assert_allclose(out.chisqr, ret.fun)
+    assert_allclose(out.residual, ret.fun)
     assert_allclose(out.params['x'].value, ret.x)
 
 
@@ -69,7 +69,7 @@ def test_basinhopping_2d():
     kws = {'minimizer_kwargs': {'method': 'L-BFGS-B'}, 'seed': 7}
     out = mini.minimize(method='basinhopping', **kws)
 
-    assert_allclose(out.chisqr, ret.fun)
+    assert_allclose(out.residual, ret.fun)
     assert_allclose(out.params['x0'].value, ret.x[0])
     assert_allclose(out.params['x1'].value, ret.x[1], rtol=1e-5)
 
@@ -130,10 +130,10 @@ def test_basinhopping_Alpine02():
     out = mini.minimize(method='basinhopping', **kws)
     out_x = np.array([out.params['x0'].value, out.params['x1'].value])
 
-    assert_allclose(out.chisqr, fglob, rtol=1e-5)
+    assert_allclose(out.residual, fglob, rtol=1e-5)
     assert_allclose(min(out_x), min(global_optimum))
     assert_allclose(max(out_x), max(global_optimum))
-    assert(out.chisqr <= ret.fun)
+    assert(out.residual <= ret.fun)
 
 
 if __name__ == '__main__':

--- a/tests/test_brute_method.py
+++ b/tests/test_brute_method.py
@@ -96,7 +96,7 @@ def test_brute_lmfit_vs_scipy():
     assert_equal(resbrute[0][1], resbrute_lmfit.brute_x0[1], verbose=True) # best fit y value identical
     assert_equal(resbrute[0][1], resbrute_lmfit.params['y'].value, verbose=True) # best fit y value stored correctly
     assert_equal(resbrute[1], resbrute_lmfit.brute_fval, verbose=True) # best fit function value identical
-    assert_equal(resbrute[1], resbrute_lmfit.chisqr, verbose=True) # best fit function value stored correctly
+    assert_equal(resbrute[1], resbrute_lmfit.residual, verbose=True) # best fit function value stored correctly
 
     # TEST 2: using bounds, setting Ns=40 and no stepsize specified
     assert(not params_lmfit['x'].brute_step)  # brute_step for x == None
@@ -112,7 +112,7 @@ def test_brute_lmfit_vs_scipy():
     assert_equal(resbrute[3], resbrute_lmfit.brute_Jout, verbose=True) # function values on grid identical
     assert_equal(resbrute[0][0], resbrute_lmfit.params['x'].value, verbose=True) # best fit x value identical
     assert_equal(resbrute[0][1], resbrute_lmfit.params['y'].value, verbose=True) # best fit y value identical
-    assert_equal(resbrute[1], resbrute_lmfit.chisqr, verbose=True) # best fit function value identical
+    assert_equal(resbrute[1], resbrute_lmfit.residual, verbose=True) # best fit function value identical
 
     # TEST 3: using bounds and specifing stepsize for both parameters
     params_lmfit['x'].set(brute_step=0.25)
@@ -130,7 +130,7 @@ def test_brute_lmfit_vs_scipy():
     assert_equal(resbrute[3], resbrute_lmfit.brute_Jout, verbose=True) # function values on grid identical
     assert_equal(resbrute[0][0], resbrute_lmfit.params['x'].value, verbose=True) # best fit x value identical
     assert_equal(resbrute[0][1], resbrute_lmfit.params['y'].value, verbose=True) # best fit y value identical
-    assert_equal(resbrute[1], resbrute_lmfit.chisqr, verbose=True) # best fit function value identical
+    assert_equal(resbrute[1], resbrute_lmfit.residual, verbose=True) # best fit function value identical
 
     # TEST 4: using bounds, Ns=10, adn specifing stepsize for parameter 'x'
     params_lmfit['x'].set(brute_step=0.15)
@@ -148,7 +148,7 @@ def test_brute_lmfit_vs_scipy():
     assert_equal(resbrute[3], resbrute_lmfit.brute_Jout, verbose=True) # function values on grid identical
     assert_equal(resbrute[0][0], resbrute_lmfit.params['x'].value, verbose=True) # best fit x value identical
     assert_equal(resbrute[0][1], resbrute_lmfit.params['y'].value, verbose=True) # best fit y value identical
-    assert_equal(resbrute[1], resbrute_lmfit.chisqr, verbose=True) # best fit function value identical
+    assert_equal(resbrute[1], resbrute_lmfit.residual, verbose=True) # best fit function value identical
 
 
 def test_brute():


### PR DESCRIPTION
This PR adds a function to the MinimizerResult class to calculate the fitting statistics. With the addition of more solvers there is currently quite a bit of code duplication to do this. It assumes that every solver will still calculate/set ```result.residual``` correctly before calling the function.

In addition, the tests for brute/basinhopping/ampgo were updated. When fitting to a function one should compare the output from the ```scipy``` solver to ```result.residual``` not ```result.chisqr```.

