### PR TITLE
Fixes to testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ sandbox/
 .ipynb_checkpoints/
 doc/html
 *.sav
+.pytest*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include requirements.txt
 exclude *.pyc core.* *~ *.pdf
 recursive-include lmfit *.py
 recursive-include tests *.py *.dat
+recursive-include examples *.py *.dat
 recursive-include NIST_STRD *.dat
 recursive-include doc *
 recursive-exclude doc/_build *

--- a/lmfit/ui/basefitter.py
+++ b/lmfit/ui/basefitter.py
@@ -2,8 +2,8 @@ import warnings
 
 import numpy as np
 
-from ..asteval import Interpreter
-from ..astutils import NameFinder
+from asteval import Interpreter
+from asteval.astutils import NameFinder
 from ..model import Model
 from ..models import ExponentialModel  # arbitrary default
 from ..parameter import check_ast_errors

--- a/tests/test_NIST_Strd.py
+++ b/tests/test_NIST_Strd.py
@@ -7,19 +7,6 @@ from lmfit import Parameters, minimize
 
 from NISTModels import Models, ReadNistData
 
-HASPYLAB = False
-for arg in sys.argv:
-    if 'nose' in arg or 'pytest' in arg:
-        HASPYLAB = False
-
-if HASPYLAB:
-    try:
-        import matplotlib
-        import pylab
-        HASPYLAB = True
-    except ImportError:
-        HASPYLAB = False
-
 def ndig(a, b):
     "precision for NIST values"
     return round(-math.log10((abs(abs(a)-abs(b)) +1.e-15)/ abs(b)))
@@ -72,7 +59,7 @@ def Compare_NIST_Results(DataSet, myfit, params, NISTdata):
     return val_dig_min, '\n'.join(buff)
 
 def NIST_Dataset(DataSet, method='leastsq', start='start2',
-                 plot=True, verbose=False):
+                 plot=False, verbose=False):
 
     NISTdata = ReadNistData(DataSet)
     resid, npar, dimx = Models[DataSet]
@@ -91,11 +78,6 @@ def NIST_Dataset(DataSet, method='leastsq', start='start2',
     digs, buff = Compare_NIST_Results(DataSet, myfit, myfit.params, NISTdata)
     if verbose:
         print(buff)
-    if plot and HASPYLAB:
-        fit = -resid(myfit.params, x, )
-        pylab.plot(x, y, 'ro')
-        pylab.plot(x, fit, 'k+-')
-        pylab.show()
 
     return digs > 1
 
@@ -173,7 +155,7 @@ def run_interactive():
         print(usage)
     else:
         return NIST_Dataset(dset, method=opts.method,
-                            start=start, plot=True, verbose=True)
+                            start=start, plot=False, verbose=True)
 
 def RunNIST_Model(model):
     out1 = NIST_Dataset(model, start='start1', plot=False, verbose=False)

--- a/tests/test_algebraic_constraint2.py
+++ b/tests/test_algebraic_constraint2.py
@@ -5,22 +5,7 @@ from lmfit.printfuncs import report_fit
 import sys
 
 
-# Turn off plotting if run by nosetests.
-WITHPLOT = True
-for arg in sys.argv:
-    if 'nose' in arg or 'pytest' in arg:
-        WITHPLOT = False
-
-if WITHPLOT:
-    try:
-        import matplotlib
-        import pylab
-    except ImportError:
-        WITHPLOT = False
-
-
-def test_constraints(with_plot=True):
-    with_plot = with_plot and WITHPLOT
+def test_constraints():
 
     def residual(pars, x, sigma=None, data=None):
         yg = gaussian(x, pars['amp_g'], pars['cen_g'], pars['wid_g'])
@@ -43,9 +28,6 @@ def test_constraints(with_plot=True):
             lorentzian(x, 10, 9.6, 2.4) +
             random.normal(scale=0.23,  size=n) +
             x*0.5)
-
-    if with_plot:
-        pylab.plot(x, data, 'r+')
 
     pfit = Parameters()
     pfit.add(name='amp_g',  value=10)
@@ -77,8 +59,6 @@ def test_constraints(with_plot=True):
     report_fit(result.params, min_correl=0.3)
 
     fit = residual(result.params, x)
-    if with_plot:
-        pylab.plot(x, fit, 'b-')
     assert(result.params['cen_l'].value == 1.5 + result.params['cen_g'].value)
     assert(result.params['amp_l'].value == result.params['amp_tot'].value - result.params['amp_g'].value)
     assert(result.params['wid_l'].value == 2 * result.params['wid_g'].value)
@@ -88,9 +68,6 @@ def test_constraints(with_plot=True):
     result = myfit.leastsq()
     report_fit(result.params, min_correl=0.4)
     fit2 = residual(result.params, x)
-    if with_plot:
-        pylab.plot(x, fit2, 'k')
-        pylab.show()
 
     assert(result.params['cen_l'].value == 1.5 + result.params['cen_g'].value)
     assert(result.params['amp_l'].value == result.params['amp_tot'].value - result.params['amp_g'].value)

--- a/tests/test_height_fwhm.py
+++ b/tests/test_height_fwhm.py
@@ -10,31 +10,13 @@ import sys
 
 import os
 
-# Turn off plotting if run by nosetests.
-WITHPLOT = True
-for arg in sys.argv:
-    if 'nose' in arg or 'pytest' in arg:
-        WITHPLOT = False
 
-if WITHPLOT:
-    try:
-        import matplotlib
-        import pylab
-    except ImportError:
-        WITHPLOT = False
-
-
-def check_height_fwhm(x, y, lineshape, model, with_plot=True, report=False):
+def check_height_fwhm(x, y, lineshape, model, with_plot=False, report=False):
     """Check height and fwhm parameters"""
-    with_plot = with_plot and WITHPLOT
     pars = model.guess(y, x=x)
     out = model.fit(y, pars, x=x)
     if report:
         print(out.fit_report())
-    if with_plot:
-        fig = pylab.figure()
-        out.plot(fig=fig)
-        pylab.show()
 
     # account for functions whose centers are not mu
     mu = out.params['center'].value


### PR DESCRIPTION
This PR contains a few fixes related to testing:
- remove all plotting from the tests, not useful anyway in automatic testing, which should really be the only stuff in ```tests```
- fix imports in ```lmfit/ui``` related to ```asteval```
- add the ```examples``` directory to the PyPI distribution
- ignore files related to ```pytest```

this should make automatic testing in macports and such possible...