### PR TITLE
add missing Jupyter notebook examples

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include requirements.txt
 exclude *.pyc core.* *~ *.pdf
 recursive-include lmfit *.py
 recursive-include tests *.py *.dat
-recursive-include examples *.py *.dat
+recursive-include examples *.py *.ipynb *.dat
 recursive-include NIST_STRD *.dat
 recursive-include doc *
 recursive-exclude doc/_build *


### PR DESCRIPTION
I turns out that I forgot to add the ```*.ipynb``` files in the example directory - this fixes that. In addition, for some reason there are a few spurious left-over files in the ```examples``` directory when downloading from PyPI (e.g., ```A.py``` and ```so1.py```). I don't really understand where they come from, but removing the ```dist``` directory and running ```python setup.py sdist``` does fix it. 

Not a big deal and no need to upload a new file to PyPI, but let's fix this now before I forget... 