### PR TITLE
Transform covariance matrix and refactor code for parameter uncertainties/correlations

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -323,7 +323,6 @@ class MinimizerResult(object):
 
     def _calculate_statistics(self):
         """Calculate the fitting statistics."""
-
         self.nvarys = len(self.init_vals)
         if isinstance(self.residual, ndarray):
             self.chisqr = (self.residual**2).sum()
@@ -695,6 +694,48 @@ class Minimizer(object):
 
         cov_ext = cov_int * grad
         return cov_ext
+
+    def _calculate_uncertainties_correlations(self):
+        """Calculate parameter uncertainties and correlations."""
+        if self.scale_covar:
+            self.result.covar *= self.result.redchi
+
+        vbest = np.atleast_1d([self.result.params[name].value for i, name in
+                               enumerate(self.result.var_names)])
+
+        has_expr = False
+        for par in self.result.params.values():
+            par.stderr, par.correl = 0, None
+            has_expr = has_expr or par.expr is not None
+
+        for ivar, name in enumerate(self.result.var_names):
+            par = self.result.params[name]
+            par.stderr = sqrt(self.result.covar[ivar, ivar])
+            par.correl = {}
+            try:
+                self.result.errorbars = self.result.errorbars and (par.stderr > 0.0)
+                for jvar, varn2 in enumerate(self.result.var_names):
+                    if jvar != ivar:
+                        par.correl[varn2] = (self.result.covar[ivar, jvar] /
+                                             (par.stderr * sqrt(self.result.covar[jvar, jvar])))
+            except ZeroDivisionError:
+                self.result.errorbars = False
+
+        if has_expr:
+            try:
+                uvars = uncertainties.correlated_values(vbest, self.result.covar)
+            except (LinAlgError, ValueError):
+                uvars = None
+
+            # for uncertainties on constrained parameters, use the calculated
+            # "correlated_values", evaluate the uncertainties on the constrained
+            # parameters and reset the Parameters to best-fit value
+            if uvars is not None:
+                for par in self.result.params.values():
+                    eval_stderr(par, uvars, self.result.var_names, self.result.params)
+                # restore nominal values
+                for v, nam in zip(uvars, self.result.var_names):
+                    self.result.params[nam].value = v.nominal_value
 
     def scalar_minimize(self, method='Nelder-Mead', params=None, **kws):
         """Scalar minimization using :scipydoc:`optimize.minimize`.
@@ -1327,7 +1368,6 @@ class Minimizer(object):
             pass
 
         result._calculate_statistics()
-        params = result.params
 
         if result.aborted:
             return result
@@ -1348,68 +1388,14 @@ class Minimizer(object):
         else:
             result.message = 'Tolerance seems to be too small.'
 
-        # need to map _best values to params, then calculate the
-        # grad for the variable parameters
-        vbest = ones_like(_best)
-
-        # ensure that _best, vbest, and grad are not
-        # broken 1-element ndarrays.
-        if len(np.shape(_best)) == 0:
-            _best = np.array([_best])
-        if len(np.shape(vbest)) == 0:
-            vbest = np.array([vbest])
-
-        for ivar, name in enumerate(result.var_names):
-            vbest[ivar] = params[name].value
-
-        has_expr = False
-        for par in params.values():
-            par.stderr, par.correl = 0, None
-            has_expr = has_expr or par.expr is not None
-
         # self.errorbars = error bars were successfully estimated
         result.errorbars = (_cov is not None)
         if result.errorbars:
-            if self.scale_covar:
-                result.cov_int = _cov * result.redchi
-            else:
-                result.cov_int = _cov
             # transform the covariance matrix to "external" parameter space
-            result.covar = self._int2ext_cov_x(result.cov_int, _best)
-
-            for ivar, name in enumerate(result.var_names):
-                par = params[name]
-                par.stderr = sqrt(result.covar[ivar, ivar])
-                par.correl = {}
-                try:
-                    result.errorbars = result.errorbars and (par.stderr > 0.0)
-                    for jvar, varn2 in enumerate(result.var_names):
-                        if jvar != ivar:
-                            par.correl[varn2] = (
-                                result.covar[ivar, jvar] /
-                                (par.stderr * sqrt(result.covar[jvar, jvar])))
-                # TODO: do not use bare except
-                except:
-                    result.errorbars = False
-
-            if has_expr:
-                # uncertainties on constrained parameters:
-                #   get values with uncertainties (including correlations),
-                #   temporarily set Parameter values to these,
-                #   re-evaluate contrained parameters to extract stderr
-                #   and then set Parameters back to best-fit value
-                try:
-                    uvars = uncertainties.correlated_values(vbest, result.covar)
-                except (LinAlgError, ValueError):
-                    uvars = None
-                if uvars is not None:
-                    for par in params.values():
-                        eval_stderr(par, uvars, result.var_names, params)
-                    # restore nominal values
-                    for v, nam in zip(uvars, result.var_names):
-                        params[nam].value = v.nominal_value
-
-        if not result.errorbars:
+            result.covar = self._int2ext_cov_x(_cov, _best)
+            # calculate parameter uncertainties and correlations
+            self._calculate_uncertainties_correlations()
+        else:
             result.message = '%s Could not estimate error-bars.' % result.message
 
         np.seterr(**orig_warn_settings)

--- a/tests/test_covariance_matrix.py
+++ b/tests/test_covariance_matrix.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+import os
+
+import numpy as np
+from numpy import pi
+from numpy.testing import assert_allclose, assert_almost_equal
+
+from lmfit import minimize, Parameters
+from lmfit.models import VoigtModel
+
+
+def check(para, real_val, sig=3):
+    err = abs(para.value - real_val)
+    assert(err < sig * para.stderr)
+
+
+def check_wo_stderr(para, real_val, sig=0.1):
+    err = abs(para.value - real_val)
+    assert(err < sig)
+
+
+def check_paras(para_fit, para_real, sig=3):
+    for i in para_fit:
+        check(para_fit[i], para_real[i].value, sig=sig)
+
+
+def test_bounded_parameters():
+    # create data to be fitted
+    np.random.seed(1)
+    x = np.linspace(0, 15, 301)
+    data = (5. * np.sin(2 * x - 0.1) * np.exp(-x*x*0.025) +
+            np.random.normal(size=len(x), scale=0.2))
+
+    # define objective function: returns the array to be minimized
+    def fcn2min(params, x, data):
+        """ model decaying sine wave, subtract data"""
+        amp = params['amp']
+        shift = params['shift']
+        omega = params['omega']
+        decay = params['decay']
+
+        model = amp * np.sin(x * omega + shift) * np.exp(-x*x*decay)
+        return model - data
+
+    # create a set of Parameters
+    params = Parameters()
+    params.add('amp', value=10, min=0, max=50)
+    params.add('decay', value=0.1, min=0, max=10)
+    params.add('shift', value=0.0, min=-pi/2., max=pi/2.)
+    params.add('omega', value=3.0, min=0, max=np.inf)
+
+    # do fit, here with leastsq model
+    result = minimize(fcn2min, params, args=(x, data))
+
+    # assert that the real parameters are found
+    for para, val in zip(result.params.values(), [5, 0.025, -.1, 2]):
+        check(para, val)
+
+    # assert that the covariance matrix is correct [cf. lmfit v0.9.10]
+    cov_x = np.array([
+        [1.42428250e-03, 9.45395985e-06, -4.33997922e-05, 1.07362106e-05],
+        [9.45395985e-06, 1.84110424e-07, -2.90588963e-07, 7.19107184e-08],
+        [-4.33997922e-05, -2.90588963e-07, 9.53427031e-05, -2.37750362e-05],
+        [1.07362106e-05, 7.19107184e-08, -2.37750362e-05, 9.60952336e-06]])
+    assert_allclose(result.covar, cov_x, rtol=1e-6)
+
+    # assert that stderr and correlations are correct [cf. lmfit v0.9.10]
+    assert_almost_equal(result.params['amp'].stderr, 0.03773967, decimal=6)
+    assert_almost_equal(result.params['decay'].stderr, 4.2908e-04, decimal=6)
+    assert_almost_equal(result.params['shift'].stderr, 0.00976436, decimal=6)
+    assert_almost_equal(result.params['omega'].stderr, 0.00309992, decimal=6)
+
+    assert_almost_equal(result.params['amp'].correl['decay'],
+                        0.5838166760743324, decimal=6)
+    assert_almost_equal(result.params['amp'].correl['shift'],
+                        -0.11777303073961824, decimal=6)
+    assert_almost_equal(result.params['amp'].correl['omega'],
+                        0.09177027400788784, decimal=6)
+    assert_almost_equal(result.params['decay'].correl['shift'],
+                        -0.0693579417651835, decimal=6)
+    assert_almost_equal(result.params['decay'].correl['omega'],
+                        0.05406342001021014, decimal=6)
+    assert_almost_equal(result.params['shift'].correl['omega'],
+                        -0.7854644476455469, decimal=6)
+
+
+def test_bounds_expression():
+    # load data to be fitted
+    data = np.loadtxt(os.path.join(os.path.dirname(__file__), '..', 'examples',
+                                   'test_peak.dat'))
+    x = data[:, 0]
+    y = data[:, 1]
+
+    # define the model and initialize parameters
+    mod = VoigtModel()
+    params = mod.guess(y, x=x)
+    params['amplitude'].set(min=0, max=100)
+    params['center'].set(min=5, max=10)
+
+    # do fit, here with leastsq model
+    result = mod.fit(y, params, x=x)
+    print(result.fit_report())
+
+    # assert that stderr and correlations are correct [cf. lmfit v0.9.10]
+    assert_almost_equal(result.params['sigma'].stderr, 0.00368468, decimal=6)
+    assert_almost_equal(result.params['center'].stderr, 0.00505496, decimal=6)
+    assert_almost_equal(result.params['amplitude'].stderr, 0.13861506, decimal=6)
+    assert_almost_equal(result.params['gamma'].stderr, 0.00368468, decimal=6)
+    assert_almost_equal(result.params['fwhm'].stderr, 0.01326968, decimal=6)
+    assert_almost_equal(result.params['height'].stderr, 0.03009459, decimal=6)
+
+    assert_almost_equal(result.params['sigma'].correl['center'],
+                        -4.6623973788006615e-05, decimal=6)
+    assert_almost_equal(result.params['sigma'].correl['amplitude'],
+                        0.651304091954038, decimal=6)
+    assert_almost_equal(result.params['center'].correl['amplitude'],
+                        -4.390334984618851e-05, decimal=6)
+
+
+if __name__ == '__main__':
+    test_bounded_parameters()
+    test_bounds_expression()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -595,7 +595,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         self.assertTrue(np.isnan(result.chisqr))
         self.assertTrue(np.isnan(result.aic))
         self.assertFalse(result.errorbars)
-        self.assertTrue(result.params['amplitude'].stderr==0)
+        self.assertTrue(result.params['amplitude'].stderr is None)
         self.assertTrue(abs(result.params['amplitude'].value - 20.0) < 0.001)
 
         # with omit, should get good results


### PR DESCRIPTION
This PR contains some groundwork in preparation for working on Issue #169, in particular:

* do the MINUIT transformation to the external parameter space directly on the covariance matrix
* apply this method in ```leastsq``` and use the covariance matrix from ```scipy.leastsq``` instead of calculating it again from ```fjac``` and ```ipvt```.
* re-factor the code for calculating parameter uncertainties/correlactions into a method
* fix a test: now ```stderr``` is ```None```, when ```result.errorbars``` is ```False```
* add a (non-exhaustive) test to make sure the covariance matrix and uncertainties/correlations are still the same (compare to version 0.9.10). 

In the first commit (f3648f9), I explicitly assert-ed whether the "old" and "new" methods to get the transformed covariance matrix gave the same results, and for all my fits and running the tests, this was the case. I think the code is pretty straightforward and I've done quite a bit of testing, but a few more eyes on this won't hurt since it's a rather important piece of code in ```lmfit```. 

Once this is agreed upon, I'll experiment with a few methods to calculate the covariance matrix for solvers other than ```leastsq```, which can use then the same code to do the scaling and provide  uncertainties/correlations.