### PR TITLE
Parinit bounds

### DIFF
--- a/lmfit/jsonutils.py
+++ b/lmfit/jsonutils.py
@@ -60,7 +60,10 @@ def encode4js(obj):
     elif isinstance(obj, (np.float, np.int)):
         return float(obj)
     elif isinstance(obj, six.string_types):
-        return str(obj)
+        try:
+            return str(obj)
+        except:
+            return obj
     elif isinstance(obj, np.complex):
         return dict(__class__='Complex', value=(obj.real, obj.imag))
     elif isinstance(obj, (tuple, list)):

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 import json
 
 from asteval import Interpreter, get_ast_names, valid_symbol_name
-from numpy import arcsin, array, cos, inf, nan, sin, sqrt
+from numpy import arcsin, array, cos, inf, nan, sin, sqrt, isfinite
 import scipy.special
 import uncertainties
 
@@ -636,17 +636,15 @@ class Parameter(object):
             self.max = inf
         if self.min is None:
             self.min = -inf
-        if self._val is not None:
-            if self.min > self.max:
-                self.min, self.max = self.max, self.min
-            if isclose(self.min, self.max, atol=1e-13, rtol=1e-13):
-                raise ValueError("Parameter '%s' has min == max" % self.name)
-
-            if self._val > self.max:
-                self._val = self.max
-            if self._val < self.min:
-                self._val = self.min
-        elif self._expr is None:
+        if self._val is None:
+            self._val = -inf
+        if self.min > self.max:
+            self.min, self.max = self.max, self.min
+        if isclose(self.min, self.max, atol=1e-13, rtol=1e-13):
+            raise ValueError("Parameter '%s' has min == max" % self.name)
+        if self._val > self.max:
+            self._val = self.max
+        if self._val < self.min:
             self._val = self.min
         self.setup_bounds()
 
@@ -705,6 +703,8 @@ class Parameter(object):
             actually be used in a fit.
 
         """
+        # print("setup bounds ", self.min, self.max, self._val)
+
         if self.min is None:
             self.min = -inf
         if self.max is None:

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -201,6 +201,17 @@ class TestParameters(unittest.TestCase):
         assert_(isclose(np.inf, np.inf))
         assert_(not isclose(np.nan, np.nan))
 
+    def test_expr_with_bounds(self):
+        "test an expression with bounds, without value"
+        pars = Parameters()
+        pars.add('c1', value=0.2)
+        pars.add('c2', value=0.2)
+        pars.add('c3', value=0.2)
+        pars.add('csum', value=0.8)
+        # this should not raise TypeError:
+        pars.add('c4', expr='csum-c1-c2-c3', min=0, max=1)
+        assert_(isclose(pars['c4'].value, 0.2))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR does a better job of initializing a Parameter value, especially for bounded expressions. Basically, in the case where `value` is `None`, it assigns that to `-Inf` sooner.

A test is included.