### PR TITLE
Add python3.7 to Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7-dev
 
 # test minium required and latest versions of SciPy and NumPy
 env:
@@ -24,9 +25,11 @@ before_install:
     - conda info -a
 
 install:
-    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION != 3.6 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy=1.10 scipy=0.17 six=1.10 nose; fi
-    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION == 3.6 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy=1.12 scipy=0.18 six=1.10 nose; fi
-    - if [[ $version == latest ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy six pandas matplotlib dill nose; fi
+    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION != 3.6 && $TRAVIS_PYTHON_VERSION != 3.7-dev ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy=1.10 scipy=0.17 six=1.10 nose; fi
+    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION == 3.6 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy=1.11.2 scipy=0.18 six=1.10 nose; fi
+    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION == 3.7-dev ]]; then conda create -q -n test_env python=3.7 numpy=1.11.3 scipy=1.1 six=1.11 nose; fi
+    - if [[ $version == latest && $TRAVIS_PYTHON_VERSION != 3.7-dev ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy six pandas matplotlib dill nose; fi
+    - if [[ $version == latest && $TRAVIS_PYTHON_VERSION == 3.7-dev ]]; then conda create -q -n test_env python=3.7 numpy scipy six pandas matplotlib dill nose; fi
     - source activate test_env
     - pip install asteval
     - pip install emcee


### PR DESCRIPTION
Travis CI has some issues with Python 3.7 and does not support the ```3.7``` version; however, ```3.7-dev``` works. This installs an old, pre-release version of Python (alpha4), but since we use ```conda``` anyway, it doesn't really matter for us. This workaround allows us to test Python 3.7 right now and we can change to ```3.7``` when Travis officially supports it.