### PR TITLE
fixed #486

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -826,6 +826,8 @@ class Parameter(object):
         if val is None:
             self._expr_ast = None
         if val is not None and self._expr_eval is not None:
+            self._expr_eval.error = []
+            self._expr_eval.error_msg = None
             self._expr_ast = self._expr_eval.parse(val)
             check_ast_errors(self._expr_eval)
             self._expr_deps = get_ast_names(self._expr_ast)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -212,6 +212,23 @@ class TestParameters(unittest.TestCase):
         pars.add('c4', expr='csum-c1-c2-c3', min=0, max=1)
         assert_(isclose(pars['c4'].value, 0.2))
 
+    def test_invalid_expr_exceptions(self):
+        "test if an exception is raised for invalid expressions (GH486)"""
+        p1 = Parameters()
+        p1.add('t', 2.0, min=0.0, max=5.0)
+        p1.add('x', 10.0)
+        with self.assertRaises(SyntaxError):
+            p1.add('y', expr='x*t + sqrt(t)/')
+        assert(len(p1['y']._expr_eval.error) > 0)
+        p1.add('y', expr='x*t + sqrt(t)/3.0')
+        p1['y'].set(expr='x*3.0 + t**2')
+        assert('x*3' in p1['y'].expr)
+        assert(len(p1['y']._expr_eval.error) == 0)
+        with self.assertRaises(SyntaxError):
+            p1['y'].set(expr='t+')
+        assert(len(p1['y']._expr_eval.error) > 0)
+        assert_almost_equal(p1['y'].value, 34.0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A test is not needed since all this does is clear the list `parameter._expr_eval.errors` **before** parsing a newly given parameter expression string. The only use of this list is to compare if its length is >0 **after** trying to parse the expression. If it is, an exception is raised.

For more detail, see #486.