### PR TITLE
calculate uncertainties in least_squares method

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1294,6 +1294,14 @@ class Minimizer(object):
 
         result._calculate_statistics()
 
+        # calculate the cov_x and estimate uncertainties/correlations
+        try:
+            hess = np.matmul(ret.jac.T, ret.jac)
+            result.covar = np.linalg.inv(hess)
+            self._calculate_uncertainties_correlations()
+        except LinAlgError:
+            pass
+
         return result
 
     def leastsq(self, params=None, **kws):
@@ -1738,7 +1746,7 @@ class Minimizer(object):
             Name of the fitting method to use. Valid values are:
 
             - `'leastsq'`: Levenberg-Marquardt (default)
-            - `'least_squares'`: Least-Squares minimization, using Trust Region Reflective method by default
+            - `'least_squares'`: Least-Squares minimization, using Trust Region Reflective method
             - `'differential_evolution'`: differential evolution
             - `'brute'`: brute force method
             - `'basinhopping'`: basinhopping
@@ -2047,7 +2055,7 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None,
         Name of the fitting method to use. Valid values are:
 
         - `'leastsq'`: Levenberg-Marquardt (default)
-        - `'least_squares'`: Least-Squares minimization, using Trust Region Reflective method by default
+        - `'least_squares'`: Least-Squares minimization, using Trust Region Reflective method
         - `'differential_evolution'`: differential evolution
         - `'brute'`: brute force method
         - `'basinhopping'`: basinhopping

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -697,6 +697,8 @@ class Minimizer(object):
 
     def _calculate_uncertainties_correlations(self):
         """Calculate parameter uncertainties and correlations."""
+        self.result.errorbars = True
+
         if self.scale_covar:
             self.result.covar *= self.result.redchi
 

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -292,8 +292,7 @@ def test_scalar_minimize_reduce_fcn():
 
     yo = 1.0 + 2.0*np.sin(4*x) * np.exp(-x / 5)
     y = yo + np.random.normal(size=len(yo), scale=0.250)
-    outliers = np.random.random_integers(int(len(x)/3.0), len(x)-1,
-                                         int(len(x)/12))
+    outliers = np.random.randint(int(len(x)/3.0), len(x), int(len(x)/12))
     y[outliers] += 5*np.random.random(len(outliers))
 
     # define objective function: returns the array to be minimized


### PR DESCRIPTION
This PR adds the calculation of parameter uncertainties/correlations to the ```least_squares``` method. 

I am still working on using ```numdifftools``` to get the covariance matrix for the scalar_minimizers, which works for non-bounded fits, but does not yet work correctly when bounds are specified... to be continued. Nevertheless, if the optimizer provides enough information already to calculate the covariance matrix, as is the case for ```least_squares``` (which gives the Jacobian) there is no need to use any external algorithms. A test is added to confirm that the results are the same as obtained for ```leastsq```.  

In addition, ```results.errorbars``` is set to ```True``` in the function ```_calculate_uncertainties_correlations```. Finally, a unrelated DeprecationWarning is addressed in one of the tests.