### PR TITLE
add numdifftools to estimate parameter uncertainties/correlations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
     - export PATH="$HOME/miniconda/bin:$PATH"
     - hash -r
     - conda config --set always_yes yes --set changeps1 no
+    - conda config --add channels conda-forge
     - conda update -q conda
     - conda info -a
 

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -119,7 +119,9 @@ variables, as discussed in :ref:`fit-results-label`.
 Alternative algorithms can also be used by providing the ``method``
 keyword to the :func:`minimize` function or :meth:`Minimizer.minimize`
 class as listed in the :ref:`Table of Supported Fitting Methods
-<fit-methods-table>`.
+<fit-methods-table>`. If you have the `numdifftools` package installed, lmfit
+will try to estimate the covariance matrix and determine parameter
+uncertainties and correlations if `calc_covar` is True (default).
 
 .. _fit-methods-table:
 
@@ -181,10 +183,13 @@ class as listed in the :ref:`Table of Supported Fitting Methods
 
 .. warning::
 
-  Much of this documentation assumes that the Levenberg-Marquardt method is
-  used.  Many of the fit statistics and estimates for uncertainties in
-  parameters discussed in :ref:`fit-results-label` are done only for this
-  method.
+  Much of this documentation assumes that the Levenberg-Marquardt (`leastsq`)
+  method is used. Many of the fit statistics and estimates for uncertainties in
+  parameters discussed in :ref:`fit-results-label` are done only unconditionally
+  for this (and the `least_squares`) method. Lmfit versions newer than 0.9.11
+  provide the capability to use `numdifftools` to estimate the covariance matrix
+  and calculate parameter uncertainties and correlations for other methods as
+  well.
 
 ..  _fit-results-label:
 
@@ -259,14 +264,16 @@ that the returned residual function is scaled properly to the
 uncertainties in the data.  For these statistics to be meaningful, the
 person writing the function to be minimized **must** scale them properly.
 
-After a fit using the :meth:`leastsq` method has completed
-successfully, standard errors for the fitted variables and correlations
-between pairs of fitted variables are automatically calculated from the
-covariance matrix.  The standard error (estimated :math:`1\sigma`
-error-bar) goes into the :attr:`stderr` attribute of the Parameter.  The
-correlations with all other variables will be put into the
-:attr:`correl` attribute of the Parameter -- a dictionary with keys for
-all other Parameters and values of the corresponding correlation.
+After a fit using the :meth:`leastsq` or :meth:`least_squares` method has
+completed successfully, standard errors for the fitted variables and
+correlations between pairs of fitted variables are automatically calculated from
+the covariance matrix. For other methods, the `calc_covar` parameter (default is
+True) in the :class:`Minimizer` class determines whether or not to use the
+`numdifftools` package to estimate the covariance matrix. The standard error
+(estimated :math:`1\sigma` error-bar) goes into the :attr:`stderr` attribute of
+the Parameter. The correlations with all other variables will be put into the
+:attr:`correl` attribute of the Parameter -- a dictionary with keys for all
+other Parameters and values of the corresponding correlation.
 
 In some cases, it may not be possible to estimate the errors and
 correlations.  For example, if a variable actually has no practical effect

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -16,6 +16,8 @@ Downloading and Installation
 .. _asteval:  https://github.com/newville/asteval
 .. _six:  https://github.com/benjaminp/six
 .. _uncertainties:  https://github.com/lebigot/uncertainties
+.. _numdifftools:  https://github.com/pbrod/numdifftools
+
 
 Prerequisites
 ~~~~~~~~~~~~~~~
@@ -31,8 +33,8 @@ uncertainties version 3.0 are the minimum requirements.
 In order to run the test suite, either the `nose`_ or `pytest`_ package is
 required. Some functionality of lmfit requires the `emcee`_ package, some
 functionality will make use of the `pandas`_, `Jupyter`_, `matplotlib`_,
-or `dill`_ packages if available.  We highly recommend each of these
-packages.
+`dill`_,  or `numdifftools`_ packages if available.  We highly recommend each of
+these packages.
 
 
 Downloads

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -925,7 +925,8 @@ class Minimizer(object):
         result._calculate_statistics()
 
         # calculate the cov_x and estimate uncertanties/correlations
-        if self.calc_covar and HAS_NUMDIFFTOOLS:
+        if (self.calc_covar and HAS_NUMDIFFTOOLS and
+                len(result.residual) > len(result.var_names)):
             _covar_ndt = self._calculate_covariance_matrix(result.x)
             if _covar_ndt is not None:
                 result.covar = self._int2ext_cov_x(_covar_ndt, result.x)
@@ -1532,7 +1533,8 @@ class Minimizer(object):
         result._calculate_statistics()
 
         # calculate the cov_x and estimate uncertanties/correlations
-        if self.calc_covar and HAS_NUMDIFFTOOLS:
+        if (self.calc_covar and HAS_NUMDIFFTOOLS and
+                len(result.residual) > len(result.var_names)):
             _covar_ndt = self._calculate_covariance_matrix(ret.x)
             if _covar_ndt is not None:
                 result.covar = self._int2ext_cov_x(_covar_ndt, ret.x)
@@ -1806,7 +1808,8 @@ class Minimizer(object):
         result._calculate_statistics()
 
         # calculate the cov_x and estimate uncertanties/correlations
-        if self.calc_covar and HAS_NUMDIFFTOOLS:
+        if (self.calc_covar and HAS_NUMDIFFTOOLS and
+                len(result.residual) > len(result.var_names)):
             _covar_ndt = self._calculate_covariance_matrix(result.ampgo_x0)
             if _covar_ndt is not None:
                 result.covar = self._int2ext_cov_x(_covar_ndt, result.ampgo_x0)

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -333,7 +333,7 @@ class MinimizerResult(object):
             self.chisqr = self.residual
             self.ndata = 1
             self.nfree = 1
-        self.redchi = self.chisqr / self.nfree
+        self.redchi = self.chisqr / max(1, self.nfree)
         # this is -2*loglikelihood
         _neg2_log_likel = self.ndata * np.log(self.chisqr / self.ndata)
         self.aic = _neg2_log_likel + 2 * self.nvarys

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -924,6 +924,13 @@ class Minimizer(object):
 
         result._calculate_statistics()
 
+        # calculate the cov_x and estimate uncertanties/correlations
+        if self.calc_covar and HAS_NUMDIFFTOOLS:
+            _covar_ndt = self._calculate_covariance_matrix(result.x)
+            if _covar_ndt is not None:
+                result.covar = self._int2ext_cov_x(_covar_ndt, result.x)
+                self._calculate_uncertainties_correlations()
+
         return result
 
     def emcee(self, params=None, steps=1000, nwalkers=100, burn=0, thin=1,
@@ -1524,6 +1531,13 @@ class Minimizer(object):
 
         result._calculate_statistics()
 
+        # calculate the cov_x and estimate uncertanties/correlations
+        if self.calc_covar and HAS_NUMDIFFTOOLS:
+            _covar_ndt = self._calculate_covariance_matrix(ret.x)
+            if _covar_ndt is not None:
+                result.covar = self._int2ext_cov_x(_covar_ndt, ret.x)
+                self._calculate_uncertainties_correlations()
+
         return result
 
     def brute(self, params=None, Ns=20, keep=50):
@@ -1790,6 +1804,13 @@ class Minimizer(object):
             pass
 
         result._calculate_statistics()
+
+        # calculate the cov_x and estimate uncertanties/correlations
+        if self.calc_covar and HAS_NUMDIFFTOOLS:
+            _covar_ndt = self._calculate_covariance_matrix(result.ampgo_x0)
+            if _covar_ndt is not None:
+                result.covar = self._int2ext_cov_x(_covar_ndt, result.ampgo_x0)
+                self._calculate_uncertainties_correlations()
 
         return result
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -710,7 +710,7 @@ class Minimizer(object):
             Hfun = ndt.Hessian(self.penalty, full_output=True)
             hessian_ndt, info = Hfun(fvars)
             cov_x = inv(hessian_ndt) * 2.0
-        except LinAlgError:
+        except (LinAlgError, ValueError):
             return None
         finally:
             self.result.nfev = nfev


### PR DESCRIPTION
This PR addresses Issue #169 and allows for the estimation of parameter uncertainties and correlations for minimizers other than ```leastsq``` and ```least_squares```. In order to do so, it requires the ```numdifftools``` package to be installed.

A parameter, ```calc_covar```, is added to the Minimizer and Model classes (default is True) and can be set to False if one does not want to calculate the covariance matrix. Test are added to check whether everything works as intended for a simple case.

To avoid failures of existing tests, it seems a requirement that ```result.residual``` has a length greater than the number of fitting parameters. I think that's correct, but would appreciate others to take a look at this and the rest of the code (in particular the Model class). Additionally, I have tested the examples in the documentation with different scalar_minimizers and the uncertainties/correlations agree very well with those obtained using ```leastsq```.

The docstring of affected code has been updated, but no changes are made yet to the main documentation (I will do that hopefully soon-ish). There are some changes here that will probably conflict with PR #505, so that one should probably be merged first. In short, this PR is not fully ready yet to be merged, but I submit it now to elicit some feedback and testing on more complicated, "real-life" fitting problems. Ideally, if you do a fit with ```nelder``` and then use these results as starting values for a ```leastsq``` minimization, the reported uncertainties/correlations should be fairly similar in both cases. Please give it a try and report back here - thanks!