### PR TITLE
Add `usersyms` to Parameters() initialization

### DIFF
--- a/lmfit/jsonutils.py
+++ b/lmfit/jsonutils.py
@@ -34,8 +34,9 @@ else:
         """b64encode wrapper, Python 2 version."""
         return str(b64encode(val))
 
+
 def find_importer(obj):
-    "find importer of an object"
+    """find importer of an object"""
     oname = obj.__name__
     for modname, module in sys.modules.items():
         if modname.startswith('__main__'):
@@ -45,13 +46,16 @@ def find_importer(obj):
             return modname
     return None
 
+
 def import_from(modulepath, objectname):
+    """wrapper for __import__ for nested objects"""
     path = modulepath.split('.')
     top = path.pop(0)
     parent = __import__(top)
     while len(path) > 0:
         parent = getattr(parent, path.pop(0))
     return getattr(parent, objectname)
+
 
 def encode4js(obj):
     """Prepare an object for json encoding.
@@ -148,7 +152,7 @@ def decode4js(obj):
         if pyvers == obj['pyversion'] and HAS_DILL:
             out = dill.loads(bindecode(obj['value']))
         elif obj['importer'] is not None:
-            out  = import_from(obj['importer'], val)
+            out = import_from(obj['importer'], val)
 
     elif classname in ('Dict', 'dict'):
         out = {}

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1576,7 +1576,7 @@ class ModelResult(Minimizer):
                'model': encode4js(self.model._get_state())}
         pasteval = self.params._asteval
         out['params'] = [p.__getstate__() for p in self.params.values()]
-        out['unique_symbols'] = {key: pasteval.symtable[key]
+        out['unique_symbols'] = {key: encode4js(pasteval.symtable[key])
                                  for key in pasteval.user_defined_symbols()}
 
         for attr in ('aborted', 'aic', 'best_values', 'bic', 'chisqr',

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from lmfit import Parameters, Parameter
+from lmfit import Parameters, Parameter, Model
 from lmfit.parameter import isclose
 from numpy.testing import assert_, assert_almost_equal, assert_equal
 import unittest
@@ -167,6 +167,23 @@ class TestParameters(unittest.TestCase):
         pkl = pickle.dumps(p)
         q = pickle.loads(pkl)
 
+    def test_params_usersyms(self):
+        # test passing usersymes to Parameters()
+        def myfun(x):
+            return x**3
+
+        params = Parameters(usersyms={"myfun": myfun})
+        params.add("a", value=2.3)
+        params.add("b", expr="myfun(a)")
+
+        xx = np.linspace(0, 1, 10)
+        yy = 3 * xx + np.random.normal(scale=0.002, size=len(xx))
+
+        model = Model(lambda x, a: a * x)
+        result = model.fit(yy, params=params, x=xx)
+        assert_(isclose(result.params['a'].value, 3.0, rtol=0.025))
+        assert_(result.nfev > 3)
+        assert_(result.nfev < 300)
 
     def test_set_symtable(self):
         # test that we use Parameter.set(value=XXX) and have


### PR DESCRIPTION
This PR attempts to address #507.    The main idea is to add a `usersyms` keyword to `Parameters.__init__()` to make it easier to add custion functions and symbols, as with:

```python 
def myfun(x):
       return x*x

params = Parameters(usersyms={'myfun': myfun})
```

This works failrly simply itself (and a test is added based on the simple example in #507).  With this change, we could probably deprecate the `asteval` argument to `Parameters.__init__()`. 

However, a complication arises in `dump/load` of Parameters that contain an added reference to a numpy ufunc (and, to be clear we always do this).  Previously we were sort of cheating (when dill was not available) by assuming we knew which functions and ufuncs we were adding to the asteval interpreter.   When a user adds a user symbol, we really cannot use that trick.

Because of this complication there are additional changes, especially to how the encode/decode functions in `jsonutils.py` work when `dill` is not available.   Now if a function needs to be saved to json and `dill` is not available, the import location of the method or numpy ufunc is recorded on `dump` and then that location is used on `load`to re-import in the new session.   

This was needed to pass the `dump/load` tests here.  I think this should be a robust way to dump/load functions/ufuncs in general (including multiprocessing) as long as the import locations don't change (but if yhey do, probably no method is actually reliable).  Of course, it has not been heavily tested for that sort of application.
