### PR TITLE
Add emcee

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1844,6 +1844,7 @@ class Minimizer(object):
             - `'trust-constr'`: trust-region for constrained optimization (SciPy >= 1.1)
             - `'dogleg'`: Dog-leg trust-region
             - `'slsqp'`: Sequential Linear Squares Programming
+            - `'emcee'`: Maximum liklihood via Monte-Carlo Markov Chain
 
             In most cases, these methods wrap and use the method with the
             same name from `scipy.optimize`, or use
@@ -1889,6 +1890,8 @@ class Minimizer(object):
             function = self.basinhopping
         elif user_method == 'ampgo':
             function = self.ampgo
+        elif user_method == 'emcee':
+            function = self.emcee
         else:
             function = self.scalar_minimize
             for key, val in SCALAR_METHODS.items():
@@ -2154,6 +2157,7 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None, iter_cb=None,
         - `'trust-constr'`: trust-region for constrained optimization (SciPy >= 1.1)
         - `'dogleg'`: Dog-leg trust-region
         - `'slsqp'`: Sequential Linear Squares Programming
+        - `'emcee'`: Maximum liklihood via Monte-Carlo Markov Chain
 
         In most cases, these methods wrap and use the method of the same
         name from `scipy.optimize`, or use `scipy.optimize.minimize` with

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -751,8 +751,8 @@ class Minimizer(object):
         if self.scale_covar:
             self.result.covar *= self.result.redchi
 
-        vbest = np.atleast_1d([self.result.params[name].value for i, name in
-                               enumerate(self.result.var_names)])
+        vbest = np.atleast_1d([self.result.params[name].value for name in
+                               self.result.var_names])
 
         has_expr = False
         for par in self.result.params.values():


### PR DESCRIPTION
## Submission checklist:
##  1. Follow PEP-8 as closely as possible
Yes, except for line lengths. Also removed unrelated unused variable from previous author to make more pep-8 compliant.
##  2. Reference Issue #
N/A
##  3. Add a test or explain why this is not needed.
Doesn't change any existing test coverage (i.e. only adds a new way to access existing code)

##  4. Consider if an example is needed.
```
fitter = Minimizer(fcn, params, fcn_args, fcn_kws, **fit_kws)
fitter.minimize(method='emcee')
```
##  5. Include changes to main documentation if the API changes or a new feature is added.
Updated docstrings accordingly.

# Describe changes here

There are several class methods of Minimizer that return a MinimizerResult object, and set the method attribute of that object. Currently, `Minimizer.emcee` is the only one that is not accessible by passing the `method` kwarg to `Minimizer.minimize`.

The reason why `'emcee'` should be added as an option for the `method` kwarg to `Minimizer.minimize` is because when you want to run a fit on a `Model` object by calling `Model.fit`, that calls `Minimizer.minimize` under the hood. There is no way to run emcee directly on a `Model` class (since there is no transparent access to the `Minimizer` class from the `Model` object) without first running any other fit method and then calling the emcee method of `ModelResult` object.

Note: MCMC sampling process is not strictly a minimization routine, but under certain constraints the maximum likelihood estimate should be identical to the output of a least-squares routine that minimizes Chi-square. In other words, it is possible to use emcee to "fit" to the model in addition to just calculating better parameter covariances.

# Describe changes to tests and/or docs here
Updated docstrings to show the expanded cabability.