### PR TITLE
Add Double Lorentzian Model

### DIFF
--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -62,10 +62,10 @@ methods for all of these make a fairly crude guess for the value of
 
 .. autoclass:: LorentzianModel
 
-:class:`DoubleLorentzianModel`
+:class:`SplitLorentzianModel`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: DoubleLorentzianModel
+.. autoclass:: SplitLorentzianModel
 
 
 :class:`VoigtModel`

--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -62,6 +62,11 @@ methods for all of these make a fairly crude guess for the value of
 
 .. autoclass:: LorentzianModel
 
+:class:`DoubleLorentzianModel`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: DoubleLorentzianModel
+
 
 :class:`VoigtModel`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -18,7 +18,7 @@ functions = ('gaussian', 'lorentzian', 'voigt', 'pvoigt', 'moffat', 'pearson7',
              'students_t', 'expgaussian', 'donaich', 'skewed_gaussian',
              'skewed_voigt', 'step', 'rectangle', 'erf', 'erfc', 'wofz',
              'gamma', 'gammaln', 'exponential', 'powerlaw', 'linear',
-             'parabolic', 'sine', 'expsine')
+             'parabolic', 'sine', 'expsine', 'double_lorentzian')
 
 
 def gaussian(x, amplitude=1.0, center=0.0, sigma=1.0):
@@ -39,6 +39,29 @@ def lorentzian(x, amplitude=1.0, center=0.0, sigma=1.0):
 
     """
     return (amplitude/(1 + ((1.0*x-center)/sigma)**2)) / (pi*sigma)
+
+
+def double_lorentzian(x, amplitude=1.0, center=0.0, sigma=1.0, sigma_r=1.0):
+    """Return a 1-dimensional double-sided Lorentzian function.
+
+    Double-sided means that width of the function is different between
+    left and right slope of the function. The peak height is calculated
+    from the condition that the integral from -.inf to +.inf is equal
+    to amplitude.
+
+    double_lorentzian(x, amplitude, center, sigma, sigma_r) =
+        amplitude * 2 / pi / (sigma + sigma_r) * \
+        (1 / (1 + (dx / sigma)**2) * step(-dx)
+         + 1 / (1 + (dx / sigma_r)**2) * step(dx))
+
+    """
+    def step(x):
+        return 1.0 * (x >= 0)
+
+    dx = 1.0 * x - center
+    return amplitude * 2 / pi / (sigma + sigma_r) * \
+        (1 / (1 + (dx / sigma)**2) * step(-dx)
+         + 1 / (1 + (dx / sigma_r)**2) * step(dx))
 
 
 def voigt(x, amplitude=1.0, center=0.0, sigma=1.0, gamma=None):

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -51,17 +51,13 @@ def double_lorentzian(x, amplitude=1.0, center=0.0, sigma=1.0, sigma_r=1.0):
 
     double_lorentzian(x, amplitude, center, sigma, sigma_r) =
         amplitude * 2 / pi / (sigma + sigma_r) * \
-        (1 / (1 + (dx / sigma)**2) * heaviside_step(-dx)
-         + 1 / (1 + (dx / sigma_r)**2) * heaviside_step(dx))
+        (1 / (1 + ((x - center) / sigma)**2) * (x < center)
+         + 1 / (1 + ((x - center) / sigma_r)**2) * (x >= center))
 
     """
-    def heaviside_step(x):
-        return 1.0 * (x >= 0)
-
-    dx = 1.0 * x - center
     return amplitude * 2 / pi / (sigma + sigma_r) * \
-        (1 / (1 + (dx / sigma)**2) * heaviside_step(-dx)
-         + 1 / (1 + (dx / sigma_r)**2) * heaviside_step(dx))
+        (1 / (1 + ((x - center) / sigma)**2) * (x < center)
+         + 1 / (1 + ((x - center) / sigma_r)**2) * (x >= center))
 
 
 def voigt(x, amplitude=1.0, center=0.0, sigma=1.0, gamma=None):

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -79,7 +79,7 @@ def pvoigt(x, amplitude=1.0, center=0.0, sigma=1.0, fraction=0.5):
     """Return a 1-dimensional pseudo-Voigt function.
 
     pvoigt(x, amplitude, center, sigma, fraction) =
-       amplitude*(1-fraction)*gaussion(x, center, sigma_g) +
+       amplitude*(1-fraction)*gaussian(x, center, sigma_g) +
        amplitude*fraction*lorentzian(x, center, sigma)
 
     where sigma_g (the sigma for the Gaussian component) is

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -46,8 +46,8 @@ def double_lorentzian(x, amplitude=1.0, center=0.0, sigma=1.0, sigma_r=1.0):
 
     Double-sided means that width of the function is different between
     left and right slope of the function. The peak height is calculated
-    from the condition that the integral from -.inf to +.inf is equal
-    to amplitude.
+    from the condition that the integral from ``-.inf`` to ``+.inf`` is equal
+    to ``amplitude``.
 
     double_lorentzian(x, amplitude, center, sigma, sigma_r) =
         amplitude * 2 / pi / (sigma + sigma_r) * \

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -18,7 +18,7 @@ functions = ('gaussian', 'lorentzian', 'voigt', 'pvoigt', 'moffat', 'pearson7',
              'students_t', 'expgaussian', 'donaich', 'skewed_gaussian',
              'skewed_voigt', 'step', 'rectangle', 'erf', 'erfc', 'wofz',
              'gamma', 'gammaln', 'exponential', 'powerlaw', 'linear',
-             'parabolic', 'sine', 'expsine', 'double_lorentzian')
+             'parabolic', 'sine', 'expsine', 'split_lorentzian')
 
 
 def gaussian(x, amplitude=1.0, center=0.0, sigma=1.0):
@@ -41,15 +41,15 @@ def lorentzian(x, amplitude=1.0, center=0.0, sigma=1.0):
     return (amplitude/(1 + ((1.0*x-center)/sigma)**2)) / (pi*sigma)
 
 
-def double_lorentzian(x, amplitude=1.0, center=0.0, sigma=1.0, sigma_r=1.0):
-    """Return a 1-dimensional double-sided Lorentzian function.
+def split_lorentzian(x, amplitude=1.0, center=0.0, sigma=1.0, sigma_r=1.0):
+    """Return a 1-dimensional piecewise Lorentzian function.
 
-    Double-sided means that width of the function is different between
+    Split means that width of the function is different between
     left and right slope of the function. The peak height is calculated
     from the condition that the integral from ``-.inf`` to ``+.inf`` is equal
     to ``amplitude``.
 
-    double_lorentzian(x, amplitude, center, sigma, sigma_r) =
+    split_lorentzian(x, amplitude, center, sigma, sigma_r) =
         amplitude * 2 / pi / (sigma + sigma_r) * \
         (1 / (1 + ((x - center) / sigma)**2) * (x < center)
          + 1 / (1 + ((x - center) / sigma_r)**2) * (x >= center))

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -51,17 +51,17 @@ def double_lorentzian(x, amplitude=1.0, center=0.0, sigma=1.0, sigma_r=1.0):
 
     double_lorentzian(x, amplitude, center, sigma, sigma_r) =
         amplitude * 2 / pi / (sigma + sigma_r) * \
-        (1 / (1 + (dx / sigma)**2) * step(-dx)
-         + 1 / (1 + (dx / sigma_r)**2) * step(dx))
+        (1 / (1 + (dx / sigma)**2) * heaviside_step(-dx)
+         + 1 / (1 + (dx / sigma_r)**2) * heaviside_step(dx))
 
     """
-    def step(x):
+    def heaviside_step(x):
         return 1.0 * (x >= 0)
 
     dx = 1.0 * x - center
     return amplitude * 2 / pi / (sigma + sigma_r) * \
-        (1 / (1 + (dx / sigma)**2) * step(-dx)
-         + 1 / (1 + (dx / sigma_r)**2) * step(dx))
+        (1 / (1 + (dx / sigma)**2) * heaviside_step(-dx)
+         + 1 / (1 + (dx / sigma_r)**2) * heaviside_step(dx))
 
 
 def voigt(x, amplitude=1.0, center=0.0, sigma=1.0, gamma=None):

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -9,7 +9,7 @@ from .lineshapes import (breit_wigner, damped_oscillator, dho, donaich,
                          expgaussian, exponential, gaussian, linear, lognormal,
                          lorentzian, moffat, parabolic, pearson7, powerlaw,
                          pvoigt, rectangle, skewed_gaussian, skewed_voigt,
-                         step, students_t, voigt)
+                         step, students_t, voigt, double_lorentzian)
 from .model import Model
 
 
@@ -374,6 +374,58 @@ class LorentzianModel(Model):
     def guess(self, data, x=None, negative=False, **kwargs):
         """Estimate initial model parameter values from data."""
         pars = guess_from_peak(self, data, x, negative, ampscale=1.25)
+        return update_param_vals(pars, self.prefix, **kwargs)
+
+    __init__.__doc__ = COMMON_INIT_DOC
+    guess.__doc__ = COMMON_GUESS_DOC
+
+
+class DoubleLorentzianModel(Model):
+    r"""A model based on a Lorentzian or Cauchy-Lorentz distribution function
+    (see https://en.wikipedia.org/wiki/Cauchy_distribution), with four
+    parameters: ``amplitude``, ``center``, ``sigma``, and ``sigma_r``.
+
+    'Double' means that the width of the distribution is different between
+    left and right slopes.
+
+    In addition, parameters ``fwhm`` and ``height`` are included as constraints
+    to report full width at half maximum and maximum peak height, respectively.
+
+    .. math::
+
+        f(x; A, \mu, \sigma, \sigma_r) = \frac{2 A}{\pi (\sigma+\sigma_r)} \big[\frac{1}{(x - \mu)^2 + \sigma^2} * H(\mu-x, 1) + \frac{1}{(x - \mu)^2 + \sigma_r^2} * H(x-\mu, 0)\big]
+
+    where the parameter ``amplitude`` corresponds to :math:`A`, ``center`` to
+    :math:`\mu`, ``sigma`` to :math:`\sigma`, and ``sigma_l`` to
+    :math:`\sigma_l`, and :math:`H(x)` is a Heaviside step function:
+
+    .. math::
+
+        H(x) = 0 | x < 0, 1 | x >= 0
+
+    The full width at half maximum is :math:`\sigma_l+\sigma_r`. Just as with
+    the Lorentzian model, integral of this function from -.inf to +.inf
+    equals to `amplitude`.
+    """
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
+                 **kwargs):
+        kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
+                       'independent_vars': independent_vars})
+        super(DoubleLorentzianModel, self).__init__(double_lorentzian, **kwargs)
+        self._set_paramhints_prefix()
+
+    def _set_paramhints_prefix(self):
+        self.set_param_hint('sigma', min=0)
+        self.set_param_hint('sigma_r', min=0)
+        self.set_param_hint('fwhm', expr='sigma+sigma_r')
+        self.set_param_hint(
+            'height', expr='2*amplitude/{:.7f}/(sigma+sigma_r)'.format(np.pi))
+
+    def guess(self, data, x=None, negative=False, **kwargs):
+        """Estimate initial model parameter values from data."""
+        pars = guess_from_peak(self, data, x, negative, ampscale=1.25)
+        sigma = pars['sigma']
+        pars['sigma_r'].set(value=sigma.value, min=sigma.min, max=sigma.max)
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -385,27 +385,27 @@ class DoubleLorentzianModel(Model):
     (see https://en.wikipedia.org/wiki/Cauchy_distribution), with four
     parameters: ``amplitude``, ``center``, ``sigma``, and ``sigma_r``.
 
-    'Double' means that the width of the distribution is different between
-    left and right slopes.
-
     In addition, parameters ``fwhm`` and ``height`` are included as constraints
     to report full width at half maximum and maximum peak height, respectively.
 
+    'Double' means that the width of the distribution is different between
+    left and right slopes.
+
     .. math::
 
-        f(x; A, \mu, \sigma, \sigma_r) = \frac{2 A}{\pi (\sigma+\sigma_r)} \big[\frac{1}{(x - \mu)^2 + \sigma^2} * H(\mu-x, 1) + \frac{1}{(x - \mu)^2 + \sigma_r^2} * H(x-\mu, 0)\big]
+        f(x; A, \mu, \sigma, \sigma_r) = \frac{2 A}{\pi (\sigma+\sigma_r)} \big[\frac{1}{(x - \mu)^2 + \sigma^2} * H(\mu-x) + \frac{1}{(x - \mu)^2 + \sigma_r^2} * H(x-\mu)\big]
 
     where the parameter ``amplitude`` corresponds to :math:`A`, ``center`` to
-    :math:`\mu`, ``sigma`` to :math:`\sigma`, and ``sigma_l`` to
+    :math:`\mu`, ``sigma`` to :math:`\sigma`, ``sigma_l`` to
     :math:`\sigma_l`, and :math:`H(x)` is a Heaviside step function:
 
     .. math::
 
-        H(x) = 0 | x < 0, 1 | x >= 0
+        H(x) = 0 | x < 0, 1 | x \geq 0
 
     The full width at half maximum is :math:`\sigma_l+\sigma_r`. Just as with
-    the Lorentzian model, integral of this function from -.inf to +.inf
-    equals to `amplitude`.
+    the Lorentzian model, integral of this function from ``-.inf`` to
+    ``+.inf`` equals to ``amplitude``.
     """
     def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  **kwargs):

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -9,7 +9,7 @@ from .lineshapes import (breit_wigner, damped_oscillator, dho, donaich,
                          expgaussian, exponential, gaussian, linear, lognormal,
                          lorentzian, moffat, parabolic, pearson7, powerlaw,
                          pvoigt, rectangle, skewed_gaussian, skewed_voigt,
-                         step, students_t, voigt, double_lorentzian)
+                         step, students_t, voigt, split_lorentzian)
 from .model import Model
 
 
@@ -380,7 +380,7 @@ class LorentzianModel(Model):
     guess.__doc__ = COMMON_GUESS_DOC
 
 
-class DoubleLorentzianModel(Model):
+class SplitLorentzianModel(Model):
     r"""A model based on a Lorentzian or Cauchy-Lorentz distribution function
     (see https://en.wikipedia.org/wiki/Cauchy_distribution), with four
     parameters: ``amplitude``, ``center``, ``sigma``, and ``sigma_r``.
@@ -388,7 +388,7 @@ class DoubleLorentzianModel(Model):
     In addition, parameters ``fwhm`` and ``height`` are included as constraints
     to report full width at half maximum and maximum peak height, respectively.
 
-    'Double' means that the width of the distribution is different between
+    'Split' means that the width of the distribution is different between
     left and right slopes.
 
     .. math::
@@ -411,7 +411,7 @@ class DoubleLorentzianModel(Model):
                  **kwargs):
         kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
-        super(DoubleLorentzianModel, self).__init__(double_lorentzian, **kwargs)
+        super(SplitLorentzianModel, self).__init__(split_lorentzian, **kwargs)
         self._set_paramhints_prefix()
 
     def _set_paramhints_prefix(self):


### PR DESCRIPTION
This PR adds DoubleLorentzianModel. 

The changes include: 
* addition of ``double_lorentzian()`` lineshape
* addition of ``DoubleLorentzianModel``
* addition of the model to the list of peak-like models in the docs.

I haven't found any tests for Lorentzian model, please let me know if those exist / are needed.
Also, no example for the new model was added.