### PR TITLE
[WIP] Add html_repr's

### DIFF
--- a/examples/complex_resonator_model.ipynb
+++ b/examples/complex_resonator_model.ipynb
@@ -17,7 +17,6 @@
    "outputs": [],
    "source": [
     "%pylab inline\n",
-    "\n",
     "#%config InlineBackend.figure_format='retina'  # for hi-dpi displays"
    ]
   },

--- a/examples/complex_resonator_model.ipynb
+++ b/examples/complex_resonator_model.ipynb
@@ -17,6 +17,7 @@
    "outputs": [],
    "source": [
     "%pylab inline\n",
+    "\n",
     "#%config InlineBackend.figure_format='retina'  # for hi-dpi displays"
    ]
   },

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -284,9 +284,8 @@ class Parameters(OrderedDict):
             print(line.format(name_len=name_len, n=colwidth, p=precision,
                               f=fmt, **pvalues))
 
-    def html_repr(self):
+    def _repr_html_(self):
         """Returns a HTML representation of parameters data."""
-
         # We omit certain columns if they would be empty.
         any_err = any([p.stderr is not None for p in self.values()])
         any_par_expr = any([p.expr is not None for p in self.values()])
@@ -303,7 +302,7 @@ class Parameters(OrderedDict):
         if any_err:
             headers = headers[:2] + ['', 'error', 'rel. error'] + headers[2:]
         if any_par_expr:
-            headers.append('exrp.')
+            headers.append('expr.')
         for h in headers:
             head(h)
         add('</tr>')

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -284,6 +284,54 @@ class Parameters(OrderedDict):
             print(line.format(name_len=name_len, n=colwidth, p=precision,
                               f=fmt, **pvalues))
 
+    def html_repr(self):
+        """Returns a HTML representation of parameters data."""
+
+        # We omit certain columns if they would be empty.
+        any_err = any([p.stderr is not None for p in self.values()])
+        any_par_expr = any([p.expr is not None for p in self.values()])
+        # Helper functions for shorter code
+        html = []
+        add = html.append
+        cell = lambda x: add('<td>%s</td>' % x)
+        head = lambda x: add('<th>%s</th>' % x)
+
+        add('<table>')
+        # Header ----
+        add('<tr>')
+        headers = ['name', 'value', '(init)', 'min', 'max', 'vary']
+        if any_err:
+            headers = headers[:2] + ['', 'error', 'rel. error'] + headers[2:]
+        if any_par_expr:
+            headers.append('exrp.')
+        for h in headers:
+            head(h)
+        add('</tr>')
+        # Parameters ----------
+        for p in self.values():
+            add('<tr>')
+            cell(p.name)
+            cell('%f' % p.value)
+            if p.stderr is not None:
+                cell('+/-')
+                cell('%f' % p.stderr)
+                cell('%.2f%%' % (100 * p.stderr / p.value))
+            elif any_err:
+                cell('')
+                cell('')
+                cell('')
+            cell(p.user_value)
+            cell('%f' % p.min)
+            cell('%f' % p.max)
+            cell('%s' % p.vary)
+            if p.expr is not None:
+                cell('%s' % p.expr)
+            elif any_par_expr:
+                cell('')
+            add('</tr>')
+        add('</table>')
+        return ''.join(html)
+
     def add(self, name, value=None, vary=True, min=-inf, max=inf, expr=None,
             brute_step=None):
         """Add a Parameter.


### PR DESCRIPTION
Voices from the dead again :-)

<img width="344" alt="unbenannt" src="https://user-images.githubusercontent.com/189880/50035054-5b1ae500-0000-11e9-8c09-35183bb24996.png">

I try to make the output of my software a bit little nicer to look at. One thing it is missing is a nice html representation of the fit results. I think this may fit directly into lmfit. There are different approaches to choose from:

* This PR simply adds a html_repr method to parameters, which will be used automatically in a notebook environment. While I prefer this approach, it may change the output of existing notebooks. 

* Add an extra `print_html` function. This would require the end-user to use the ipython `display` function manually, which I think is not very user-friendly. 

* Combine the first approach with some method of configuration, either via a lmfit setting/function or some environments. This would introduce state to lmfit, but it may be worth it. 

So is there any interest at all? If so, which approach to we want to choose? Of course the `Result`-class and the CI classes can get similar methods, making the use of the report functions in the notebook unnecessary for standard usage.