### PR TITLE
Bump minimum SciPy version and support parallelization in DE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 
 # test minium required and latest versions of SciPy and NumPy
 env:
-    - version=minimum  # SciPy>=0.17 NumPy>=1.10
+    - version=minimum  # SciPy>=0.19 NumPy>=1.10
     - version=latest
 
 before_install:
@@ -25,8 +25,8 @@ before_install:
     - conda info -a
 
 install:
-    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION != 3.6 && $TRAVIS_PYTHON_VERSION != 3.7-dev ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy=1.10 scipy=0.17 six=1.10; fi
-    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION == 3.6 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy=1.11.2 scipy=0.18 six=1.10; fi
+    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION != 3.6 && $TRAVIS_PYTHON_VERSION != 3.7-dev ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy=1.10 scipy=0.19 six=1.10; fi
+    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION == 3.6 ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy=1.11.2 scipy=0.19 six=1.10; fi
     - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION == 3.7-dev ]]; then conda create -q -n test_env python=3.7 numpy=1.11.3 scipy=1.1 six=1.11; fi
     - if [[ $version == latest && $TRAVIS_PYTHON_VERSION != 3.7-dev ]]; then conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy six pandas matplotlib dill; fi
     - if [[ $version == latest && $TRAVIS_PYTHON_VERSION == 3.7-dev ]]; then conda create -q -n test_env python=3.7 numpy scipy six pandas matplotlib dill; fi

--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,7 @@ To install the lmfit python module, use::
 For lmfit 0.9.10, the following versions are required:
   Python: 2.7, 3.4, 3.5, or 3.6
   NumPy: 1.10 or higher
-  SciPy: 0.17 or higher
+  SciPy: 0.19 or higher
   six: 1.10 or higher
   asteval: 0.9.12 or higher
   uncertainties: 3.0 or higher

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -28,7 +28,7 @@ for 2.7 is expected to end in early 2019.
 Lmfit requires the following Python packages, with versions given:
    * `six`_ version 1.10 or higher.
    * `NumPy`_ version 1.10 or higher.
-   * `SciPy`_ version 0.17 or higher.
+   * `SciPy`_ version 0.19 or higher.
    * `asteval`_ version 0.9.12 or higher.
    * `uncertainties`_ version 3.0 or higher.
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1537,13 +1537,6 @@ class Minimizer(object):
         basinhopping_kws.update(self.kws)
         basinhopping_kws.update(kws)
 
-        # FIXME - remove after requirement for scipy >= 0.19
-        major, minor, micro = scipy_version.split('.', 2)
-        if int(major) < 1 and int(minor) < 19:
-            _ = basinhopping_kws.pop('seed')
-            print("Warning: basinhopping doesn't support argument 'seed' for "
-                  "scipy versions below 0.19!")
-
         x0 = result.init_vals
 
         try:

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -894,7 +894,8 @@ class Minimizer(object):
             kwargs = dict(args=(), strategy='best1bin', maxiter=None,
                           popsize=15, tol=0.01, mutation=(0.5, 1),
                           recombination=0.7, seed=None, callback=None,
-                          disp=False, polish=True, init='latinhypercube')
+                          disp=False, polish=True, init='latinhypercube',
+                          atol=0)
 
             for k, v in fmin_kws.items():
                 if k in kwargs:

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -869,8 +869,9 @@ class Minimizer(object):
         fmin_kws.update(kws)
 
         # hess supported only in some methods
-        if 'hess' in fmin_kws and method not in ('Newton-CG',
-                                                 'dogleg', 'trust-ncg'):
+        if 'hess' in fmin_kws and method not in ('Newton-CG', 'dogleg',
+                                                 'trust-constr', 'trust-ncg',
+                                                 'trust-krylov', 'trust-exact'):
             fmin_kws.pop('hess')
 
         # jac supported only in some methods (and Dfun could be used...)
@@ -879,7 +880,9 @@ class Minimizer(object):
             fmin_kws['jac'] = self.__jacobian
 
         if 'jac' in fmin_kws and method not in ('CG', 'BFGS', 'Newton-CG',
-                                                'dogleg', 'trust-ncg'):
+                                                'L-BFGS-B', 'TNC', 'SLSQP',
+                                                'dogleg', 'trust-ncg',
+                                                'trust-krylov', 'trust-exact'):
             self.jacfcn = None
             fmin_kws.pop('jac')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six>1.10
 numpy>=1.10
-scipy>=0.17
+scipy>=0.19
 asteval>=0.9.12
 uncertainties>=3.0

--- a/tests/test_basinhopping.py
+++ b/tests/test_basinhopping.py
@@ -3,7 +3,6 @@ import numpy as np
 from numpy.testing import assert_allclose
 import pytest
 from scipy.optimize import basinhopping
-from scipy.version import version as scipy_version
 
 import lmfit
 
@@ -17,12 +16,7 @@ def test_basinhopping_lmfit_vs_scipy():
     minimizer_kwargs = {'method': 'L-BFGS-B'}
     x0 = [1.]
 
-    # FIXME - remove after requirement for scipy >= 0.19
-    major, minor, _micro = scipy_version.split('.', 2)
-    if int(major) < 1 and int(minor) < 19:
-        ret = basinhopping(func, x0, minimizer_kwargs=minimizer_kwargs)
-    else:
-        ret = basinhopping(func, x0, minimizer_kwargs=minimizer_kwargs, seed=7)
+    ret = basinhopping(func, x0, minimizer_kwargs=minimizer_kwargs, seed=7)
 
     # lmfit
     def residual(params):
@@ -48,13 +42,7 @@ def test_basinhopping_2d_lmfit_vs_scipy():
     minimizer_kwargs = {'method': 'L-BFGS-B'}
     x0 = [1.0, 1.0]
 
-    # FIXME - remove after requirement for scipy >= 0.19
-    major, minor, _micro = scipy_version.split('.', 2)
-    if int(major) < 1 and int(minor) < 19:
-        ret = basinhopping(func2d, x0, minimizer_kwargs=minimizer_kwargs)
-    else:
-        ret = basinhopping(func2d, x0, minimizer_kwargs=minimizer_kwargs,
-                           seed=7)
+    ret = basinhopping(func2d, x0, minimizer_kwargs=minimizer_kwargs, seed=7)
 
     # lmfit
     def residual_2d(params):


### PR DESCRIPTION
This PR bumps the required SciPy version to 0.19, which prompted the following changes:
- keyword ```seed``` is present for the ```basinhopping``` method
- keyword ```atol``` is present for the ```differential_evolution``` method

In addition:
- several (newer) algorithms are present in newer SciPy that accept the ```hess``` and ```jac``` keywords, this list is updated
- SciPy v1.2 added supports parallelization in the ```differential_evolution``` methods, this is supported now in ```lmfit``` as well. Two additional keywords (```updating``` and ```workers```) are added; see the commit message or SciPy documentation for more information. I'll review the need for extra test as part of the switch to ```pytest```.

The presence of the ```seed``` keyword simplifies the tests in ```test_basinhopping.py```; no tests were added for the addition of new keywords in ```differential_evolution``` or the newer methods that accept ```jac```/```hess```. I did verify though that the keywords are actually passed on to the solvers.

Some test failures will be present, which have been resolved already in PR #525 (DE with SciPy v1.2 and too strict criteria in ```test_basinhopping.py``` and ```test_covariance_matrix.py```). Of note, these two PRs do change some of the same files - so let's finish one of them first ; I'll rebase and fix merge conflicts in the other one.