### PR TITLE
force final evaluation of residual with best-fit parameter values

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1394,7 +1394,12 @@ class Minimizer(object):
         except AbortFitException:
             pass
 
-        result.residual = self.__residual(ret.x)
+        # note: upstream least_squares is actually returning
+        # "last evaluation", not "best result", but we do this
+        # here for consistency, and assuming it will be fixed.
+        if not result.aborted:
+            result.residual = self.__residual(ret.x, False)
+            result.nfev -= 1
         result._calculate_statistics()
 
         if not result.aborted:
@@ -1479,12 +1484,13 @@ class Minimizer(object):
 
         try:
             lsout = scipy_leastsq(self.__residual, variables, **lskws)
-            _best, _cov, infodict, errmsg, ier = lsout
-            # result.residual = infodict['fvec']
         except AbortFitException:
             pass
 
-        result.residual = self.__residual(_best)
+        if not result.aborted:
+            _best, _cov, infodict, errmsg, ier = lsout
+            result.residual = self.__residual(_best)
+            result.nfev -= 1
         result._calculate_statistics()
 
         if result.aborted:

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1394,6 +1394,7 @@ class Minimizer(object):
         except AbortFitException:
             pass
 
+        result.residual = self.__residual(ret.x)
         result._calculate_statistics()
 
         if not result.aborted:
@@ -1479,10 +1480,11 @@ class Minimizer(object):
         try:
             lsout = scipy_leastsq(self.__residual, variables, **lskws)
             _best, _cov, infodict, errmsg, ier = lsout
-            result.residual = infodict['fvec']
+            # result.residual = infodict['fvec']
         except AbortFitException:
             pass
 
+        result.residual = self.__residual(_best)
         result._calculate_statistics()
 
         if result.aborted:


### PR DESCRIPTION
This addresses #535 by explicitly calling the residual function one last time with the best-fit values.

Because the differences will typically by at the 1.e-7 level, I'm reluctant to try to add an automated test for this, but if anyone has an idea for how to do that well, suggestions would be welcome!