### PR TITLE
Show FutureWarning about deprecation of "missing" and "drop"

### DIFF
--- a/examples/example_reduce_fcn.py
+++ b/examples/example_reduce_fcn.py
@@ -27,7 +27,7 @@ y = offset + amp * np.sin(omega*x) * np.exp(-x/decay)
 
 yn = y + np.random.normal(size=len(y), scale=0.250)
 
-outliers = np.random.random_integers(int(len(x)/3.0), len(x)-1, int(len(x)/12))
+outliers = np.random.randint(int(len(x)/3.0), len(x), int(len(x)/12))
 yn[outliers] += 5*np.random.random(len(outliers))
 
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -2094,6 +2094,9 @@ def validate_nan_policy(policy):
     policy = policy.lower()
     if policy == 'drop':
         policy = 'omit'
+        warnings.warn("The option 'drop' is deprecated as of lmfit 0.9.13 and "
+                      "will be removed in the next release. Use 'omit' "
+                      "instead.", FutureWarning)
     if policy == 'none':
         policy = 'propagate'
     if policy not in VALID_NAN_POLICIES:

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -273,6 +273,9 @@ class Model(object):
         self._func_haskeywords = False
         if missing is not None:
             nan_policy = missing
+            warnings.warn("The keyword 'missing' is deprecated as of lmfit "
+                          "0.9.13 and will be removed in the next release. "
+                          "Use 'nan_policy' instead.", FutureWarning)
         self.nan_policy = validate_nan_policy(nan_policy)
 
         self.opts = kws


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->
In lmfit 0.9.8 the ```missing``` argument was deprecated in favor of ```nan_policy```, for consistency with the ```Minimizer``` class. Similarly, ```drop``` was deprecated in favor of ```omit``` (and additional code for backwards compatibility was added). 

This deprecation was, however, only done in the documentation and no warning was shown when these keywords/arguments were still being used. This PR adds an explicit ```FutureWarning``` (which is as far as I can tell the appropriate thing to do if the message is intended for end-users) about it and states that these things will be removed in the next release (we can get rid of the compatibility-code and clean up the function signatures and docstrings).

In the tests we still use some of this ourselves and that should be cleaned up, but I have still intentions to re-work parts of the test-suite so hopefully will get to that... Otherwise, we can fix them by just replacing "drop-->omit" and "missing-->nan_policy" before the next release. 

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties, six
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}, six: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__, six.__version__))
-->
Python: 3.7.2 (default, Jan  6 2019, 12:34:03)
[Clang 10.0.0 (clang-1000.11.45.5)]

lmfit: 0.9.12+62.g77d9c42, scipy: 1.2.1, numpy: 1.16.2, asteval: 0.9.13, uncertainties: 3.0.3, six: 1.12.0


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?