### PR TITLE
FIX: update parameters/constraints after guess in built-in models

### DIFF
--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -77,6 +77,7 @@ def update_param_vals(pars, prefix, **kwargs):
         pname = "%s%s" % (prefix, key)
         if pname in pars:
             pars[pname].value = val
+    pars.update_constraints()
     return pars
 
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->
As shown in Issue #539 the parameters are not updated immediately after using the ```guess``` method for the built-in model (at least for ```VoigtModel```). Adding a ```pars.update_constraints()``` at the beginning of the ```update_param_vals``` function resolves this. 

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties, six
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}, six: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__, six.__version__))
-->
Python: 3.7.2 (default, Jan  6 2019, 12:34:03)
[Clang 10.0.0 (clang-1000.11.45.5)]

lmfit: 0.9.12+69.gc405af5, scipy: 1.2.1, numpy: 1.16.2, asteval: 0.9.13, uncertainties: 3.0.3, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] referenced existing Issue and/or provided relevant link to mailing list? Issue #539 
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?