### PR TITLE
Report for noerrorbar

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,6 @@
 exclude: 'versioneer.py|lmfit/_version|doc/conf.py'
 
 repos:
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.9
-    hooks:
-    -   id: isort
-
 -   repo: https://github.com/asottile/pyupgrade
     rev: v1.12.0
     hooks:


### PR DESCRIPTION
This more or less reproduces #537 to report why errorbars may have not been estimated.

It also removes the isort `pre-commit` hook -- I was having odd troubles with this.  I also sort of disagreed with at least one of its choices.   It looks like there are other similar pre-commit hooks, so perhaps this could be revisited.  For now, the feature is more important than the linter choices.
