### PR TITLE
SHGO algorithm

### DIFF
--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -172,6 +172,9 @@ uncertainties and correlations if ``calc_covar`` is True (default).
  | Programming for Global   |                                                                  |
  | Optimization             |                                                                  |
  +--------------------------+------------------------------------------------------------------+
+ | Simplicial Homology      |  ``shgo``                                                        |
+ | Global Ooptimization     |                                                                  |
+ +--------------------------+------------------------------------------------------------------+
  | Maximum likelihood via   |  ``emcee``                                                       |
  | Monte-Carlo Markov Chain |                                                                  |
  +--------------------------+------------------------------------------------------------------+
@@ -397,6 +400,8 @@ For more information, check the examples in ``examples/lmfit_brute_example.ipynb
 .. automethod:: Minimizer.basinhopping
 
 .. automethod:: Minimizer.ampgo
+
+.. automethod:: Minimizer.shgo
 
 .. automethod:: Minimizer.emcee
 

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -4,9 +4,8 @@ import re
 import numpy as np
 
 try:
-    import numdifftools
+    import numdifftools  # noqa: F401
     HAS_NUMDIFFTOOLS = True
-    flake8_is_wrong_but_easily_foold = numdifftools.Hessian
 except ImportError:
     HAS_NUMDIFFTOOLS = False
 
@@ -154,11 +153,10 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
                         add('    %s:%s  at boundary' % (name, space))
             else:
                 add("    this fitting method does not natively calculate uncertainties")
-                add("    and numdifftools is not installed for lmfit to do this.  Use")
+                add("    and numdifftools is not installed for lmfit to do this. Use")
                 add("    `pip install numdifftools` for lmfit to estimate uncertainties")
                 add("    with this fitting method.")
 
-    namelen = max([len(n) for n in parnames])
     add("[[Variables]]")
     for name in parnames:
         par = params[name]

--- a/tests/test_covariance_matrix.py
+++ b/tests/test_covariance_matrix.py
@@ -108,7 +108,8 @@ def test_bounds_expression():
                         -4.390334984618851e-05, decimal=6)
 
 
-def test_numdifftools_no_bounds():
+@pytest.mark.parametrize("fit_method", ['nelder', 'basinhopping', 'ampgo'])
+def test_numdifftools_no_bounds(fit_method):
     pytest.importorskip("numdifftools")
     # load data to be fitted
     data = np.loadtxt(os.path.join(os.path.dirname(__file__), '..', 'examples',
@@ -124,36 +125,40 @@ def test_numdifftools_no_bounds():
     # do fit, here with leastsq model
     result = mod.fit(y, params, x=x, method='leastsq')
 
-    for fit_method in ['nelder', 'basinhopping', 'ampgo']:
-        result_ndt = mod.fit(y, params, x=x, method=fit_method)
+    result_ndt = mod.fit(y, params, x=x, method=fit_method)
 
-        # assert that fit converged to the same result
-        vals = [result.params[p].value for p in result.params.valuesdict()]
-        vals_ndt = [result_ndt.params[p].value for p in result_ndt.params.valuesdict()]
-        assert_allclose(vals_ndt, vals, rtol=0.1)
-        assert_allclose(result_ndt.chisqr, result.chisqr, rtol=1e-5)
+    # assert that fit converged to the same result
+    vals = [result.params[p].value for p in result.params.valuesdict()]
+    vals_ndt = [result_ndt.params[p].value for p in result_ndt.params.valuesdict()]
+    assert_allclose(vals_ndt, vals, rtol=0.1)
+    assert_allclose(result_ndt.chisqr, result.chisqr, rtol=1e-5)
 
-        # assert that parameter uncertaintes from leastsq and calculated from
-        # the covariance matrix using numdifftools are very similar
-        stderr = [result.params[p].stderr for p in result.params.valuesdict()]
-        stderr_ndt = [result_ndt.params[p].stderr for p in result_ndt.params.valuesdict()]
+    # assert that parameter uncertaintes from leastsq and calculated from
+    # the covariance matrix using numdifftools are very similar
+    stderr = [result.params[p].stderr for p in result.params.valuesdict()]
+    stderr_ndt = [result_ndt.params[p].stderr for p in result_ndt.params.valuesdict()]
 
-        perr = np.array(stderr) / np.array(vals)
-        perr_ndt = np.array(stderr_ndt) / np.array(vals_ndt)
-        assert_almost_equal(perr_ndt, perr, decimal=4)
+    perr = np.array(stderr) / np.array(vals)
+    perr_ndt = np.array(stderr_ndt) / np.array(vals_ndt)
+    assert_almost_equal(perr_ndt, perr, decimal=4)
 
-        # assert that parameter correlatations from leastsq and calculated from
-        # the covariance matrix using numdifftools are very similar
-        for par1 in result.var_names:
-            cor = [result.params[par1].correl[par2] for par2 in
-                   result.params[par1].correl.keys()]
-            cor_ndt = [result_ndt.params[par1].correl[par2] for par2 in
-                       result_ndt.params[par1].correl.keys()]
-            assert_almost_equal(cor_ndt, cor, decimal=2)
+    # assert that parameter correlatations from leastsq and calculated from
+    # the covariance matrix using numdifftools are very similar
+    for par1 in result.var_names:
+        cor = [result.params[par1].correl[par2] for par2 in
+               result.params[par1].correl.keys()]
+        cor_ndt = [result_ndt.params[par1].correl[par2] for par2 in
+                   result_ndt.params[par1].correl.keys()]
+        assert_almost_equal(cor_ndt, cor, decimal=2)
 
 
-def test_numdifftools_with_bounds():
+@pytest.mark.parametrize("fit_method", ['nelder', 'basinhopping', 'ampgo',
+                                        'shgo'])
+def test_numdifftools_with_bounds(fit_method):
     pytest.importorskip("numdifftools")
+    if fit_method == 'shgo':
+        pytest.importorskip("scipy", minversion="1.2")
+
     # load data to be fitted
     data = np.loadtxt(os.path.join(os.path.dirname(__file__), '..', 'examples',
                                    'test_peak.dat'))
@@ -164,38 +169,37 @@ def test_numdifftools_with_bounds():
     mod = VoigtModel()
     params = mod.guess(y, x=x)
     params['amplitude'].set(min=25, max=70)
-    params['sigma'].set(min=0, max=1)
+    params['sigma'].set(max=1)
     params['center'].set(min=5, max=15)
 
     # do fit, here with leastsq model
     result = mod.fit(y, params, x=x, method='leastsq')
 
-    for fit_method in ['nelder', 'basinhopping', 'ampgo']:
-        result_ndt = mod.fit(y, params, x=x, method=fit_method)
+    result_ndt = mod.fit(y, params, x=x, method=fit_method)
 
-        # assert that fit converged to the same result
-        vals = [result.params[p].value for p in result.params.valuesdict()]
-        vals_ndt = [result_ndt.params[p].value for p in result_ndt.params.valuesdict()]
-        assert_allclose(vals_ndt, vals, rtol=0.1)
-        assert_allclose(result_ndt.chisqr, result.chisqr, rtol=1e-5)
+    # assert that fit converged to the same result
+    vals = [result.params[p].value for p in result.params.valuesdict()]
+    vals_ndt = [result_ndt.params[p].value for p in result_ndt.params.valuesdict()]
+    assert_allclose(vals_ndt, vals, rtol=0.1)
+    assert_allclose(result_ndt.chisqr, result.chisqr, rtol=1e-5)
 
-        # assert that parameter uncertaintes from leastsq and calculated from
-        # the covariance matrix using numdifftools are very similar
-        stderr = [result.params[p].stderr for p in result.params.valuesdict()]
-        stderr_ndt = [result_ndt.params[p].stderr for p in result_ndt.params.valuesdict()]
+    # assert that parameter uncertaintes from leastsq and calculated from
+    # the covariance matrix using numdifftools are very similar
+    stderr = [result.params[p].stderr for p in result.params.valuesdict()]
+    stderr_ndt = [result_ndt.params[p].stderr for p in result_ndt.params.valuesdict()]
 
-        perr = np.array(stderr) / np.array(vals)
-        perr_ndt = np.array(stderr_ndt) / np.array(vals_ndt)
-        assert_almost_equal(perr_ndt, perr, decimal=4)
+    perr = np.array(stderr) / np.array(vals)
+    perr_ndt = np.array(stderr_ndt) / np.array(vals_ndt)
+    assert_almost_equal(perr_ndt, perr, decimal=4)
 
-        # assert that parameter correlatations from leastsq and calculated from
-        # the covariance matrix using numdifftools are very similar
-        for par1 in result.var_names:
-            cor = [result.params[par1].correl[par2] for par2 in
-                   result.params[par1].correl.keys()]
-            cor_ndt = [result_ndt.params[par1].correl[par2] for par2 in
-                       result_ndt.params[par1].correl.keys()]
-            assert_almost_equal(cor_ndt, cor, decimal=2)
+    # assert that parameter correlatations from leastsq and calculated from
+    # the covariance matrix using numdifftools are very similar
+    for par1 in result.var_names:
+        cor = [result.params[par1].correl[par2] for par2 in
+               result.params[par1].correl.keys()]
+        cor_ndt = [result_ndt.params[par1].correl[par2] for par2 in
+                   result_ndt.params[par1].correl.keys()]
+        assert_almost_equal(cor_ndt, cor, decimal=2)
 
 
 def test_numdifftools_calc_covar_false():

--- a/tests/test_lineshapes_models.py
+++ b/tests/test_lineshapes_models.py
@@ -114,3 +114,82 @@ def test_finite_output_lineshape(lineshape):
     ls = getattr(lineshapes, lineshape)
     out = ls(*func_args)
     assert np.all(np.isfinite(out))
+
+
+def test_height_and_fwhm_expression_evalution_in_builtin_models():
+    """Assert models do not throw an ZeroDivisionError."""
+    mod = models.GaussianModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0)
+    params.update_constraints()
+
+    mod = models.LorentzianModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0)
+    params.update_constraints()
+
+    mod = models.SplitLorentzianModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, sigma_r=0.0)
+    params.update_constraints()
+
+    mod = models.VoigtModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0)
+    params.update_constraints()
+
+    mod = models.PseudoVoigtModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, fraction=0.5)
+    params.update_constraints()
+
+    mod = models.MoffatModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, beta=0.0)
+    params.update_constraints()
+
+    mod = models.Pearson7Model()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, expon=1.0)
+    params.update_constraints()
+
+    mod = models.StudentsTModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0)
+    params.update_constraints()
+
+    mod = models.BreitWignerModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, q=0.0)
+    params.update_constraints()
+
+    mod = models.LognormalModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0)
+    params.update_constraints()
+
+    mod = models.DampedOscillatorModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0)
+    params.update_constraints()
+
+    mod = models.DampedHarmonicOscillatorModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0)
+    params.update_constraints()
+
+    mod = models.ExponentialGaussianModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0)
+    params.update_constraints()
+
+    mod = models.SkewedGaussianModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0)
+    params.update_constraints()
+
+    mod = models.SkewedVoigtModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0,
+                             skew=0.0)
+    params.update_constraints()
+
+    mod = models.DonaichModel()
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0)
+    params.update_constraints()
+
+    mod = models.StepModel()
+    for f in ('linear', 'arctan', 'erf', 'logistic'):
+        params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, form=f)
+        params.update_constraints()
+
+    mod = models.RectangleModel()
+    for f in ('linear', 'arctan', 'erf', 'logistic'):
+        params = mod.make_params(amplitude=1.0, center1=0.0, sigma1=0.0,
+                                 center2=0.0, sigma2=0.0, form=f)
+        params.update_constraints()

--- a/tests/test_shgo.py
+++ b/tests/test_shgo.py
@@ -1,0 +1,113 @@
+"""Tests for the SHGO global minimization algorithm."""
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+import scipy
+
+import lmfit
+
+# SHGO algorithm is present in SciPy >= 1.2
+pytest.importorskip("scipy", minversion="1.2")
+
+
+def eggholder(x):
+    return (-(x[1] + 47.0) * np.sin(np.sqrt(abs(x[0]/2.0 + (x[1] + 47.0))))
+            - x[0] * np.sin(np.sqrt(abs(x[0] - (x[1] + 47.0)))))
+
+
+def eggholder_lmfit(params):
+    x0 = params['x0'].value
+    x1 = params['x1'].value
+
+    return (-(x1 + 47.0) * np.sin(np.sqrt(abs(x0/2.0 + (x1 + 47.0))))
+            - x0 * np.sin(np.sqrt(abs(x0 - (x1 + 47.0)))))
+
+
+def test_shgo_scipy_vs_lmfit():
+    """Test SHGO algorithm in lmfit versus SciPy."""
+    bounds = [(-512, 512), (-512, 512)]
+    result_scipy = scipy.optimize.shgo(eggholder, bounds, n=30,
+                                       sampling_method='sobol')
+    assert len(result_scipy.xl) == 13
+
+    pars = lmfit.Parameters()
+    pars.add_many(('x0', 0, True, -512, 512), ('x1', 0, True, -512, 512))
+    mini = lmfit.Minimizer(eggholder_lmfit, pars)
+    result = mini.minimize(method='shgo', n=30, sampling_method='sobol')
+    out_x = np.array([result.params['x0'].value, result.params['x1'].value])
+
+    assert_allclose(result_scipy.fun, result.residual)
+    assert_allclose(result_scipy.funl, result.shgo_funl)
+    assert_allclose(result_scipy.xl, result.shgo_xl)
+    assert_allclose(result.shgo_x, out_x)
+
+
+def test_shgo_scipy_vs_lmfit_2():
+    """Test SHGO algorithm in lmfit versus SciPy."""
+    bounds = [(-512, 512), (-512, 512)]
+    result_scipy = scipy.optimize.shgo(eggholder, bounds, n=60, iters=5,
+                                       sampling_method='sobol')
+    assert len(result_scipy.xl) == 39
+
+    pars = lmfit.Parameters()
+    pars.add_many(('x0', 0, True, -512, 512), ('x1', 0, True, -512, 512))
+    mini = lmfit.Minimizer(eggholder_lmfit, pars)
+    result = mini.minimize(method='shgo', n=60, iters=5,
+                           sampling_method='sobol')
+    assert_allclose(result_scipy.fun, result.residual)
+    assert_allclose(result_scipy.xl, result.shgo_xl)
+    assert_allclose(result_scipy.funl, result.shgo_funl)
+
+
+# correct result for Alpine02 function
+global_optimum = [7.91705268, 4.81584232]
+fglob = -6.12950
+
+
+def test_shgo_simplicial_Alpine02(minimizer_Alpine02):
+    """Test SHGO algorithm on Alpine02 function."""
+    # sampling_method 'simplicial' fails with iters=1
+    out = minimizer_Alpine02.minimize(method='shgo', iters=5)
+    out_x = np.array([out.params['x0'].value, out.params['x1'].value])
+
+    assert_allclose(out.residual, fglob, rtol=1e-5)
+    assert_allclose(min(out_x), min(global_optimum), rtol=1e-3)
+    assert_allclose(max(out_x), max(global_optimum), rtol=1e-3)
+    assert out.method == 'shgo'
+
+
+def test_shgo_sobol_Alpine02(minimizer_Alpine02):
+    """Test SHGO algorithm on Alpine02 function."""
+    out = minimizer_Alpine02.minimize(method='shgo', sampling_method='sobol')
+    out_x = np.array([out.params['x0'].value, out.params['x1'].value])
+
+    assert_allclose(out.residual, fglob, rtol=1e-5)
+    assert_allclose(min(out_x), min(global_optimum), rtol=1e-3)
+    assert_allclose(max(out_x), max(global_optimum), rtol=1e-3)
+
+
+def test_shgo_bounds(minimizer_Alpine02):
+    """Test SHGO algorithm with bounds."""
+    pars_bounds = lmfit.Parameters()
+    pars_bounds.add_many(('x0', 1., True, 5.0, 15.0),
+                         ('x1', 1., True, 2.5, 7.5))
+
+    out = minimizer_Alpine02.minimize(params=pars_bounds, method='shgo')
+    assert 5.0 <= out.params['x0'].value <= 15.0
+    assert 2.5 <= out.params['x1'].value <= 7.5
+
+
+def test_shgo_disp_true(minimizer_Alpine02, capsys):
+    """Test SHGO algorithm with disp is True."""
+    kws = {'disp': True}
+    minimizer_Alpine02.minimize(method='shgo', options=kws)
+    captured = capsys.readouterr()
+    assert 'Splitting first generation' in captured.out
+
+
+def test_shgo_local_solver(minimizer_Alpine02):
+    """Test SHGO algorithm with local solver."""
+    min_kws = {'method': 'unknown'}
+    with pytest.raises(KeyError, match=r'unknown'):
+        minimizer_Alpine02.minimize(method='shgo', minimizer_kwargs=min_kws)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->
#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->
SciPy v1.2 introduced two new global optimization algorithms and these should be supported in lmfit as well (see #527). This PR adds the ```shgo``` (simplicial homology global optimization) method.

Tests were added to check make sure the implementation in lmfit gives the same result as calling ```scipy.optimize.shgo``` directly, using the example in thes SciPy function docstring. It seems to me there *might* be an upstream issue when using bounds at ```0``` or ```None```, but I'll need to narrow that down a bit more to make sure that's indeed the case. The tests in ```test_covariance_matrix.py``` and a few others I tried myself did not work when a boundary was exactly set to zero (throwing an error from ```scipy/optimize/_shgo_lib/triangulation.py```). Replacing the ```0``` with a very small value (I picked machine precision for a float64) seems to solve that problem. That required a bit of work before calling ```prepare_fit```, but I think the logic works there.

Similarly, I think something looks weird when no bounds are specified (```shgo``` will internally set the boundaries then to + and - 1e50), and it looks like the initial starting point for the minimization is then zero (at least when specifying finite bounds, it will take the the value in the middle between ```min``` and ```max```), which throws the same error as when having bounds at zero. At least I cannot get it to pass the ```test_numdifftools_no_bounds``` in ```test_covariance_matrix.py```, so for now I did not add the shgo method there.

I think this has nothing to do with the implementation in lmfit, but I would welcome a few more pairs of eyes to make sure... So, please take a look at the PR, try it on a few of your favorite minimization problems to see how it behaves and let me know.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature: add SHGO algorithm
- [x] Refactoring / maintenance: a few small fixes after the last PR merge
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties, six
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}, six: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__, six.__version__))
-->
Python: 2.7.16, 3.6.8, and 3.7.2 
lmfit: 0.9.12+77.ga05de1a, scipy: 1.2.1, numpy: 1.16.2, asteval: 0.9.13, uncertainties: 3.0.3, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation?
- [ ] added an example?
