### PR TITLE
add MinimizerResult when loading ModelResult

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
     - if [[ $version == latest && $TRAVIS_PYTHON_VERSION == 3.7-dev ]]; then conda create -q -n test_env python=3.7 numpy scipy six pandas matplotlib dill sphinx; fi
     - source activate test_env
     - pip install pytest
+    - pip install codecov
     - pip install asteval
     - pip install uncertainties
     - if [[ $version == latest ]]; then pip install emcee numdifftools; fi
@@ -41,4 +42,10 @@ install:
 script:
     - cd tests
     - pytest
-    - if [[ $version == latest && $TRAVIS_PYTHON_VERSION == 3.7-dev ]]; then cd ../doc ; make ; fi  # test building the documentation
+    - coverage run --source=lmfit -m pytest
+    - coverage report -m
+    # test building the documentation
+    - if [[ $version == latest && $TRAVIS_PYTHON_VERSION == 3.7-dev ]]; then cd ../doc ; make ; fi
+
+after_success:
+    - codecov

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,9 @@ LMfit-py
 .. image:: https://travis-ci.org/lmfit/lmfit-py.svg
    :target: https://travis-ci.org/lmfit/lmfit-py
 
+.. image:: https://codecov.io/gh/lmfit/lmfit-py/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/lmfit/lmfit-py
+
 .. image:: 	https://img.shields.io/pypi/v/lmfit.svg
    :target: https://pypi.org/project/lmfit
 

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -75,7 +75,7 @@ def gformat(val, length=11):
         if expon > 0:
             prec -= expon
     fmt = '{0: %i.%i%s}' % (length, prec, form)
-    return fmt.format(val)
+    return fmt.format(val)[:length]
 
 
 CORREL_HEAD = '[[Correlations]] (unreported correlations are < %.3f)'


### PR DESCRIPTION
This should address #534 by creating a new MinimizerResult when loading a ModelResult with `ModelResult.loads`.    It is not finished, definitely needing a test similar to the offending script of #534.
