### PR TITLE
alternative html_repr 

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -35,6 +35,7 @@ import uncertainties
 
 from ._ampgo import ampgo
 from .parameter import Parameter, Parameters
+from .printfuncs import fitreport_html_table
 
 # check for EMCEE
 try:
@@ -348,6 +349,11 @@ class MinimizerResult(object):
         _neg2_log_likel = self.ndata * np.log(self.chisqr / self.ndata)
         self.aic = _neg2_log_likel + 2 * self.nvarys
         self.bic = _neg2_log_likel + np.log(self.ndata) * self.nvarys
+
+    def _repr_html_(self, show_correl=True, min_correl=0.1):
+        """Returns a HTML representation of parameters data."""
+        return fitreport_html_table(self, show_correl=show_correl,
+                                    min_correl=min_correl)
 
 
 class Minimizer(object):

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -15,7 +15,7 @@ from . import Minimizer, Parameter, Parameters, lineshapes
 from .confidence import conf_interval
 from .jsonutils import HAS_DILL, decode4js, encode4js
 from .minimizer import validate_nan_policy, MinimizerResult
-from .printfuncs import ci_report, fit_report
+from .printfuncs import ci_report, fit_report, fitreport_html_table
 
 # Use pandas.isnull for aligning missing data if pandas is available.
 # otherwise use numpy.isnan
@@ -1564,6 +1564,13 @@ class ModelResult(Minimizer):
                             min_correl=min_correl, sort_pars=sort_pars)
         modname = self.model._reprstring(long=True)
         return '[[Model]]\n    %s\n%s\n' % (modname, report)
+
+    def _repr_html_(self, show_correl=True, min_correl=0.1):
+        """Returns a HTML representation of parameters data."""
+        report = fitreport_html_table(self, show_correl=show_correl,
+                                      min_correl=min_correl)
+        modname = self.model._reprstring(long=True)
+        return "<h2> Model</h2> %s %s" % (modname, report)
 
     def dumps(self, **kws):
         """Represent ModelResult as a JSON string.

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -11,6 +11,7 @@ import scipy.special
 import uncertainties
 
 from .jsonutils import decode4js, encode4js
+from .printfuncs import params_html_table
 
 SCIPY_FUNCTIONS = {'gamfcn': scipy.special.gamma}
 for name in ('erf', 'erfc', 'wofz'):
@@ -283,6 +284,10 @@ class Parameters(OrderedDict):
                     pvalues['brute_step'], n=colwidth, p=precision, f=fmt)
             print(line.format(name_len=name_len, n=colwidth, p=precision,
                               f=fmt, **pvalues))
+
+    def _repr_html_(self):
+        """Returns a HTML representation of parameters data."""
+        return params_html_table(self)
 
     def add(self, name, value=None, vary=True, min=-inf, max=inf, expr=None,
             brute_step=None):

--- a/tests/test_fitreports.py
+++ b/tests/test_fitreports.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from lmfit import Minimizer, Parameters, conf_interval, ci_report, fit_report
 from lmfit.models import GaussianModel
 from lmfit.lineshapes import gaussian
 
@@ -30,3 +31,45 @@ def test_reports_created():
 
     html_report = result._repr_html_()
     assert(len(html_report) > 1000)
+
+
+def test_ci_report():
+    """test confidence interval report"""
+
+    def residual(pars, x, data=None):
+        argu = (x*pars['decay'])**2
+        shift = pars['shift']
+        if abs(shift) > np.pi/2:
+            shift = shift - np.sign(shift)*np.pi
+        model = pars['amp']*np.sin(shift + x/pars['period']) * np.exp(-argu)
+        if data is None:
+            return model
+        return model - data
+
+    p_true = Parameters()
+    p_true.add('amp', value=14.0)
+    p_true.add('period', value=5.33)
+    p_true.add('shift', value=0.123)
+    p_true.add('decay', value=0.010)
+
+    n = 2500
+    xmin = 0.
+    xmax = 250.0
+    x = np.linspace(xmin, xmax, n)
+    data = residual(p_true, x) + np.random.normal(scale=0.7215, size=n)
+
+    fit_params = Parameters()
+    fit_params.add('amp', value=13.0)
+    fit_params.add('period', value=2)
+    fit_params.add('shift', value=0.0)
+    fit_params.add('decay', value=0.02)
+
+    mini = Minimizer(residual, fit_params, fcn_args=(x,),
+                     fcn_kws={'data': data})
+    out = mini.leastsq()
+    report = fit_report(out)
+    assert(len(report) > 500)
+
+    ci, tr = conf_interval(mini, out, trace=True)
+    report = ci_report(ci)
+    assert(len(report) > 250)

--- a/tests/test_fitreports.py
+++ b/tests/test_fitreports.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from lmfit.models import GaussianModel
+from lmfit.lineshapes import gaussian
+
+np.random.seed(0)
+
+
+def test_reports_created():
+    """do a simple Model fit but with all the bells-and-whistles
+    and verify that the reports are created
+    """
+    x = np.linspace(0, 12, 601)
+    data = gaussian(x, amplitude=36.4, center=6.70, sigma=0.88)
+    data = data + np.random.normal(size=len(x), scale=3.2)
+    model = GaussianModel()
+    params = model.make_params(amplitude=50, center=5, sigma=2)
+
+    params['amplitude'].min = 0
+    params['sigma'].min = 0
+    params['sigma'].brute_step = 0.001
+
+    result = model.fit(data, params, x=x)
+
+    report = result.fit_report()
+    assert(len(report) > 500)
+
+    html_params = result.params._repr_html_()
+    assert(len(html_params) > 500)
+
+    html_report = result._repr_html_()
+    assert(len(html_report) > 1000)


### PR DESCRIPTION
This is an alternative to #524 that ought to merge more seamlessly (ie, I started with current master). 
 It includes the fixes suggested by @reneeotten in the discussion there, putting the actual code in `printfuncs.py`, replacing `user_value` with `init_value` and adding `brute_step` if used.

This also includes a basic test that the html_reprs are created for a non-trivial case.

Hopefully, we can merge this and tag 0.9.13 within a couple days. ;)
