### PR TITLE
Params eval

### DIFF
--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -74,6 +74,8 @@ The :class:`Parameters` class
 
     .. automethod:: dump
 
+    .. automethod:: eval
+
     .. automethod:: loads
 
     .. automethod:: load

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -188,6 +188,22 @@ class Parameters(OrderedDict):
         # then add all the parameters
         self.add_many(*state['params'])
 
+    def eval(self, expr):
+        """Evaluate a statement using the asteval Interpreter.
+
+        Parameters
+        ----------
+        expr : string
+            An expression containing parameter names and other symbols
+            recognizable by the asteval Interpreter.
+
+        Returns
+        -------
+           The result of the expression.
+
+        """
+        return self._asteval.eval(expr)
+
     def update_constraints(self):
         """Update all constrained parameters, checking that dependencies are
         evaluated as needed."""

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -246,3 +246,13 @@ class TestParameters(unittest.TestCase):
             p1['y'].set(expr='t+')
         assert(len(p1['y']._expr_eval.error) > 0)
         assert_almost_equal(p1['y'].value, 34.0)
+
+    def test_eval(self):
+        # check that eval() works with usersyms and parameter values
+        def myfun(x):
+            return 2.0 * x
+        p = Parameters(usersyms={"myfun": myfun})
+        p.add("a", value=4.0)
+        p.add("b", value=3.0)
+        assert_almost_equal(p.eval("myfun(2.0) * a"), 16)
+        assert_almost_equal(p.eval("b / myfun(3.0)"), 0.5)


### PR DESCRIPTION
#### Description
This PR is in reference to the discussion here: https://groups.google.com/forum/#!topic/lmfit-py/pJWdxzYRGqI

Expressions derived from parameter values are often added to a Parameters() object using params.add("name", expr="expression"). These expressions can contain common numpy functions, user-defined functions, and parameter values. During a fit, they are evaluated every iteration. 

If this updating behavior is not desired, an expression can be evaluated post-fitting using the parameter values directly using p = params.valuesdict(). However, there is currently no public method to retrieve user-defined symbols from the object. 

This PR addresses this point by allowing the user to evaluate arbitrary expressions in the Parameters object's namespace via the params.eval() method. A test for this method is also included.

###### Type of Changes
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples

###### Tested on
Python: 3.7.3 (default, Mar 27 2019, 16:54:48)
[Clang 4.0.1 (tags/RELEASE_401/final)]

lmfit: 0.9.13+7.gbcec209, scipy: 1.2.1, numpy: 1.16.3, asteval: 0.9.13, uncertainties: 3.0.3, six: 1.12.0

###### Verification
- [x] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
Not sure the best way to do these two
- [ ] updated the documentation?
- [ ] added an example?
