### PR TITLE
MAINT: don't run test-suite twice on Travis CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'versioneer.py|lmfit/_version|doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.16.1
+    rev: v1.16.3
     hooks:
     -   id: pyupgrade
         # for now don't force to change from %-operator to {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ install:
 
 script:
     - cd tests
-    - pytest
     - coverage run --source=lmfit -m pytest
     - coverage report -m
     # test building the documentation


### PR DESCRIPTION
#### Description
Commit e1f71975ff37bdb7cace6902e9d384ae1c398710 added running ```coverage``` as part of Travis CI. Since then the test-suite is run twice for every Python version (see, for example, [here](https://travis-ci.org/lmfit/lmfit-py/jobs/527066018)). Admittedly, setting up the conda environment takes most of the time anyway, but running the tests first with ```pytest``` and then again with ```coverage run --source=lmfit -m pytest``` is not really necessary ;) This PR removes the first call of ```pytest```.

In addition, it updates the ```pre-commit``` hook for ```pyupgrade``` to version 1.16.3.


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.3 (default, Mar 31 2019, 14:30:14)
[Clang 10.0.1 (clang-1001.0.46.3)]

lmfit: 0.9.13+17.g81d88f8, scipy: 1.2.1, numpy: 1.16.3, asteval: 0.9.13, uncertainties: 3.0.3, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?