### PR TITLE
Fix Division by Zero problem

### DIFF
--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -284,7 +284,7 @@ def params_html_table(params):
             serr, perr = '', ''
             if p.stderr is not None:
                 serr = gformat(p.stderr)
-            if p.value != 0.0:
+            if not p.value == 0.:
                 perr = '%.2f%%' % (100 * p.stderr / p.value)
             rows.extend([serr, perr])
         rows.extend((p.init_value, gformat(p.min), gformat(p.max),

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -285,7 +285,7 @@ def params_html_table(params):
             if p.stderr is not None:
                 serr = gformat(p.stderr)
             try:
-                perr = '%.2f%%' % (100 * p.stderr / p.value)
+                perr = '({.2%})'.format(p.stderr / p.value)
             except ZeroDivisionError:
                 perr = ''
             rows.extend([serr, perr])

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -284,6 +284,7 @@ def params_html_table(params):
             serr, perr = '', ''
             if p.stderr is not None:
                 serr = gformat(p.stderr)
+            if p.value != 0.0:
                 perr = '%.2f%%' % (100 * p.stderr / p.value)
             rows.extend([serr, perr])
         rows.extend((p.init_value, gformat(p.min), gformat(p.max),

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -284,8 +284,10 @@ def params_html_table(params):
             serr, perr = '', ''
             if p.stderr is not None:
                 serr = gformat(p.stderr)
-            if not p.value == 0.:
+            try:
                 perr = '%.2f%%' % (100 * p.stderr / p.value)
+            except ZeroDivisionError:
+                perr = ''
             rows.extend([serr, perr])
         rows.extend((p.init_value, gformat(p.min), gformat(p.max),
                      '%s' % p.vary))

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -9,6 +9,8 @@ from numpy.testing import assert_, assert_almost_equal, assert_equal
 
 from lmfit import Model, Parameter, Parameters
 
+from lmfit.printfuncs import params_html_table
+
 
 class TestParameters(unittest.TestCase):
 
@@ -256,3 +258,12 @@ class TestParameters(unittest.TestCase):
         p.add("b", value=3.0)
         assert_almost_equal(p.eval("myfun(2.0) * a"), 16)
         assert_almost_equal(p.eval("b / myfun(3.0)"), 0.5)
+
+    def test_params_html_table(self):
+        p1 = Parameters()
+        p1.add('t', 2.0, min=0.0, max=5.0)
+        p1.add('x', 0.0, )
+        
+        html = params_html_table(p1)
+        self.assertIsInstance(html, str)
+


### PR DESCRIPTION


#### Description
`lmfit.printfuncs.params_html_table` is prone to unhandled ZeroDivisionError exception in the case where one of the parameters is fixed to zero. I added an if statement to check for this possibility, so to avoid this potential issue.


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.3 (default, Mar 27 2019, 17:13:21) [MSC v.1915 64 bit (AMD64)]

lmfit: 0.9.13+23.g579f2a5, scipy: 1.2.1, numpy: 1.16.2, asteval: 0.9.13, uncertainties: 3.0.3, six: 1.12.0



###### Verification <!-- (delete not applicable items) -->
Have you
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x ] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation?
- [ ] added an example?

It's a bit hard to write a test case because I can not define parameter with stderr not None. This property only emerges at the output of minimize. I would be happy to add test coverage otherwize. 

In any case, one should not divide without checking the variable to be equal to zero.

Best regards,
Andrey
