### PR TITLE
Add dual_annealing algorithm

### DIFF
--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -175,6 +175,8 @@ uncertainties and correlations if ``calc_covar`` is True (default).
  | Simplicial Homology      |  ``shgo``                                                        |
  | Global Ooptimization     |                                                                  |
  +--------------------------+------------------------------------------------------------------+
+ | Dual Annealing           |  ``dual_annealing``                                              |
+ +--------------------------+------------------------------------------------------------------+
  | Maximum likelihood via   |  ``emcee``                                                       |
  | Monte-Carlo Markov Chain |                                                                  |
  +--------------------------+------------------------------------------------------------------+
@@ -402,6 +404,8 @@ For more information, check the examples in ``examples/lmfit_brute_example.ipynb
 .. automethod:: Minimizer.ampgo
 
 .. automethod:: Minimizer.shgo
+
+.. automethod:: Minimizer.dual_annealing
 
 .. automethod:: Minimizer.emcee
 

--- a/tests/test_covariance_matrix.py
+++ b/tests/test_covariance_matrix.py
@@ -152,10 +152,10 @@ def test_numdifftools_no_bounds(fit_method):
 
 
 @pytest.mark.parametrize("fit_method", ['nelder', 'basinhopping', 'ampgo',
-                                        'shgo'])
+                                        'shgo', 'dual_annealing'])
 def test_numdifftools_with_bounds(fit_method):
     pytest.importorskip("numdifftools")
-    if fit_method == 'shgo':
+    if fit_method in ['shgo', 'dual_annealing']:
         pytest.importorskip("scipy", minversion="1.2")
 
     # load data to be fitted

--- a/tests/test_dual_annealing.py
+++ b/tests/test_dual_annealing.py
@@ -1,0 +1,70 @@
+"""Tests for the Dual Annealing algorithm."""
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+import scipy
+
+import lmfit
+
+# dual_annealing algorithm is present in SciPy >= 1.2
+pytest.importorskip("scipy", minversion="1.2")
+
+
+def eggholder(x):
+    return (-(x[1] + 47.0) * np.sin(np.sqrt(abs(x[0]/2.0 + (x[1] + 47.0))))
+            - x[0] * np.sin(np.sqrt(abs(x[0] - (x[1] + 47.0)))))
+
+
+def eggholder_lmfit(params):
+    x0 = params['x0'].value
+    x1 = params['x1'].value
+
+    return (-(x1 + 47.0) * np.sin(np.sqrt(abs(x0/2.0 + (x1 + 47.0))))
+            - x0 * np.sin(np.sqrt(abs(x0 - (x1 + 47.0)))))
+
+
+def test_da_scipy_vs_lmfit():
+    """Test DA algorithm in lmfit versus SciPy."""
+    bounds = [(-512, 512), (-512, 512)]
+    result_scipy = scipy.optimize.dual_annealing(eggholder, bounds, seed=7)
+
+    pars = lmfit.Parameters()
+    pars.add_many(('x0', 0, True, -512, 512), ('x1', 0, True, -512, 512))
+    mini = lmfit.Minimizer(eggholder_lmfit, pars)
+    result = mini.minimize(method='dual_annealing', seed=7)
+    out_x = np.array([result.params['x0'].value, result.params['x1'].value])
+
+    assert_allclose(result_scipy.fun, result.residual)
+    assert_allclose(result_scipy.x, out_x)
+
+
+# TODO: add scipy example from docstring after the reproducibility issue in
+# https://github.com/scipy/scipy/issues/9732 is resolved.
+
+# correct result for Alpine02 function
+global_optimum = [7.91705268, 4.81584232]
+fglob = -6.12950
+
+
+def test_da_Alpine02(minimizer_Alpine02):
+    """Test dual_annealing algorithm on Alpine02 function."""
+    out = minimizer_Alpine02.minimize(method='dual_annealing')
+    out_x = np.array([out.params['x0'].value, out.params['x1'].value])
+
+    assert_allclose(out.residual, fglob, rtol=1e-5)
+    assert_allclose(min(out_x), min(global_optimum), rtol=1e-3)
+    assert_allclose(max(out_x), max(global_optimum), rtol=1e-3)
+    assert out.method == 'dual_annealing'
+
+
+def test_da_bounds(minimizer_Alpine02):
+    """Test dual_annealing algorithm with bounds."""
+    pars_bounds = lmfit.Parameters()
+    pars_bounds.add_many(('x0', 1., True, 5.0, 15.0),
+                         ('x1', 1., True, 2.5, 7.5))
+
+    out = minimizer_Alpine02.minimize(params=pars_bounds,
+                                      method='dual_annealing')
+    assert 5.0 <= out.params['x0'].value <= 15.0
+    assert 2.5 <= out.params['x1'].value <= 7.5


### PR DESCRIPTION
#### Description
This PR adds the ``dual_annealing``` algorithm that was introduced in ```scipy``` v1.2 (see Issue #527)

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties, six
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}, six: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__, six.__version__))
-->
Python: 3.7.3 (default, Mar 31 2019, 14:30:14)
[Clang 10.0.1 (clang-1001.0.46.3)]

lmfit: 0.9.13+29.g63369d3, scipy: 1.2.1, numpy: 1.16.3, asteval: 0.9.13, uncertainties: 3.0.3, six: 1.12.0


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation?
- [ ] added an example?
