### PR TITLE
Fix brute method/test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@ exclude: 'versioneer.py|lmfit/_version|doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.16.3
+    rev: v1.17.1
     hooks:
     -   id: pyupgrade
         # for now don't force to change from %-operator to {}
         args: [--keep-percent-format]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.1
+    rev: v2.2.3
     hooks:
     -   id: check-ast
     -   id: check-builtin-literals
@@ -37,6 +37,6 @@ repos:
         additional_dependencies: [rstcheck, sphinx]
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.3.0
+    rev: v1.4.0
     hooks:
     -   id: rst-backticks

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1681,7 +1681,9 @@ class Minimizer(object):
         """
         result = self.prepare_fit(params=params)
         result.method = 'brute'
-        result.nfev -= 1  # correct for "pre-fit" initialization/checks
+        # FIXME: remove after requirement for scipy >= 1.3
+        if int(major) == 0 or (int(major) == 1 and int(minor) < 3):
+            result.nfev -= 1  # correct for "pre-fit" initialization/checks
 
         brute_kws = dict(full_output=1, finish=None, disp=False)
 


### PR DESCRIPTION
#### Description
The ```brute``` code has undergone some changes in ```scipy``` v1.3 (I'll make a PR to support the new parallelization later). Now, the tests fail because there is no need anymore for the "pre-fit" correction of ```nfev```. I have changed the code in the ```brute``` function accordingly (only do the correction for SciPy <= 1.2). Additionally, I have updated the ```pre-commit``` update hooks.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.3 (default, Mar 31 2019, 14:30:14)
[Clang 10.0.1 (clang-1001.0.46.3)]

lmfit: 0.9.13+30.gca4f853.dirty, scipy: 1.3.0, numpy: 1.16.3, asteval: 0.9.13, uncertainties: 3.1, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
