### PR TITLE
FIX: always set result.method for emcee

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1166,7 +1166,6 @@ class Minimizer(object):
             tparams = None
 
         result = self.prepare_fit(params=tparams)
-        result.method = 'emcee'
         params = result.params
 
         # check if the userfcn returns a vector of residuals
@@ -1181,6 +1180,8 @@ class Minimizer(object):
                 # have to re-prepare the fit
                 result = self.prepare_fit(params)
                 params = result.params
+
+        result.method = 'emcee'
 
         # Removing internal parameter scaling. We could possibly keep it,
         # but I don't know how this affects the emcee sampling.

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -452,6 +452,9 @@ class CommonMinimizerTest(unittest.TestCase):
 
         check_paras(out.params, self.p_true, sig=3)
 
+        out_unweighted = self.mini.minimize(method='emcee', is_weighted=False)
+        assert out_unweighted.method == 'emcee'
+
     @dec.slow
     def test_emcee_PT(self):
         # test emcee with parallel tempering


### PR DESCRIPTION
#### Description
Currently, the ```emcee``` method does not set the ```.method``` attribute when using ```is_weighted=False``` and fails when doing ```lmfit.report_fit(<out>)``` with:

```
AttributeError: 'MinimizerResult' object has no attribute 'method'
```

The issue is that when is_weighted=False, ```result = self.prepare_fit(params)``` gets (correctly) called again, which re-initializes the ```MinimizerResult```. Since we did set ```result.method = 'emcee'``` a few lines earlier, that attribute is now undefined.

This PR fixes that and adds a regression tests.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.3 (default, Mar 31 2019, 14:30:14)
[Clang 10.0.1 (clang-1001.0.46.3)]

lmfit: 0.9.13+34.gbbdda29, scipy: 1.3.0, numpy: 1.16.3, asteval: 0.9.13, uncertainties: 3.1, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?