### PR TITLE
more careful adding of parameters to handle out-of-order constraint expressions

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -387,12 +387,34 @@ class Parameters(OrderedDict):
         >>> params.add_many(f, g)
 
         """
-        for para in parlist:
+        def _addpar(para):
             if isinstance(para, Parameter):
                 self.__setitem__(para.name, para)
             else:
                 param = Parameter(*para)
                 self.__setitem__(param.name, param)
+
+        missing = []
+        for par in parlist:
+            try:
+                _addpar(par)
+            except NameError:
+                missing.append(par)
+                if par.name in self.keys():
+                    self.pop(par.name)
+
+        nmissing = len(missing)
+        count = 0
+        while len(missing) > 0 and count < 2 + nmissing**2:
+            for par in missing:
+                try:
+                    _addpar(par)
+                    missing.remove(par)
+                except NameError:
+                    pass
+                count += 1
+        if len(missing) > 0:
+            raise ValueError("error setting parameters: %s" % missing)
 
     def valuesdict(self):
         """Return an ordered dictionary of parameter values.

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -387,34 +387,16 @@ class Parameters(OrderedDict):
         >>> params.add_many(f, g)
 
         """
-        def _addpar(para):
-            if isinstance(para, Parameter):
-                self.__setitem__(para.name, para)
-            else:
-                param = Parameter(*para)
-                self.__setitem__(param.name, param)
-
-        missing = []
+        __params = []
         for par in parlist:
-            try:
-                _addpar(par)
-            except NameError:
-                missing.append(par)
-                if par.name in self.keys():
-                    self.pop(par.name)
+            if not isinstance(par, Parameter):
+                par = Parameter(*par)
+            __params.append(par)
+            par._delay_asteval = True
+            self.__setitem__(par.name, par)
 
-        nmissing = len(missing)
-        count = 0
-        while len(missing) > 0 and count < 2 + nmissing**2:
-            for par in missing:
-                try:
-                    _addpar(par)
-                    missing.remove(par)
-                except NameError:
-                    pass
-                count += 1
-        if len(missing) > 0:
-            raise ValueError("error setting parameters: %s" % missing)
+        for para in __params:
+            para._delay_asteval = False
 
     def valuesdict(self):
         """Return an ordered dictionary of parameter values.

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -263,7 +263,19 @@ class TestParameters(unittest.TestCase):
         p1 = Parameters()
         p1.add('t', 2.0, min=0.0, max=5.0)
         p1.add('x', 0.0, )
-        
+
         html = params_html_table(p1)
         self.assertIsInstance(html, str)
 
+    def test_add_params_expr_outoforder(self):
+        params1 = Parameters()
+        params1.add("a", value=1.0)
+
+        params2 = Parameters()
+        params2.add("b", value=1.0)
+        params2.add("c", value=2.0)
+        params2['b'].expr = 'c/2'
+
+        params = params1 + params2
+        assert('b' in params)
+        assert_almost_equal(params['b'].value, 1.0)


### PR DESCRIPTION
Addresses #560 


### Description

This looks for NameError on adding parameters and tries again (up to a few times) to try to resolve NameErrors when adding parameters with valid but out-of-order constraint expressions.


### Type of Changes

- [ x] Bug fix


### Verification 
Have you

- [ x] verified that existing tests pass locally?
- [ x] added or updated existing tests to cover the changes?

