### PR TITLE
Parallellization of brute force method 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'versioneer.py|lmfit/_version|doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.17.1
+    rev: v1.19.0
     hooks:
     -   id: pyupgrade
         # for now don't force to change from %-operator to {}

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1602,7 +1602,7 @@ class Minimizer(object):
 
         return result
 
-    def brute(self, params=None, Ns=20, keep=50):
+    def brute(self, params=None, Ns=20, keep=50, workers=1):
         """Use the `brute` method to find the global minimum of a function.
 
         The following parameters are passed to :scipydoc:`optimize.brute`
@@ -1636,6 +1636,9 @@ class Minimizer(object):
             Number of best candidates from the brute force method that are
             stored in the :attr:`candidates` attribute. If 'all', then all grid
             points from :scipydoc:`optimize.brute` are stored as candidates.
+        workers : int or map-like callable, optional
+            For parallel evaluation of the grid, added in SciPy v1.3 (see
+            :scipydoc:`optimize.brute` for more details).
 
         Returns
         -------
@@ -1682,11 +1685,16 @@ class Minimizer(object):
         """
         result = self.prepare_fit(params=params)
         result.method = 'brute'
+
         # FIXME: remove after requirement for scipy >= 1.3
         if int(major) == 0 or (int(major) == 1 and int(minor) < 3):
             result.nfev -= 1  # correct for "pre-fit" initialization/checks
 
         brute_kws = dict(full_output=1, finish=None, disp=False)
+        # keyword 'workers' is introduced in SciPy v1.3
+        # FIXME: remove this check after updating the requirement >= 1.3
+        if int(major) == 1 and int(minor) >= 3:
+            brute_kws.update({'workers': workers})
 
         varying = np.asarray([par.vary for par in self.params.values()])
         replace_none = lambda x, sign: sign*np.inf if x is None else x


### PR DESCRIPTION
In SciPy v1.3 the ```brute``` method learned how to evaluate the search grid in parallel and gained a new keyword ```workers``` for this feature. This PR adds that keyword to the ```brute``` method in lmfit, but will only use it when scipy >= 1.3 is installed. Requirement here is of course that ```func``` can be pickle-d.

I added the keyword to the end of the function in order not to break backwards compatibility. In all other methods calling ```scipy``` minimizers the function arguments in lmfit are always ```def method(self, params=None, **kws)```, except for ```brute```. I initally made this decision since ```Ns``` was needed for calculation of the boundaries within the function and the ```keep``` keyword was also not a ```scipy.brute``` argument. Does it make sense to add ```workers``` just to the end of this list or should I rework the function to only use ```kws```? To be honest, I am not even sure if it makes a difference.... and it would probably break backwards compatibility @newville?

I didn't add a test because it's a bit hard to verify (for the small problems in our tests it actually takes a bit longer to run due to the overhead), but it's passed correctly to ```scipy.brute``` as it fails when you supply a function that is  not pickleable ;)

Additionally, the ```pyupgrade``` pre-commit hook is updated.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.3 (default, Mar 31 2019, 14:30:14)
[Clang 10.0.1 (clang-1001.0.46.3)]

lmfit: 0.9.13+45.g9ebc22f, scipy: 1.3.0, numpy: 1.16.4, asteval: 0.9.14, uncertainties: 3.1.1, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x] included docstrings that follow PEP 257?
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation?
- [ ] added an example?
