### PR TITLE
Remove deprecated "missing" and "drop"

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -2254,34 +2254,6 @@ def _make_random_gen(seed):
                      ' instance' % seed)
 
 
-VALID_NAN_POLICIES = ('propagate', 'omit', 'raise')
-
-
-def validate_nan_policy(policy):
-    """Validate and rationalize `nan_policy`.
-
-    This function ensures backwards compatibility and as well as compatibility
-    with Pandas `missing` convention.
-
-    """
-    if policy in VALID_NAN_POLICIES:
-        return policy
-    if policy is None:
-        policy = 'propagate'
-
-    policy = policy.lower()
-    if policy == 'drop':
-        policy = 'omit'
-        warnings.warn("The option 'drop' is deprecated as of lmfit 0.9.13 and "
-                      "will be removed in the next release. Use 'omit' "
-                      "instead.", FutureWarning)
-    if policy == 'none':
-        policy = 'propagate'
-    if policy not in VALID_NAN_POLICIES:
-        raise ValueError("nan_policy must be 'propagate', 'omit', or 'raise'.")
-    return policy
-
-
 def _nan_policy(arr, nan_policy='raise', handle_inf=True):
     """Specify behaviour when an array contains numpy.nan or numpy.inf.
 
@@ -2308,7 +2280,8 @@ def _nan_policy(arr, nan_policy='raise', handle_inf=True):
     scipy/stats/stats.py/_contains_nan
 
     """
-    nan_policy = validate_nan_policy(nan_policy)
+    if nan_policy not in ('propagate', 'omit', 'raise'):
+        raise ValueError("nan_policy must be 'propagate', 'omit', or 'raise'.")
 
     if handle_inf:
         handler_func = lambda x: ~np.isfinite(x)
@@ -2320,6 +2293,7 @@ def _nan_policy(arr, nan_policy='raise', handle_inf=True):
         mask = ~handler_func(arr)
         if not np.all(mask):  # there are some NaNs/infs/missing values
             return arr[mask]
+
     if nan_policy == 'raise':
         try:
             # Calling np.sum to avoid creating a huge array into memory

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -14,7 +14,7 @@ from scipy.stats import t
 from . import Minimizer, Parameter, Parameters, lineshapes
 from .confidence import conf_interval
 from .jsonutils import HAS_DILL, decode4js, encode4js
-from .minimizer import validate_nan_policy, MinimizerResult
+from .minimizer import MinimizerResult
 from .printfuncs import ci_report, fit_report, fitreport_html_table
 
 # Use pandas.isnull for aligning missing data if pandas is available.
@@ -191,7 +191,7 @@ class Model(object):
     _hint_names = ('value', 'vary', 'min', 'max', 'expr')
 
     def __init__(self, func, independent_vars=None, param_names=None,
-                 nan_policy='raise', missing=None, prefix='', name=None, **kws):
+                 nan_policy='raise', prefix='', name=None, **kws):
         """Create a model from a user-supplied model function.
 
         The model function will normally take an independent variable
@@ -211,8 +211,6 @@ class Model(object):
         nan_policy : str, optional
             How to handle NaN and missing values in data. Must be one of
             'raise' (default), 'propagate', or 'omit'. See Note below.
-        missing : str, optional
-            Synonym for 'nan_policy' for backward compatibility.
         prefix : str, optional
             Prefix used for the model.
         name : str, optional
@@ -236,12 +234,7 @@ class Model(object):
 
            - 'propagate' : do nothing
 
-           -  'omit' : (was 'drop') drop missing data
-
-        4. The `missing` argument is deprecated in lmfit 0.9.8 and will be
-        removed in a later version. Use `nan_policy` instead, as it is
-        consistent with the Minimizer class.
-
+           -  'omit' : drop missing data
 
         Examples
         --------
@@ -271,12 +264,7 @@ class Model(object):
         self.independent_vars = independent_vars
         self._func_allargs = []
         self._func_haskeywords = False
-        if missing is not None:
-            nan_policy = missing
-            warnings.warn("The keyword 'missing' is deprecated as of lmfit "
-                          "0.9.13 and will be removed in the next release. "
-                          "Use 'nan_policy' instead.", FutureWarning)
-        self.nan_policy = validate_nan_policy(nan_policy)
+        self.nan_policy = nan_policy
 
         self.opts = kws
         self.param_hints = OrderedDict()
@@ -979,7 +967,7 @@ class Model(object):
 
         # Handle null/missing values.
         if nan_policy is not None:
-            self.nan_policy = validate_nan_policy(nan_policy)
+            self.nan_policy = nan_policy
 
         mask = None
         if self.nan_policy == 'omit':
@@ -1346,7 +1334,7 @@ class ModelResult(Minimizer):
         if method is not None:
             self.method = method
         if nan_policy is not None:
-            self.nan_policy = validate_nan_policy(nan_policy)
+            self.nan_policy = nan_policy
 
         self.ci_out = None
         self.userargs = (self.data, self.weights)

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -94,8 +94,6 @@ COMMON_INIT_DOC = """
     nan_policy : str, optional
         How to handle NaN and missing values in data. Must be one of:
         'raise' (default), 'propagate', or 'omit'. See Notes below.
-    missing : str, optional
-        Synonym for 'nan_policy' for backward compatibility.
     **kwargs : optional
         Keyword arguments to pass to :class:`Model`.
 
@@ -106,11 +104,7 @@ COMMON_INIT_DOC = """
 
         - 'raise' : Raise a ValueError (default)
         - 'propagate' : do nothing
-        - 'omit' : (was 'drop') drop missing data
-
-    2. The `missing` argument is deprecated in lmfit 0.9.8 and will be
-    removed in a later version. Use `nan_policy` instead, as it is
-    consistent with the Minimizer class.
+        - 'omit' : drop missing data
 
     """
 
@@ -1224,8 +1218,6 @@ class ExpressionModel(Model):
         nan_policy : str, optional
             How to handle NaN and missing values in data. Must be one of:
             'raise' (default), 'propagate', or 'omit'. See Notes below.
-        missing : str, optional
-            Synonym for 'nan_policy' for backward compatibility.
         **kws : optional
             Keyword arguments to pass to :class:`Model`.
 
@@ -1241,11 +1233,7 @@ class ExpressionModel(Model):
 
             - 'raise' : Raise a ValueError (default)
             - 'propagate' : do nothing
-            - 'omit' : (was 'drop') drop missing data
-
-        4. The `missing` argument is deprecated in lmfit 0.9.8 and will be
-        removed in a later version. Use `nan_policy` instead, as it is
-        consistent with the Minimizer class.
+            - 'omit' : drop missing data
 
         """
         # create ast evaluator, load custom functions


### PR DESCRIPTION
#### Description
In version 0.9.8 the keyword ```missing``` for the ```Model``` class was deprecated in favor of ```nan_policy``` for consistency with the ```Minimizer``` class. Similarly ```drop``` was deprecated in favor of ```omit``` as an option for ```nan_policy```. In lmfit version 0.9.13 we added an explicit ```FutureWarning``` when these options were still used (see #540), this PR removes them completely as well as the -now no longer needed- compatibility code.

Additionally, the tests are updated to reflect this change and I added a tests to check that the correct option is given to ```nan_policy```.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.3 (default, Mar 31 2019, 14:30:14)
[Clang 10.0.1 (clang-1001.0.46.3)]

lmfit: 0.9.13+47.g7d99a32, scipy: 1.3.0, numpy: 1.16.4, asteval: 0.9.14, uncertainties: 3.1.1, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation?
- [ ] added an example?
