### PR TITLE
make sure all parameters in Model.guess() use prefixes

### DIFF
--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -427,8 +427,8 @@ class SplitLorentzianModel(Model):
     def guess(self, data, x=None, negative=False, **kwargs):
         """Estimate initial model parameter values from data."""
         pars = guess_from_peak(self, data, x, negative, ampscale=1.25)
-        sigma = pars['sigma']
-        pars['sigma_r'].set(value=sigma.value, min=sigma.min, max=sigma.max)
+        sigma = pars['%ssigma' % self.prefix]
+        pars['%ssigma_r' % self.prefix].set(value=sigma.value, min=sigma.min, max=sigma.max)
         return update_param_vals(pars, self.prefix, **kwargs)
 
     __init__.__doc__ = COMMON_INIT_DOC


### PR DESCRIPTION

#### Description

This addresses #566 and message https://groups.google.com/forum/#!topic/lmfit-py/HgPt_EVXQfo

###### Type of Changes

- [x] Bug fix



###### Tested on

lmfit: 0.9.13+47.gc5efd5c, scipy: 1.2.1, numpy: 1.16.4, asteval: 0.9.14+1.g14b5e13.dirty, uncertainties: 3.0.2, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you

- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?

