### PR TITLE
Explicitly add install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,6 @@ provided for exploring minmization problems where the approximation of
 estimating Parameter uncertainties from the covariance matrix is
 questionable. """
 
-with open('requirements.txt', 'r') as f:
-    install_reqs = f.read().splitlines()
-
 setup(name='lmfit',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
@@ -32,7 +29,11 @@ setup(name='lmfit',
       author_email='matt.newville@gmail.com',
       url='https://lmfit.github.io/lmfit-py/',
       download_url='https://lmfit.github.io//lmfit-py/',
-      install_requires=install_reqs,
+      install_requires=['asteval>=0.9.12',
+                        'numpy>=1.10',
+                        'scipy>=0.19',
+                        'six>1.10',
+                        'uncertainties>=3.0'],
       python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
       license='BSD-3',
       description="Least-Squares Minimization with Bounds and Constraints",


### PR DESCRIPTION
#### Description
Currently, the requirements do not end up in the json meta-data on PyPI which limits the usability of tools that rely on it. For example, the tool [upt](https://framagit.org/upt/upt) that we are currently exploring to help with packaging for MacPorts, does not report any dependencies.

Apparently, the information is computed locally when generating the PyPI package and, therefore, might depend on how this is exactly done. Nevertheless, explicitly listing the dependencies should resolve this.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.3 (default, Mar 31 2019, 14:30:14)
[Clang 10.0.1 (clang-1001.0.46.3)]

lmfit: 0.9.13+47.g3e45ad8, scipy: 1.3.0, numpy: 1.16.4, asteval: 0.9.14, uncertainties: 3.1.1, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?