### PR TITLE
Splitloren hints with prefix

### DIFF
--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -418,11 +418,12 @@ class SplitLorentzianModel(Model):
         self._set_paramhints_prefix()
 
     def _set_paramhints_prefix(self):
+        fwhm_expr = '{pre:s}sigma+{pre:s}sigma_r'
+        height_expr = '2*{pre:s}amplitude/{0:.7f}/max({1:.7f}, ({pre:s}sigma+{pre:s}sigma_r))'
         self.set_param_hint('sigma', min=0)
         self.set_param_hint('sigma_r', min=0)
-        self.set_param_hint('fwhm', expr='sigma+sigma_r')
-        self.set_param_hint(
-            'height', expr='2*amplitude/{:.7f}/max({}, (sigma+sigma_r))'.format(np.pi, tiny))
+        self.set_param_hint('fwhm', expr=fwhm_expr.format(pre=self.prefix))
+        self.set_param_hint('height', expr=height_expr.format(np.pi, tiny, pre=self.prefix))
 
     def guess(self, data, x=None, negative=False, **kwargs):
         """Estimate initial model parameter values from data."""

--- a/tests/test_lineshapes_models.py
+++ b/tests/test_lineshapes_models.py
@@ -119,73 +119,73 @@ def test_finite_output_lineshape(lineshape):
 def test_height_and_fwhm_expression_evalution_in_builtin_models():
     """Assert models do not throw an ZeroDivisionError."""
     mod = models.GaussianModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9)
     params.update_constraints()
 
     mod = models.LorentzianModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9)
     params.update_constraints()
 
     mod = models.SplitLorentzianModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, sigma_r=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, sigma_r=1.0)
     params.update_constraints()
 
     mod = models.VoigtModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, gamma=1.0)
     params.update_constraints()
 
     mod = models.PseudoVoigtModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, fraction=0.5)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, fraction=0.5)
     params.update_constraints()
 
     mod = models.MoffatModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, beta=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, beta=0.0)
     params.update_constraints()
 
     mod = models.Pearson7Model()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, expon=1.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, expon=1.0)
     params.update_constraints()
 
     mod = models.StudentsTModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9)
     params.update_constraints()
 
     mod = models.BreitWignerModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, q=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, q=0.0)
     params.update_constraints()
 
     mod = models.LognormalModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9)
     params.update_constraints()
 
     mod = models.DampedOscillatorModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9)
     params.update_constraints()
 
     mod = models.DampedHarmonicOscillatorModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, gamma=0.0)
     params.update_constraints()
 
     mod = models.ExponentialGaussianModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, gamma=0.0)
     params.update_constraints()
 
     mod = models.SkewedGaussianModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, gamma=0.0)
     params.update_constraints()
 
     mod = models.SkewedVoigtModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0,
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, gamma=0.0,
                              skew=0.0)
     params.update_constraints()
 
     mod = models.DonaichModel()
-    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, gamma=0.0)
+    params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, gamma=0.0)
     params.update_constraints()
 
     mod = models.StepModel()
     for f in ('linear', 'arctan', 'erf', 'logistic'):
-        params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.0, form=f)
+        params = mod.make_params(amplitude=1.0, center=0.0, sigma=0.9, form=f)
         params.update_constraints()
 
     mod = models.RectangleModel()
@@ -193,3 +193,13 @@ def test_height_and_fwhm_expression_evalution_in_builtin_models():
         params = mod.make_params(amplitude=1.0, center1=0.0, sigma1=0.0,
                                  center2=0.0, sigma2=0.0, form=f)
         params.update_constraints()
+
+
+def test_splitlorentzian_prefix():
+    mod1 = models.SplitLorentzianModel()
+    par1 = mod1.make_params(amplitude=1.0, center=0.0, sigma=0.9, sigmar=1.3)
+    par1.update_constraints()
+
+    mod2 = models.SplitLorentzianModel(prefix='prefix_')
+    par2 = mod2.make_params(amplitude=1.0, center=0.0, sigma=0.9, sigmar=1.3)
+    par2.update_constraints()

--- a/tests/test_lineshapes_models.py
+++ b/tests/test_lineshapes_models.py
@@ -201,5 +201,5 @@ def test_splitlorentzian_prefix():
     par1.update_constraints()
 
     mod2 = models.SplitLorentzianModel(prefix='prefix_')
-    par2 = mod2.make_params(amplitude=1.0, center=0.0, sigma=0.9, sigmai_r=1.3)
+    par2 = mod2.make_params(amplitude=1.0, center=0.0, sigma=0.9, sigma_r=1.3)
     par2.update_constraints()

--- a/tests/test_lineshapes_models.py
+++ b/tests/test_lineshapes_models.py
@@ -197,9 +197,9 @@ def test_height_and_fwhm_expression_evalution_in_builtin_models():
 
 def test_splitlorentzian_prefix():
     mod1 = models.SplitLorentzianModel()
-    par1 = mod1.make_params(amplitude=1.0, center=0.0, sigma=0.9, sigmar=1.3)
+    par1 = mod1.make_params(amplitude=1.0, center=0.0, sigma=0.9, sigma_r=1.3)
     par1.update_constraints()
 
     mod2 = models.SplitLorentzianModel(prefix='prefix_')
-    par2 = mod2.make_params(amplitude=1.0, center=0.0, sigma=0.9, sigmar=1.3)
+    par2 = mod2.make_params(amplitude=1.0, center=0.0, sigma=0.9, sigmai_r=1.3)
     par2.update_constraints()


### PR DESCRIPTION
addresses #566, this time for sure!

basic problem: parameter hints were not using prefix

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix

I did add a test this time!