### PR TITLE
Add tests for lmfit/jsonutils.py

### DIFF
--- a/lmfit/jsonutils.py
+++ b/lmfit/jsonutils.py
@@ -1,6 +1,5 @@
 """JSON utilities."""
 from base64 import b64decode, b64encode
-import json
 import sys
 
 import numpy as np
@@ -67,9 +66,9 @@ def encode4js(obj):
 
     """
     if isinstance(obj, DataFrame):
-        return dict(__class__='PDataFrame', value=json.loads(obj.to_json()))
-    elif isinstance(obj, DataFrame):
-        return dict(__class__='PSeries', value=encode4js(obj.to_dict()))
+        return dict(__class__='PDataFrame', value=obj.to_json())
+    elif isinstance(obj, Series):
+        return dict(__class__='PSeries', value=obj.to_json())
     elif isinstance(obj, np.ndarray):
         if 'complex' in obj.dtype.name:
             val = [(obj.real).tolist(), (obj.imag).tolist()]
@@ -142,9 +141,9 @@ def decode4js(obj):
             out = np.fromiter(obj['value'], dtype=obj['__dtype__'])
         out.shape = obj['__shape__']
     elif classname == 'PDataFrame' and read_json is not None:
-        out = read_json(json.dumps(obj['value']))
-    elif classname == 'PSeries':
-        out = Series(obj['value'])
+        out = read_json(obj['value'])
+    elif classname == 'PSeries' and read_json is not None:
+        out = read_json(obj['value'], typ='series')
     elif classname == 'Callable':
         out = val = obj['__name__']
         pyvers = "%d.%d" % (sys.version_info.major,

--- a/lmfit/jsonutils.py
+++ b/lmfit/jsonutils.py
@@ -1,4 +1,4 @@
-"""JSON utilities for larch objects."""
+"""JSON utilities."""
 from base64 import b64decode, b64encode
 import json
 import sys
@@ -58,11 +58,11 @@ def import_from(modulepath, objectname):
 
 
 def encode4js(obj):
-    """Prepare an object for json encoding.
+    """Prepare an object for JSON encoding.
 
     It has special handling for many Python types, including:
-    - pandas dataframes and series
-    - numpy ndarrays
+    - pandas DataFrames and Series
+    - NumPy ndarrays
     - complex numbers
 
     """

--- a/tests/test_jsonutils.py
+++ b/tests/test_jsonutils.py
@@ -1,0 +1,63 @@
+"""Tests for the JSON utilities."""
+# coding: utf-8
+# TODO: remove the line above when dropping Python 2.7
+from types import BuiltinFunctionType, FunctionType
+
+import numpy as np
+import pytest
+from scipy.optimize import basinhopping
+import six
+
+import lmfit
+from lmfit.jsonutils import decode4js, encode4js, find_importer, import_from
+from lmfit.printfuncs import alphanumeric_sort
+
+
+@pytest.mark.parametrize('obj', [alphanumeric_sort, np.array, basinhopping])
+def test_import_from(obj):
+    """Check return value of find_importer function."""
+    importer = find_importer(obj)
+    assert isinstance(import_from(importer, obj.__name__),
+                      (BuiltinFunctionType, FunctionType))
+
+
+objects = [('test_string', six.string_types),
+           (np.array([7.0]), np.ndarray),
+           (np.array([1.0+2.0j]), np.ndarray),
+           (123.456, np.float),
+           (10, np.float),
+           (u'café', six.string_types),
+           (10.0-5.0j, np.complex),
+           (['a', 'b', 'c'], list),
+           (('a', 'b', 'c'), tuple),
+           ({'a': 1.0, 'b': 2.0, 'c': 3.0}, dict),
+           (lmfit.lineshapes.gaussian, FunctionType)]
+
+
+@pytest.mark.parametrize('obj, obj_type', objects)
+def test_encode_decode(obj, obj_type):
+    """Test encoding/decoding of the various object types to/from JSON."""
+    encoded = encode4js(obj)
+    decoded = decode4js(encoded)
+
+    assert decoded == obj
+    assert isinstance(decoded, obj_type)
+
+
+def test_encode_decode_pandas():
+    """Test encoding/decoding of various pandas objects to/from JSON."""
+    pytest.importorskip('pandas')
+    import pandas as pd
+
+    obj_df = pd.DataFrame(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+                          columns=['a', 'b', 'c'])
+    encoded_df = encode4js(obj_df)
+    decoded_df = decode4js(encoded_df)
+    assert np.all(pd.DataFrame.eq(obj_df, decoded_df))
+    assert isinstance(decoded_df, pd.DataFrame)
+
+    obj_ser = pd.Series([1, 2, 3, 4], index=['a', 'b', 'c', 'd'])
+    encoded_ser = encode4js(obj_ser)
+    decoded_ser = decode4js(encoded_ser)
+    assert np.all(pd.Series.eq(obj_ser, decoded_ser))
+    assert isinstance(decoded_ser, pd.Series)


### PR DESCRIPTION
#### Description
Increase test-coverage for lmfit/jsonutils.py to include test in tests_jsonutils.py. While adding the tests I fixed/changed the following:

* DOC: update docstrings in jsonutils.py 

* FIX: handling of pandas.Series in encode4js()
Currently, there is twice a check for ```isinstance(obj, DataFrame)``` , one of them should be ```isinstance(obj, Series)```. Additionally, a few small changes on how to encode/decode the DataFrame/Series. 

I cannot really think of a situation or test-case for "numpy.ndarray, where dtype is'object", so I didn't add a test for this.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [x] Tests
- [x] Documentation / examples

###### Tested on
Python: 3.7.4 (default, Jul 11 2019, 08:51:12)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 0.9.13+57.gb991b9d, scipy: 1.3.0, numpy: 1.16.4, asteval: 0.9.14, uncertainties: 3.1.1, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] included docstrings that follow PEP 257?
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?