### PR TITLE
Fix documentation in PDF format

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -33,7 +33,7 @@ htmlzip: html
 	rm -f *.dat *.sav
 
 epub:
-	cp sphinx/ext_imgmath.py extensions.py
+	cp sphinx/ext_mathjax.py extensions.py
 	cp ../examples/*.dat .
 	$(SPHINXBUILD) -b epub  $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	cp -pr $(BUILDDIR)/epub/*.epub $(BUILDDIR)/html/.
@@ -70,6 +70,7 @@ help:
 clean:
 	-rm -rf $(BUILDDIR)/*
 	-rm -f extensions.py
+	-rm -f *.dat *.sav
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
@@ -93,17 +94,23 @@ htmlhelp:
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
 latex:
+	cp sphinx/ext_imgmath.py extensions.py
+	cp ../examples/*.dat .
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) _build/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in _build/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
 	      "run these through (pdf)latex."
+	rm -f *.dat *.sav
 
 latexpdf:
+	cp sphinx/ext_imgmath.py extensions.py
+	cp ../examples/*.dat .
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) _build/latex
 	@echo "Running LaTeX files through pdflatex..."
 	make -C _build/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in _build/latex."
+	rm -f *.dat *.sav
 
 changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -157,3 +157,5 @@ latex_documents = [
 # configuration for jupyter_sphinx
 package_path = os.path.abspath('../..')
 os.environ['PYTHONPATH'] = ':'.join((package_path, os.environ.get('PYTHONPATH', '')))
+
+image_converter_args=["-density", "300"]

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -18,6 +18,9 @@ Downloading and Installation
 .. _numdifftools:  https://github.com/pbrod/numdifftools
 .. _contributing.md: https://github.com/lmfit/lmfit-py/blob/master/.github/CONTRIBUTING.md
 .. _corner:  https://github.com/dfm/corner.py
+.. _sphinx: https://www.sphinx-doc.org
+.. _jupyter_sphinx: https://jupyter-sphinx.readthedocs.io
+.. _ImageMagick: https://www.imagemagick.org/
 
 
 Prerequisites
@@ -41,11 +44,17 @@ functionality requires the `emcee`_, `corner`_, `pandas`_, `Jupyter`_,
 `matplotlib`_, `dill`_, or `numdifftools`_ packages.  These are not installed
 automatically, but we highly recommend each of these packages.
 
+For building the documentation, `matplotlib`_, `emcee`_, `corner`_,
+`Sphinx`_, `jupyter_sphinx`_, and `ImageMagick`_ are required (the latter
+one only when generating the PDF document).
+
+Please refer to  ``requirements-dev.txt`` for a list of all dependencies that
+are needed if you want to participate in the development of lmfit.
 
 Downloads
 ~~~~~~~~~~~~~
 
-The latest stable version of lmfit is |release| and is available from `PyPi
+The latest stable version of lmfit is |release| and is available from `PyPI
 <https://pypi.python.org/pypi/lmfit/>`_.
 
 Installation

--- a/doc/sphinx/ext_imgmath.py
+++ b/doc/sphinx/ext_imgmath.py
@@ -7,4 +7,5 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx.ext.todo',
               'IPython.sphinxext.ipython_console_highlighting',
-              'jupyter_sphinx.execute']
+              'jupyter_sphinx.execute',
+              'sphinx.ext.imgconverter']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,4 +11,5 @@ pre-commit
 pytest
 scipy>=0.19
 six>1.10
+Sphinx
 uncertainties>=3.0


### PR DESCRIPTION
#### Description
With the previous PR (#573) I accidentally broke generating the documentation in PDF format. We now use automatically generated SVG images (using "jupyter_sphinx") in the HTML documentation - with another file format I couldn't get figures with sufficient resolution. 

However, LaTeX cannot incorporate SVG files and they need to be converted first; fortunately ```sphinx``` has a built-in extension that will take of this (you will need ImageMagick though, but that's pretty standard/easy on Linux or macOS these days). 

This PR fixes the issue and additionally adds the required dependencies for building the documentation to ```installation.rst``` (and ```requirements-dev.txt```).

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] updated the documentation?

