### PR TITLE
use `inspect.signature` for better support of Py3 and wrapped functions

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1,11 +1,11 @@
 """Implementation of the Model interface."""
-import sys
 from collections import OrderedDict
 from copy import deepcopy
 from functools import wraps
 import inspect
 import json
 import operator
+import sys
 import warnings
 
 import numpy as np
@@ -468,7 +468,7 @@ class Model(object):
             for name, defval in self.func.kwargs:
                 kw_args[name] = defval
         # 2. modern, best-practice approach: use inspect.signature
-        elif sys.version_info.major == 3 and sys.version_info.minor > 4:
+        elif sys.version_info > (3, 4):
             pos_args = []
             kw_args = {}
             keywords_ = None

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,8 @@
+import functools
 import sys
 import unittest
 import warnings
-import functools
+
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 import warnings
 import functools
@@ -624,8 +625,9 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         with pytest.raises(ValueError, match=err_msg):
             mod.fit(y, params, x=x, nan_policy='wrong_argument')
 
+    @pytest.mark.skipif(sys.version_info.major == 2,
+                        reason="cannot use wrapped functions with Python 2")
     def test_wrapped_model_func(self):
-
         x = np.linspace(-1, 1, 51)
         y = 2.0*x + 3 + 0.0003 * x*x
         y += np.random.normal(size=len(x), scale=0.025)


### PR DESCRIPTION
This addresses (partially) #570:

`inspect.signature` is used to parse argument lists of model functions.  Currently, this is Py3.5+ only, with Python2 sticking to `inspect.getfullargspec`.

Basically, we're not planning on supporting Py2 much longer.  If people have not moved to Py3, I doubt this feature being Py3 only will convince them, but at least we don't need to rely on a 3rd party backport.


#### Description

This uses `inspect.signature`, the recommended approach to inspecting functions.  It will allow some decorated functions to be used as model functions, addressing #570.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix
- [X] New feature
- [X] Refactoring / maintenance
- [ ] Documentation / examples


(probably should have an example, not just a test!).

###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties, six
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}, six: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__, six.__version__))
-->

Python: 3.7.3 (default, Mar 27 2019, 16:54:48) 
[Clang 4.0.1 (tags/RELEASE_401/final)]

lmfit: 0.9.13+83.ga3c0939, scipy: 1.3.0, numpy: 1.16.4, asteval: 0.9.13, uncertainties: 3.0.2, six: 1.12.0


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [ x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ x] added or updated existing tests to cover the changes?
- [ ] updated the documentation?
- [ ] added an example?

probably needs an example.
