### PR TITLE
Fix nfev for brute with multiprocessing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@ exclude: 'versioneer.py|lmfit/_version|doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.21.0
+    rev: v1.22.1
     hooks:
     -   id: pyupgrade
         # for now don't force to change from %-operator to {}
         args: [--keep-percent-format]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v2.3.0
     hooks:
     -   id: check-ast
     -   id: check-builtin-literals
@@ -37,6 +37,6 @@ repos:
         additional_dependencies: [rstcheck, sphinx]
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.0
+    rev: v1.4.1
     hooks:
     -   id: rst-backticks

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1686,10 +1686,6 @@ class Minimizer(object):
         result = self.prepare_fit(params=params)
         result.method = 'brute'
 
-        # FIXME: remove after requirement for scipy >= 1.3
-        if int(major) == 0 or (int(major) == 1 and int(minor) < 3):
-            result.nfev -= 1  # correct for "pre-fit" initialization/checks
-
         brute_kws = dict(full_output=1, finish=None, disp=False)
         # keyword 'workers' is introduced in SciPy v1.3
         # FIXME: remove this check after updating the requirement >= 1.3
@@ -1766,7 +1762,7 @@ class Minimizer(object):
 
             result.params = result.candidates[0].params
             result.residual = self.__residual(result.brute_x0, apply_bounds_transformation=False)
-            result.nfev -= 1
+            result.nfev = len(result.brute_Jout.ravel())
 
         result._calculate_statistics()
 

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -148,7 +148,7 @@ def fit_report(inpars, modelpars=None, show_correl=True, min_correl=0.1,
                 for name in parnames_varying:
                     par = params[name]
                     space = ' '*(namelen-len(name))
-                    if np.allclose(par.value, par.init_value):
+                    if par.init_value and np.allclose(par.value, par.init_value):
                         add('    %s:%s  at initial value' % (name, space))
                     if (np.allclose(par.value, par.min) or np.allclose(par.value, par.max)):
                         add('    %s:%s  at boundary' % (name, space))

--- a/tests/test_brute.py
+++ b/tests/test_brute.py
@@ -122,7 +122,11 @@ def test_brute_lmfit_vs_scipy_stepsize(params_lmfit):
     assert_equal(ret[0][0], out.brute_x0[0])
     assert_equal(ret[0][1], out.brute_x0[1])
     assert_equal(ret[1], out.brute_fval)
-    assert_equal(out.nfev, len(out.brute_Jout.ravel()))
+
+    points_x = np.arange(rranges[0].start, rranges[0].stop, rranges[0].step).size
+    points_y = np.arange(rranges[1].start, rranges[1].stop, rranges[1].step).size
+    nmb_evals = points_x * points_y
+    assert_equal(out.nfev, nmb_evals)
 
 
 def test_brute_lmfit_vs_scipy_Ns_stepsize(params_lmfit):
@@ -139,7 +143,11 @@ def test_brute_lmfit_vs_scipy_Ns_stepsize(params_lmfit):
 
     assert_equal(ret[2], out.brute_grid)  # grid identical
     assert_equal(ret[3], out.brute_Jout)  # function values on grid identical
-    assert_equal(out.nfev, len(out.brute_Jout.ravel()))
+
+    points_x = np.arange(rranges[0].start, rranges[0].stop, rranges[0].step).size
+    points_y = 10
+    nmb_evals = points_x * points_y
+    assert_equal(out.nfev, nmb_evals)
 
     # best-fit values and function value identical
     assert_equal(ret[0][0], out.brute_x0[0])
@@ -273,3 +281,10 @@ def test_brute_pickle(params_lmfit):
     mini = lmfit.Minimizer(func_lmfit, params_lmfit)
     out = mini.minimize(method='brute')
     pickle.dumps(out)
+
+
+def test_nfev_workers(params_lmfit):
+    """TEST 12: make sure the nfev is correct for workers != 1."""
+    mini = lmfit.Minimizer(func_lmfit, params_lmfit, workers=-1)
+    out = mini.minimize(method='brute')
+    assert_equal(out.nfev, 20**len(out.var_names))

--- a/tests/test_printfuncs.py
+++ b/tests/test_printfuncs.py
@@ -261,6 +261,24 @@ def test_report_no_errorbars_no_numdifftools(fitresult):
     assert 'numdifftools' in report
 
 
+def test_report_no_errorbars_with_numdifftools_no_init_value(fitresult):
+    """No TypeError for parameters without initial value when no errorbars.
+
+    Verify that for parameters without an init_value the fit_report() function
+    does not raise a TypeError when comparing if a parameter is at its initial
+    value (if HAS_NUMDIFFTOOLS is True and result.errorbars is False).
+
+    See GitHub Issue 578: https://github.com/lmfit/lmfit-py/issues/578
+
+    """
+    fitresult.fit(method='nelder')
+    lmfit.printfuncs.HAS_NUMDIFFTOOLS = True
+    fitresult.errorbars = False
+    fitresult.params['amplitude'].init_value = None
+    report = fitresult.fit_report()
+    assert 'Warning: uncertainties could not be estimated:' in report
+
+
 def test_report_fixed_parameter(fitresult):
     """Verify that a fixed parameter is shown correctly."""
     fitresult.params['center'].vary = False


### PR DESCRIPTION
#### Description
This PR fixes the issue(s) described in #578. Instead of relying lmfit its internal calculation of function evaluations, which fails when using multiprocessing, determine the number of evaluations from the search-grid directly.

Additionally, a (probably rare) bug was fixed in the comparison comparison of the parameter value when no errorbars could be estimated and ```numdifftools``` is present. The issue appears when no initial value is set, which is allowed for algorithms like ```brute```. 

Test were added/update to cover these changes and, finally, the ```pre-commit``` hooks were updated to their latest versions.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.4 (default, Aug 14 2019, 15:53:38)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 0.9.13+89.geafeaee, scipy: 1.3.1, numpy: 1.17.0, asteval: 0.9.14, uncertainties: 3.1.2, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?