### PR TITLE
almost ready to release 0.9.14?

### DIFF
--- a/THANKS.txt
+++ b/THANKS.txt
@@ -51,8 +51,9 @@ of size of the contribution to the existing code) are from:
 Additional patches, bug fixes, and suggestions have come from Faustin
 Carter, Christoph Deil, Francois Boulogne, Thomas Caswell, Colin Brosseau,
 nmearl, Gustavo Pasquevich, Clemens Prescher, LiCode, Ben Gamari, Yoav
-Roam, Alexander Stark, Alexandre Beelen, and many others.
+Roam, Alexander Stark, Alexandre Beelen, Andrey Aristov, Nicholas Zobrist,
+and many others.
 
 The lmfit code obviously depends on, and owes a very large debt to the code
-in scipy.optimize.  Several discussions on the scipy-user and lmfit mailing
+in scipy.optimize.  Several discussions on the SciPy-user and lmfit mailing
 lists have also led to improvements in this code.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -21,6 +21,7 @@ Downloading and Installation
 .. _sphinx: https://www.sphinx-doc.org
 .. _jupyter_sphinx: https://jupyter-sphinx.readthedocs.io
 .. _ImageMagick: https://www.imagemagick.org/
+.. _release_notes: https://lmfit.github.io/lmfit-py/whatsnew.html
 
 
 Prerequisites
@@ -55,7 +56,8 @@ Downloads
 ~~~~~~~~~~~~~
 
 The latest stable version of lmfit is |release| and is available from `PyPI
-<https://pypi.python.org/pypi/lmfit/>`_.
+<https://pypi.python.org/pypi/lmfit/>`_. Check the `release_notes`_ for a list
+of changes compared to earlier releases.
 
 Installation
 ~~~~~~~~~~~~~~~~~

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,6 +11,40 @@ significant to the use and behavior of the library.  This is not meant
 to be a comprehensive list of changes.  For such a complete record,
 consult the `lmfit GitHub repository`_.
 
+.. _whatsnew_0914_label:
+
+Version 0.9.14 Release Notes
+==========================================
+
+New features:
+
+- the global optimizers ``shgo`` and ``dual_annealing`` (new in SciPy v1.2) are now supported (Issue #527; PRs #545 and #556)
+- ``eval`` method added to the Parameter class (PR #550 by @zobristnicholas)
+- avoid ZeroDivisionError in ``printfuncs.params_html_table`` (PR #552 by @aaristov and PR #559)
+- add parallelization to ``brute`` method (PR #564, requires SciPy v1.3)
+
+Bug fixes:
+
+- consider only varying parameters when reporting potential issues with calculating errorbars (PR #549) and compare
+  ``value`` to both ``min`` and ``max`` (PR #571)
+- guard against division by zero in lineshape functions and ``FWHM`` and ``height`` expression calculations (PR #545)
+- fix issues with restoring a saved Model (Issue #553; PR #554)
+- always set ``result.method`` for ``emcee`` algorithm (PR #558)
+- more careful adding of parameters to handle out-of-order constraint expressions (Issue #560; PR #561)
+- make sure all parameters in Model.guess() use prefixes (PRs #567 and #569)
+- use ``inspect.signature`` for PY3 to support wrapped functions (Issue #570; PR #576)
+- fix ``result.nfev``` for ``brute`` method when using parallelization (Issue #578; PR #579)
+
+Various:
+
+- remove "missing" in the Model class (replaced by nan_policy) and "drop" as option to nan_policy
+  (replaced by omit) deprecated since 0.9 (PR #565).
+- deprecate 'report_errors' in printfuncs.py (PR #571)
+- updates to the documentation to use ``jupyter-sphinx`` to include examples/output (PRs #573 and #575)
+- include a Gallery with examples in the documentation using ``sphinx-gallery`` (PR #574)
+- improve test-coverage (PRs #571 and #572)
+- update pre-commit hooks and several docstrings
+
 .. _whatsnew_0913_label:
 
 Version 0.9.13 Release Notes
@@ -32,7 +66,7 @@ Bug fixes:
 - improve deprecation warnings for outdated nan_policy keywords (#540)
 - fix for edge case in gformat() (#547)
 
-Project managements:
+Project management:
 
 - using pre-commit framework to improve and enforce coding style (#533)
 - added code coverage report to github main page


### PR DESCRIPTION
#### Description
This PR updates the release notes and links to them in the documentation under the installation instructions. Additionally, new contributors were added to ```THANKS.txt```.

@newville I think with this we should be about ready to release a new version, or is there anything that I've missed?

###### Type of Changes
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
Python: 3.7.4 (default, Aug 14 2019, 15:53:38)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 0.9.13, scipy: 1.3.1, numpy: 1.17.0, asteval: 0.9.14, uncertainties: 3.1.2, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] updated the documentation?