### PR TITLE
remove deprecated max_time from asteval.Interpreter() creation

### DIFF
--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1238,7 +1238,7 @@ class ExpressionModel(Model):
 
         """
         # create ast evaluator, load custom functions
-        self.asteval = Interpreter(max_time=3600.0)
+        self.asteval = Interpreter()
         for name in lineshapes.functions:
             self.asteval.symtable[name] = getattr(lineshapes, name, None)
         if init_script is not None:


### PR DESCRIPTION
This is a one line fix for `models.ExpressionModel()` to not use the now-deprecated `max_time` keyword argument for `asteval.Interpreter()`.

Tested with Py37.

No doc or example changes...