### PR TITLE
Tweaks to generating the examples gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ doc/_build
 doc/examples
 examples/documentation
 doc/*.pdf
+doc/*.dat
+doc/*.csv
 doc/extensions.py
 build
 dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,10 +4,12 @@ include requirements.txt
 exclude *.pyc core.* *~ *.pdf
 recursive-include lmfit *.py
 recursive-include tests *.py *.dat
-recursive-include examples *.py *.ipynb *.dat
 recursive-include NIST_STRD *.dat
+recursive-include examples *.py *.csv *.dat
+recursive-exclude examples/documentation *
 recursive-include doc *
 recursive-exclude doc/_build *
-recursive-exclude doc *.pdf
+recursive-exclude doc/examples *
+recursive-exclude doc *.pdf *.csv *.dat *.sav
 include versioneer.py
 include lmfit/_version.py

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -15,41 +15,33 @@ PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
 .PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest latexpdf htmlzip
-.PHONY: all install pdf
+.PHONY: all install pdf gallery
 
-html:
+html:  gallery
 	cp sphinx/ext_mathjax.py extensions.py
-	./doc_examples_to_gallery.py
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	cp -r examples $(BUILDDIR)/html
 	@echo
 	@echo "html build finished: $(BUILDDIR)/html."
-	rm -f *.dat *.sav *.csv
-	rm -rf ../examples/documentation
+
+gallery: examples/index.rst
+
+examples/index.rst:
+	./doc_examples_to_gallery.py
 
 htmlzip: html
 	cp sphinx/ext_mathjax.py extensions.py
-	./doc_examples_to_gallery.py
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/lmfit_doc
-	cp -r examples $(BUILDDIR)/html
 	cd $(BUILDDIR) && zip -pur html/lmfit_doc.zip lmfit_doc
-	rm -f *.dat *.sav *.csv
-	rm -rf ../examples/documentation
 
-epub:
+epub: html
 	cp sphinx/ext_mathjax.py extensions.py
-	./doc_examples_to_gallery.py
 	$(SPHINXBUILD) -b epub  $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	cp -pr $(BUILDDIR)/epub/*.epub $(BUILDDIR)/html/.
-	rm -f *.dat *.sav *.csv
-	rm -rf ../examples/documentation
 
 pdf: latex
 	cp sphinx/ext_imgmath.py extensions.py
-	cp ../examples/*.dat .
 	cd $(BUILDDIR)/latex && make all-pdf
 	cp -pr $(BUILDDIR)/latex/lmfit.pdf $(BUILDDIR)/html/.
-	rm -f *.dat *.sav *.csv
 
 all: html htmlzip epub pdf
 
@@ -76,48 +68,44 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 	-rm -f extensions.py
 	-rm -f *.dat *.sav *.csv
-	-rm -rf examples
+	-rm -rf examples/*
 	-rm -rf ../examples/documentation
 
-dirhtml:
+dirhtml:  gallery
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
-pickle:
+pickle:  gallery
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
-json:
+json:  gallery
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
-htmlhelp:
+htmlhelp:  gallery
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
-latex:
+latex: gallery
 	cp sphinx/ext_imgmath.py extensions.py
-	cp ../examples/*.dat .
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) _build/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in _build/latex."
 	@echo "Run \`make all-pdf' or \`make all-ps' in that directory to" \
 	      "run these through (pdf)latex."
-	rm -f *.dat *.sav *.csv
 
 latexpdf:
 	cp sphinx/ext_imgmath.py extensions.py
-	cp ../examples/*.dat .
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) _build/latex
 	@echo "Running LaTeX files through pdflatex..."
 	make -C _build/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in _build/latex."
-	rm -f *.dat *.sav *.csv
 
 changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -16,3 +16,4 @@ Contents
    confidence
    bounds
    constraints
+   examples/index

--- a/doc/doc_examples_to_gallery.py
+++ b/doc/doc_examples_to_gallery.py
@@ -12,14 +12,17 @@ Process the examples in the documentation for inclusion in the Gallery:
 
 """
 import os
-
+import time
 basedir = os.getcwd()
 
-examples_dir = os.path.join(os.getcwd(), '../examples')
+examples_dir = os.path.abspath(os.path.join(basedir, '..', 'examples'))
 files = [fn for fn in os.listdir(examples_dir) if fn.startswith('doc_')]
 
 examples_documentation_dir = os.path.join(examples_dir, 'documentation')
 os.makedirs(examples_documentation_dir, exist_ok=True)
+
+
+scripts_to_run = []
 
 with open(os.path.join(examples_documentation_dir, 'README.txt'), 'w') as out:
     out.write("Examples from the documentation\n")
@@ -27,27 +30,40 @@ with open(os.path.join(examples_documentation_dir, 'README.txt'), 'w') as out:
     out.write("Below are all the examples that are part of the lmfit documentation.")
 
 for fn in files:
+    inp_path = os.path.join(examples_dir, fn)
+    with open(inp_path, 'r') as inp:
+        script_text = inp.read()
+
     gallery_file = os.path.join(examples_documentation_dir, fn[4:])
     with open(gallery_file, 'w') as out:
-        if fn == 'doc_model_loadmodel.py':
-            msg = ('This example *does* actually work, but for some reason the '
-                   'conversion using sphinx-gallery fails....')
-            out.write('"""\n{}\n{}\n\n{}\n\n"""\n'.format(fn, "="*len(fn), msg))
-        else:
-            out.write('"""\n{}\n{}\n\n"""\n'.format(fn, "="*len(fn)))
-    os.system('cat {} >> {}'.format(os.path.join(examples_dir, fn), gallery_file))
+        msg = ""
+        if 'model_loadmodel.py' in fn:
+            msg = ('.. note:: This example *does* actually work, but running from within '
+                   ' sphinx-gallery fails to find symbols saved in the save file.')
+        out.write('"""\n{}\n{}\n\n{}\n"""\n'.format(fn, "="*len(fn), msg))
+        out.write('##\nimport warnings\nwarnings.filterwarnings("ignore")\n##\n')
+        out.write(script_text)
 
     # make sure the saved Models and ModelResult are available
     if 'save' in fn:
-        os.chdir(examples_dir)
-        os.system('python {}'.format(fn))
-        os.chdir(basedir)
+        scripts_to_run.append(fn[4:])
+
+time.sleep(1.0)
 
 os.system('cp {}/*.dat {}'.format(examples_dir, examples_documentation_dir))
 os.system('cp {}/*.csv {}'.format(examples_dir, examples_documentation_dir))
 os.system('cp {}/*.sav {}'.format(examples_dir, examples_documentation_dir))
+#
 
+os.chdir(examples_documentation_dir)
+
+for script in scripts_to_run:
+    os.system('python {}'.format(script))
+
+os.chdir(basedir)
+
+time.sleep(1.0)
 # data files for the other Gallery examples
-os.system('cp {}/*.dat .'.format(examples_dir))
-os.system('cp {}/*.csv .'.format(examples_dir))
-os.system('cp {}/*.sav .'.format(examples_dir))
+os.system('cp {}/*.dat .'.format(examples_documentation_dir))
+os.system('cp {}/*.csv .'.format(examples_documentation_dir))
+os.system('cp {}/*.sav .'.format(examples_documentation_dir))

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -64,3 +64,4 @@ participating in this effort please use the `lmfit GitHub repository`_.
    bounds
    constraints
    whatsnew
+   examples/index

--- a/doc/sphinx/theme/lmfitdoc/layout.html
+++ b/doc/sphinx/theme/lmfitdoc/layout.html
@@ -40,7 +40,7 @@
          <font size+=1>Contents</font></a> </td>
      <td width=6% align=left>
           <a href="{{ pathto('examples/index') }}" style="color: #882222">
-          <font size+=1>Gallery</font></a></td>
+          <font size+=1>Examples</font></a></td>
      <td width=6% align=left>
           <a href="{{ pathto('installation') }}" style="color: #882222">
           <font size+=1>Download</font></a></td>

--- a/doc/sphinx/theme/lmfitdoc/layout.html
+++ b/doc/sphinx/theme/lmfitdoc/layout.html
@@ -18,7 +18,6 @@
 {% endblock %}
 
 
-
 {% block rootrellink %}
    <li>[<a href="{{ pathto('intro') }}">intro</a>|</li>
    <li><a href="{{ pathto('parameters') }}">parameters</a>|</li>
@@ -28,31 +27,36 @@
    <li><a href="{{ pathto('confidence') }}">confidence intervals</a>|</li>
    <li><a href="{{ pathto('bounds') }}">bounds</a>|</li>
    <li><a href="{{ pathto('constraints') }}">constraints</a>|</li>
-   <li><a href="{{ pathto('examples/index') }}">examples</a>]</li>
 {% endblock %}
 
 {% block relbar1 %}
 <div>
 <table border=0>
-  <tr><td></td><td width=85% padding=5 align=left>
-          <a href="{{ pathto('index') }}" style="color: #157"> <font size=+3>LMFIT</font></a>
+  <tr><td></td><td width=80% padding=5 align=left>
+          <a href="{{ pathto('contents') }}/../index.html" style="color: #157"> <font size=+3>LMFIT</font></a>
      </td>
-     <td width=7% align=left>
-         <a href="contents.html" style="color: #882222">
+     <td width=6% align=left>
+         <a href="{{ pathto('contents') }}" style="color: #882222">
          <font size+=1>Contents</font></a> </td>
-     <td width=7% align=left>
-          <a href="installation.html" style="color: #882222">
+     <td width=6% align=left>
+          <a href="{{ pathto('examples/index') }}" style="color: #882222">
+          <font size+=1>Gallery</font></a></td>
+     <td width=6% align=left>
+          <a href="{{ pathto('installation') }}" style="color: #882222">
           <font size+=1>Download</font></a></td>
      <td></td>
   </tr>
-  <tr><td></td><td width=75% padding=5 align=left>
-        <a href="index.html" style="color: #157"> <font size=+2>
+  <tr><td></td><td width=80% padding=5 align=left>
+        <a href="{{ pathto('contents') }}/../index.html" style="color: #157"> <font size=+2>
 	Non-Linear Least-Squares Minimization and Curve-Fitting for Python</font></a>
      </td>
-     <td width=7% align=left>
-         <a href="faq.html" style="color: #882222">
+     <td width=6% align=left>
+         <a href="{{ pathto('faq') }}" style="color: #882222">
          <font size+=1>FAQ</font></a> </td>
-     <td width=7% align=left>
+     <td width=6% align=left>
+         <a href="{{ pathto('support') }}" style="color: #882222">
+         <font size+=1>Support</font></a> </td>
+     <td width=6% align=left>
         <a href="https://github.com/lmfit/lmfit-py/" style="color: #882222">
          <font size+=1>Develop</font></a></td>
      <td></td>


### PR DESCRIPTION
These are all changes to the doc and build scripts for the examples gallery.

I added "Gallery" to the upper-right section of the doc, just to make it more visible.

I tweaked the gallery generation script.  In the end, this is mostly adding suppression of warnings.

I also changed the Makefile so that the gallery isn't generated every time `sphinx-build` is run, but only when the gallery is empty (as after `make clean`).

@reneeotten Let me know if any of these seem wrong or you don't like any part of this.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [X] Documentation / examples


###### Tested on

Tested with all the sphinx tools up-to-date from Anaconda Python 3.7
