### PR TITLE
Getval2setval

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1352,7 +1352,7 @@ class Minimizer(object):
             # assuming prior prob = 1, this is true
             _neg2_log_likel = -2*result.residual
 
-            # assumes that residual is properly weighted
+            # assumes that residual is properly weighted, avoid overflowing np.exp()
             result.chisqr = np.exp(min(650, _neg2_log_likel))
 
             result.redchi = result.chisqr / result.nfree

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1353,7 +1353,7 @@ class Minimizer(object):
             _neg2_log_likel = -2*result.residual
 
             # assumes that residual is properly weighted
-            result.chisqr = np.exp(_neg2_log_likel)
+            result.chisqr = np.exp(min(650, _neg2_log_likel))
 
             result.redchi = result.chisqr / result.nfree
             result.aic = _neg2_log_likel + 2 * result.nvarys


### PR DESCRIPTION
This is an attempt to improve performance or at least document an attempt to improve an occasional performance question.  

This moves the application of parameter bounds from "get time" (that is, explicitly in `_getval()`) to "set time" (in the property setter for `Parameter.value`).    

This might avoid unneeded code branches and over-applications of bounds.  I don't really have an idea how the bench-marking will turn out -- turns out "not much", perhaps as expected.  

But, I also think that this is code is not any less sensible and might be clearer.

One change that was necessary was to move the "set value when restoring from pickle" to as late as possible -- after bounds and expressions had been restored.   That might be   

I did not change any of the tests, but I did add a check of overflowing "exp()" in `minimize.py`