### PR TITLE
fixes for Travis CI and PY38

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'versioneer.py|lmfit/_version|doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.23.0
+    rev: v1.24.0
     hooks:
     -   id: pyupgrade
         # for now don't force to change from %-operator to {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_install:
 install:
     - if [[ $version == minimum ]]; then pip install asteval==0.9.12 numpy==1.16 scipy==1.2 six==1.11 uncertainties==3.0.1 pytest coverage; fi
     - if [[ $version == latest ]]; then pip install -r requirements-dev.txt ; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.8-dev ]]; then pip install https://github.com/newville/asteval/archive/master.zip; fi
     - python setup.py install
     - pip list
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
     - python -m pip install --upgrade pip setuptools
 
 install:
-    - if [[ $version == minimum ]]; then pip install asteval==0.9.12 numpy==1.16 scipy==1.2 six==1.11 uncertainties==3.0.1 pytest coverage; fi
+    - if [[ $version == minimum ]]; then pip install asteval==0.9.12 numpy==1.16 scipy==1.2 six==1.11 uncertainties==3.0.1 pytest coverage codecov; fi
     - if [[ $version == latest ]]; then pip install -r requirements-dev.txt ; fi
     - if [[ $TRAVIS_PYTHON_VERSION == 3.8-dev ]]; then pip install https://github.com/newville/asteval/archive/master.zip; fi
     - python setup.py install

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 asteval>=0.9.12
+codecov
 corner
 coverage
 dill

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ asteval>=0.9.12
 corner
 coverage
 dill
-emcee
+emcee<3.0.0
 jupyter_sphinx
 matplotlib
 numdifftools

--- a/tests/test_ampgo.py
+++ b/tests/test_ampgo.py
@@ -58,7 +58,11 @@ def test_ampgo_maxfunevals(minimizer_Alpine02):
 def test_ampgo_local_solver(minimizer_Alpine02):
     """Test AMPGO algorithm with local solver."""
     kws = {'local': 'Nelder-Mead'}
-    out = minimizer_Alpine02.minimize(method='ampgo', **kws)
+
+    msg = r'Method Nelder-Mead cannot handle constraints nor bounds'
+    with pytest.warns(RuntimeWarning, match=msg):
+        out = minimizer_Alpine02.minimize(method='ampgo', **kws)
+
     out_x = np.array([out.params['x0'].value, out.params['x1'].value])
 
     assert 'ampgo' and 'Nelder-Mead' in out.method

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -234,6 +234,9 @@ class CommonTests(object):
 class TestUserDefiniedModel(CommonTests, unittest.TestCase):
     # mainly aimed at checking that the API does what it says it does
     # and raises the right exceptions or warnings when things are not right
+    import six
+    if six.PY2:
+        from six import assertRaisesRegex
 
     def setUp(self):
         self.true_values = lambda: dict(amplitude=7.1, center=1.1, sigma=2.40)
@@ -641,7 +644,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         result = lambda: mod.fit(y, params, x=x, nan_policy='raise')
         msg = ('NaN values detected in your input data or the output of your '
                'objective/model function - fitting algorithms cannot handle this!')
-        self.assertRaisesRegexp(ValueError, msg, result)
+        self.assertRaisesRegex(ValueError, msg, result)
 
         # with propagate, should get no error, but bad results
         result = mod.fit(y, params, x=x, nan_policy='propagate')
@@ -684,7 +687,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
                                    nan_policy='raise')
 
         msg = 'The model function generated NaN values and the fit aborted!'
-        self.assertRaisesRegexp(ValueError, msg, result)
+        self.assertRaisesRegex(ValueError, msg, result)
 
     @pytest.mark.skipif(sys.version_info.major == 2,
                         reason="cannot use wrapped functions with Python 2")


### PR DESCRIPTION
#### Description
A few small changes to Travis:
- install missing ```codecov``` package so that we'll get coverage reports again (I accidentally removed it in commit d7bc8b4f553d5a9065c80df193bd1e8929415d91)
- install the "master" branch of ```asteval``` for PY38 (resolved the failures)
- restrict ```emcee``` < 3.0.0 (the latest release removed the ```PTSampler```; we'll have to see how to handle this, either don't use that sampler anymore or rely on the fork ```ptemcee```
- fix a few test warnings: catch the expected ```RuntimeWarning``` in test_ampgo.py and don't use the deprecated ```assertRaisesRegexp``` anymore for PY3
- update the ```pyupgrade``` pre-commit hook

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.4 (default, Sep 15 2019, 17:02:10)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 0.9.14+17.g55c888f, scipy: 1.3.1, numpy: 1.17.2, asteval: 0.9.15, uncertainties: 3.1.2, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
