### PR TITLE
More information about emcee fit

### DIFF
--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -493,6 +493,7 @@ place boundaries on this parameter one can do:
 Now we have to set up the minimizer and do the sampling:
 
 .. jupyter-execute::
+    :hide-output:
 
     res = lmfit.minimize(residual, method='emcee', nan_policy='omit', burn=300, steps=1000, thin=20,
                          params=mi.params, is_weighted=False)
@@ -501,9 +502,11 @@ Of note, the ``is_weighted`` argument will be ignored if your objective function
 returns a float instead of an array. See the Notes in :meth:`Minimizer.emcee` for
 more information.
 
-The performance of the method can be assessed by checking the acceptance fraction of the walkers.
-Also, one could consider the autocorrelation time, which is not possible here since the chain is 
-too short. Thus, the acceptance fraction per walker is plotted:
+The performance of the method (i.e., whether or not the sampling went well) can be assessed by checking
+the integrated autocorrelation time and/or the acceptance fraction of the walkers. For this specific
+example the autocorrelation time could not be estimated because the "chain is too short". Thus, we plot
+the acceptance fraction per walker and its values (or mean value) suggests that the sampling worked as
+intended (as a rule of thumb this value should be between 0.2 and 0.5).
 
 .. jupyter-execute::
 

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -501,6 +501,17 @@ Of note, the ``is_weighted`` argument will be ignored if your objective function
 returns a float instead of an array. See the Notes in :meth:`Minimizer.emcee` for
 more information.
 
+The performance of the method can be assessed by checking the acceptance fraction of the walkers.
+Also, one could consider the autocorrelation time, which is not possible here since the chain is 
+too short. Thus, the acceptance fraction per walker is plotted:
+
+.. jupyter-execute::
+
+    plt.plot(res.acceptance_fraction)
+    plt.xlabel('walker')
+    plt.ylabel('acceptance fraction')
+    plt.show()
+
 Lets have a look at those posterior distributions for the parameters. This requires
 installation of the ``corner`` package:
 

--- a/examples/doc_fitting_emcee.py
+++ b/examples/doc_fitting_emcee.py
@@ -53,6 +53,17 @@ if HASPYLAB and HASCORNER:
                                  truths=list(res.params.valuesdict().values()))
     plt.show()
 
+if HASPYLAB:
+    plt.plot(res.acceptance_fraction)
+    plt.xlabel('walker')
+    plt.ylabel('acceptance fraction')
+    plt.show()
+
+try:
+    print(res.acor)
+except:
+    pass
+
 print("\nmedian of posterior probability distribution")
 print('--------------------------------------------')
 lmfit.report_fit(res.params)

--- a/examples/doc_fitting_emcee.py
+++ b/examples/doc_fitting_emcee.py
@@ -62,8 +62,8 @@ if HASPYLAB:
 if hasattr(res, "acor"):
     print("Autocorrelation time for the parameters:")
     print("----------------------------------------")
-    for i, p in enumerate(res.params):
-        print(p, res.acor[i])
+    for i, par in enumerate(p):
+        print(par, res.acor[i])
 
 print("\nmedian of posterior probability distribution")
 print('--------------------------------------------')

--- a/examples/doc_fitting_emcee.py
+++ b/examples/doc_fitting_emcee.py
@@ -59,10 +59,11 @@ if HASPYLAB:
     plt.ylabel('acceptance fraction')
     plt.show()
 
-try:
-    print(res.acor)
-except:
-    pass
+if hasattr(res, "acor"):
+    print("Autocorrelation time for the parameters:")
+    print("----------------------------------------")
+    for i, p in enumerate(res.params):
+        print(p, res.acor[i])
 
 print("\nmedian of posterior probability distribution")
 print('--------------------------------------------')

--- a/examples/example_emcee_Model_interface.py
+++ b/examples/example_emcee_Model_interface.py
@@ -67,10 +67,11 @@ plt.show()
 
 ###############################################################################
 # try to compute the autocorrelation time
-try:
-    print(result_emcee.acor)
-except:
-    pass
+if hasattr(result_emcee, "acor"):
+    print("Autocorrelation time for the parameters:")
+    print("----------------------------------------")
+    for i, p in enumerate(result.params):
+        print(p, result.acor[i])
 
 
 ###############################################################################

--- a/examples/example_emcee_Model_interface.py
+++ b/examples/example_emcee_Model_interface.py
@@ -59,6 +59,21 @@ result_emcee.plot_fit(ax=ax, data_kws=dict(color='gray', markersize=2))
 plt.show()
 
 ###############################################################################
+# check the acceptance fraction to see whether emcee performed well
+plt.plot(result_emcee.acceptance_fraction)
+plt.xlabel('walker')
+plt.ylabel('acceptance fraction')
+plt.show()
+
+###############################################################################
+# try to compute the autocorrelation time
+try:
+    print(result_emcee.acor)
+except:
+    pass
+
+
+###############################################################################
 # Plot the parameter covariances returned by emcee using corner
 emcee_corner = corner.corner(result_emcee.flatchain, labels=result_emcee.var_names,
                              truths=list(result_emcee.params.valuesdict().values()))

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1064,6 +1064,11 @@ class Minimizer(object):
             `result.flatchain[parname]`. The ``lnprob`` attribute contains the
             log probability for each sample in ``chain``. The sample with the
             highest probability corresponds to the maximum likelihood estimate.
+            If `big_output` is set to `True`, the `MinimizerResult` contains also
+            the attribute `acor` (an array with the autocorrelation time
+            for each parameter if the autocorrelation time can be computed from
+            the chain) and `acceptance_fraction` (an array of the fraction
+            of steps accepted for each walker).
 
 
         Notes

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -949,7 +949,7 @@ class Minimizer(object):
 
     def emcee(self, params=None, steps=1000, nwalkers=100, burn=0, thin=1,
               ntemps=1, pos=None, reuse_sampler=False, workers=1,
-              float_behavior='posterior', is_weighted=True, seed=None, progress=True):
+              float_behavior='posterior', is_weighted=True, seed=None, progress=True, big_output=False):
         r"""Bayesian sampling of the posterior distribution using `emcee`.
 
         Bayesian sampling of the posterior distribution for the parameters
@@ -1040,6 +1040,9 @@ class Minimizer(object):
             If `seed` is already a `numpy.random.RandomState` instance, then
             that `numpy.random.RandomState` instance is used.
             Specify `seed` for repeatable minimizations.
+        big_output : bool, optional
+            If you want to also get autocorrelation times and acceptance
+            ratios, enable this feature.
 
         Returns
         -------
@@ -1310,6 +1313,12 @@ class Minimizer(object):
         result.errorbars = True
         result.nvarys = len(result.var_names)
         result.nfev = ntemps*nwalkers*steps
+        try:
+            result.acor = self.sampler.acor
+        except:
+            print("The chain is too short to reliably estimate the autocorrelation time")
+            pass
+        result.acceptance_fraction = self.sampler.acceptance_fraction
 
         # Calculate the residual with the "best fit" parameters
         out = self.userfcn(params, *self.userargs, **self.userkws)

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -949,7 +949,7 @@ class Minimizer(object):
 
     def emcee(self, params=None, steps=1000, nwalkers=100, burn=0, thin=1,
               ntemps=1, pos=None, reuse_sampler=False, workers=1,
-              float_behavior='posterior', is_weighted=True, seed=None, progress=True, big_output=False):
+              float_behavior='posterior', is_weighted=True, seed=None, progress=True):
         r"""Bayesian sampling of the posterior distribution using `emcee`.
 
         Bayesian sampling of the posterior distribution for the parameters
@@ -1040,9 +1040,6 @@ class Minimizer(object):
             If `seed` is already a `numpy.random.RandomState` instance, then
             that `numpy.random.RandomState` instance is used.
             Specify `seed` for repeatable minimizations.
-        big_output : bool, optional
-            If you want to also get autocorrelation times and acceptance
-            ratios, enable this feature.
 
         Returns
         -------
@@ -1064,11 +1061,11 @@ class Minimizer(object):
             `result.flatchain[parname]`. The ``lnprob`` attribute contains the
             log probability for each sample in ``chain``. The sample with the
             highest probability corresponds to the maximum likelihood estimate.
-            If `big_output` is set to `True`, the `MinimizerResult` contains also
-            the attribute `acor` (an array with the autocorrelation time
-            for each parameter if the autocorrelation time can be computed from
-            the chain) and `acceptance_fraction` (an array of the fraction
-            of steps accepted for each walker).
+            The `MinimizerResult` contains also the attribute `acor` (an array
+            containing the autocorrelation time for each parameter if the
+            autocorrelation time can be computed from the chain) and
+            `acceptance_fraction` (an array of the fraction of steps accepted
+            for each walker).
 
 
         Notes

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -42,6 +42,7 @@ from .printfuncs import fitreport_html_table
 # check for EMCEE
 try:
     import emcee
+    from emcee.autocorr import AutocorrError
     HAS_EMCEE = True
     EMCEE_VERSION = int(emcee.__version__[0])
 except ImportError:
@@ -1317,8 +1318,8 @@ class Minimizer(object):
         result.nfev = ntemps*nwalkers*steps
         try:
             result.acor = self.sampler.get_autocorr_time()
-        except:
-            print("The chain is too short to reliably estimate the autocorrelation time")
+        except AutocorrError as e:
+            print(str(e))
             pass
         result.acceptance_fraction = self.sampler.acceptance_fraction
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1062,10 +1062,10 @@ class Minimizer(object):
             `result.flatchain[parname]`. The ``lnprob`` attribute contains the
             log probability for each sample in ``chain``. The sample with the
             highest probability corresponds to the maximum likelihood estimate.
-            The `MinimizerResult` contains also the attribute `acor` (an array
+            The `MinimizerResult` contains also the attribute ``acor`` (an array
             containing the autocorrelation time for each parameter if the
             autocorrelation time can be computed from the chain) and
-            `acceptance_fraction` (an array of the fraction of steps accepted
+            ``acceptance_fraction`` (an array of the fraction of steps accepted
             for each walker).
 
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1316,7 +1316,7 @@ class Minimizer(object):
         result.nvarys = len(result.var_names)
         result.nfev = ntemps*nwalkers*steps
         try:
-            result.acor = self.sampler.acor
+            result.acor = self.sampler.get_autocorr_time()
         except:
             print("The chain is too short to reliably estimate the autocorrelation time")
             pass


### PR DESCRIPTION
#### Description
EMCEE has two measures to judge whether the fit performed well. Those are autocorrelation time and acceptance fraction (https://arxiv.org/pdf/1202.3665.pdf). 
I added the possibility to access this information to the emcee interface.


###### Type of Changes
- [x] Refactoring / maintenance

###### Tested on
lmfit: 0.9.14+20.g8f0f1db, scipy: 1.3.1, numpy: 1.17.2, asteval: 0.9.15, uncertainties: 3.1.2, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x ] included docstrings that follow PEP 257?
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
  No, because there is no open issue.
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
  No, since it is an extension to an existing, working interface.
- [x] updated the documentation?
- [ ] added an example?
  No, though I could easily do it if needed.