### PR TITLE
changes to the Parameter class and increase coverage

### DIFF
--- a/examples/example_Model_interface.py
+++ b/examples/example_Model_interface.py
@@ -61,16 +61,16 @@ result.params.pretty_print()
 # keyword arguments of ``fit`` that match the argments of ``decay``. You can
 # build the ``Parameter`` objects explicity; the following is equivalent.
 result = model.fit(data, t=t,
-                   N=Parameter(value=10),
-                   tau=Parameter(value=1))
+                   N=Parameter('N', value=10),
+                   tau=Parameter('tau', value=1))
 report_fit(result.params)
 
 ###############################################################################
 # By building ``Parameter`` objects explicitly, you can specify bounds
 # (``min``, ``max``) and set parameters constant (``vary=False``).
 result = model.fit(data, t=t,
-                   N=Parameter(value=7, vary=False),
-                   tau=Parameter(value=1, min=0))
+                   N=Parameter('N', value=7, vary=False),
+                   tau=Parameter('tau', value=1, min=0))
 report_fit(result.params)
 
 ###############################################################################

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1685,7 +1685,7 @@ class ModelResult(Minimizer):
         self.params = Parameters()
         state = {'unique_symbols': modres['unique_symbols'], 'params': []}
         for parstate in modres['params']:
-            _par = Parameter()
+            _par = Parameter(name='')
             _par.__setstate__(parstate)
             state['params'].append(_par)
         self.params.__setstate__(state)

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -701,11 +701,11 @@ class Parameter(object):
     def __repr__(self):
         """Return printable representation of a Parameter object."""
         s = []
-        sval = repr(self._getval())
+        sval = "value=%s" % repr(self._getval())
         if not self.vary and self._expr is None:
-            sval = "value=%s (fixed)" % sval
+            sval += " (fixed)"
         elif self.stderr is not None:
-            sval = "value=%s +/- %.3g" % (sval, self.stderr)
+            sval += " +/- %.3g" % self.stderr
         s.append(sval)
         s.append("bounds=[%s:%s]" % (repr(self.min), repr(self.max)))
         if self._expr is not None:

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -781,12 +781,15 @@ class Parameter(object):
         """Get value, with bounds applied."""
         # Note assignment to self._val has been changed to self.value
         # The self.value property setter makes sure that the
-        # _expr_eval.symtable is kept updated.
-        # If you just assign to self._val then
-        # _expr_eval.symtable[self.name]
+        # _expr_eval.symtable is kept up-to-date.
+        # If you just assign to self._val then _expr_eval.symtable[self.name]
         # becomes stale if parameter.expr is not None.
         if (isinstance(self._val, uncertainties.core.Variable) and
                 self._val is not nan):
+            msg = ("Please make sure that the Parameter value is a number, "
+                   "not an instance of 'uncertainties.core.Variable'. This "
+                   "automatic conversion will be removed in the next release.")
+            warnings.warn(FutureWarning(msg))
             try:
                 self.value = self._val.nominal_value
             except AttributeError:

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -876,9 +876,10 @@ class Parameter(object):
         """positive"""
         return +self._getval()
 
-    def __nonzero__(self):
-        """not zero"""
+    def __bool__(self):
+        """bool"""
         return self._getval() != 0
+    __nonzero__ = __bool__  # TODO: remove when PY3 only
 
     def __int__(self):
         """int"""
@@ -900,10 +901,10 @@ class Parameter(object):
         """-"""
         return self._getval() - other
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         """/"""
         return self._getval() / other
-    __truediv__ = __div__
+    __div__ = __truediv__  # TODO: remove when PY3 only
 
     def __floordiv__(self, other):
         """//"""
@@ -953,10 +954,10 @@ class Parameter(object):
         """+ (right)"""
         return other + self._getval()
 
-    def __rdiv__(self, other):
+    def __rtruediv__(self, other):
         """/ (right)"""
         return other / self._getval()
-    __rtruediv__ = __rdiv__
+    __rdiv__ = __rtruediv__  # TODO: remove when PY3 only
 
     def __rdivmod__(self, other):
         """divmod (right)"""

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from copy import deepcopy
 import json
 import importlib
+import warnings
 
 from asteval import Interpreter, get_ast_names, valid_symbol_name
 from numpy import arcsin, array, cos, inf, isclose, nan, sin, sqrt
@@ -986,5 +987,7 @@ class Parameter(object):
 
 def isParameter(x):
     """Test for Parameter-ness."""
+    msg = 'The isParameter function will be removed in the next release.'
+    warnings.warn(FutureWarning(msg))
     return (isinstance(x, Parameter) or
             x.__class__.__name__ == 'Parameter')

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -464,7 +464,7 @@ class Parameters(OrderedDict):
         state = {'unique_symbols': tmp['unique_symbols'],
                  'params': []}
         for parstate in tmp['params']:
-            _par = Parameter()
+            _par = Parameter(name='')
             _par.__setstate__(parstate)
             state['params'].append(_par)
         self.__setstate__(state)
@@ -538,12 +538,12 @@ class Parameter(object):
 
     """
 
-    def __init__(self, name=None, value=None, vary=True, min=-inf, max=inf,
+    def __init__(self, name, value=None, vary=True, min=-inf, max=inf,
                  expr=None, brute_step=None, user_data=None):
         """
         Parameters
         ----------
-        name : str, optional
+        name : str
             Name of the Parameter.
         value : float, optional
             Numerical Parameter value.
@@ -701,8 +701,6 @@ class Parameter(object):
     def __repr__(self):
         """Return printable representation of a Parameter object."""
         s = []
-        if self.name is not None:
-            s.append("'%s'" % self.name)
         sval = repr(self._getval())
         if not self.vary and self._expr is None:
             sval = "value=%s (fixed)" % sval
@@ -714,7 +712,7 @@ class Parameter(object):
             s.append("expr='%s'" % self.expr)
         if self.brute_step is not None:
             s.append("brute_step=%s" % (self.brute_step))
-        return "<Parameter %s>" % ', '.join(s)
+        return "<Parameter '%s', %s>" % (self.name, ', '.join(s))
 
     def setup_bounds(self):
         """Set up Minuit-style internal/external parameter transformation of

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,0 +1,538 @@
+"""Tests for the Parameter class."""
+
+from math import trunc
+
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+import six
+import uncertainties as un
+
+import lmfit
+
+
+@pytest.fixture
+def parameter():
+    """Initialize parameter for tests."""
+    param = lmfit.Parameter(name='a', value=10.0, vary=True, min=-100.0,
+                            max=100.0, expr=None, brute_step=5.0, user_data=1)
+    expected_attribute_values = ('a', 10.0, True, -100.0, 100.0, None, 5.0, 1)
+    assert_parameter_attributes(param, expected_attribute_values)
+    return param, expected_attribute_values
+
+
+def assert_parameter_attributes(par, expected):
+    """Assert that parameter attributes have the expected values."""
+    par_attr_values = (par.name, par._val, par.vary, par.min, par.max,
+                       par._expr, par.brute_step, par.user_data)
+    assert par_attr_values == expected
+
+
+in_out = [(lmfit.Parameter(name='a'),  # set name
+           ('a', -np.inf, True, -np.inf, np.inf, None, None, None)),
+          (lmfit.Parameter(name='a', value=10.0),  # set value
+           ('a', 10.0, True, -np.inf, np.inf, None, None, None)),
+          (lmfit.Parameter(name='a', vary=False),  # fix parameter, set vary to False
+           ('a', -np.inf, False, -np.inf, np.inf, None, None, None)),
+          (lmfit.Parameter(name='a', min=-10.0),  # set lower bound, value reset to min
+           ('a', -10.0, True, -10.0, np.inf, None, None, None)),
+          (lmfit.Parameter(name='a', value=-5.0, min=-10.0),  # set lower bound
+           ('a', -5.0, True, -10.0, np.inf, None, None, None)),
+          (lmfit.Parameter(name='a', max=10.0),  # set upper bound
+           ('a', -np.inf, True, -np.inf, 10.0, None, None, None)),
+          (lmfit.Parameter(name='a', value=25.0, max=10.0),  # set upper bound, value reset
+           ('a', 10.0, True, -np.inf, 10.0, None, None, None)),
+          (lmfit.Parameter(name='a', expr="2.0*10.0"),  # set expression, vary becomes False
+           ('a', -np.inf, True, -np.inf, np.inf, '2.0*10.0', None, None)),
+          (lmfit.Parameter(name='a', brute_step=0.1),  # set brute_step
+           ('a', -np.inf, True, -np.inf, np.inf, None, 0.1, None)),
+          (lmfit.Parameter(name='a', user_data={'b': {}}),  # set user_data
+           ('a', -np.inf, True, -np.inf, np.inf, None, None, {'b': {}}))]
+
+
+@pytest.mark.parametrize('par, attr_values', in_out)
+def test_initialize_Parameter(par, attr_values):
+    """Test the initialization of the Parameter class."""
+    assert_parameter_attributes(par, attr_values)
+
+    # check for other default attributes
+    for attribute in ['_expr', '_expr_ast', '_expr_eval', '_expr_deps',
+                      '_delay_asteval', 'stderr', 'correl', 'from_internal',
+                      '_val']:
+        assert hasattr(par, attribute)
+
+
+def test_Parameter_no_name():
+    """Test for Parameter name, now required positional argument."""
+    msg = r"missing 1 required positional argument: 'name'"
+    msg_PY2 = r"__init__()"
+    if six.PY2:
+        with pytest.raises(TypeError, match=msg_PY2):
+            lmfit.Parameter()
+    else:
+        with pytest.raises(TypeError, match=msg):
+            lmfit.Parameter()
+
+
+def test_init_bounds():
+    """Tests to make sure that initial bounds are consistent.
+
+    Only for specific cases not tested above with the initializations of the
+    Parameter class.
+
+    """
+    # test 1: min > max; should swap min and max
+    par = lmfit.Parameter(name='a', value=0.0, min=10.0, max=-10.0)
+    assert par.min == -10.0
+    assert par.max == 10.0
+
+    # test 2: min == max; should raise a ValueError
+    msg = r"Parameter 'a' has min == max"
+    with pytest.raises(ValueError, match=msg):
+        par = lmfit.Parameter(name='a', value=0.0, min=10.0, max=10.0)
+
+    # FIXME: ideally this should be impossible to happen ever....
+    # perhaps we should add a  setter method for MIN and MAX as well?
+    # test 3: max or min is equal to None
+    par.min = None
+    par._init_bounds()
+    assert par.min == -np.inf
+
+    par.max = None
+    par._init_bounds()
+    assert par.max == np.inf
+
+
+def test_parameter_set_value(parameter):
+    """Test the Parameter.set() function with value."""
+    par, initial_attribute_values = parameter
+
+    par.set(value=None)  # nothing should change
+    assert_parameter_attributes(par, initial_attribute_values)
+
+    par.set(value=5.0)
+    changed_attribute_values = ('a', 5.0, True, -100.0, 100.0, None, 5.0, 1)
+    assert_parameter_attributes(par, changed_attribute_values)
+
+
+def test_parameter_set_vary(parameter):
+    """Test the Parameter.set() function with vary."""
+    par, initial_attribute_values = parameter
+
+    par.set(vary=None)  # nothing should change
+    assert_parameter_attributes(par, initial_attribute_values)
+
+    par.set(vary=False)
+    changed_attribute_values = ('a', 10.0, False, -100.0, 100.0, None, 5.0, 1)
+    assert_parameter_attributes(par, changed_attribute_values)
+
+
+def test_parameter_set_min(parameter):
+    """Test the Parameter.set() function with min."""
+    par, initial_attribute_values = parameter
+
+    par.set(min=None)  # nothing should change
+    assert_parameter_attributes(par, initial_attribute_values)
+
+    par.set(min=-50.0)
+    changed_attribute_values = ('a', 10.0, True, -50.0, 100.0, None, 5.0, 1)
+    assert_parameter_attributes(par, changed_attribute_values)
+
+
+def test_parameter_set_max(parameter):
+    """Test the Parameter.set() function with max."""
+    par, initial_attribute_values = parameter
+
+    par.set(max=None)  # nothing should change
+    assert_parameter_attributes(par, initial_attribute_values)
+
+    par.set(max=50.0)
+    changed_attribute_values = ('a', 10.0, True, -100.0, 50.0, None, 5.0, 1)
+    assert_parameter_attributes(par, changed_attribute_values)
+
+
+def test_parameter_set_expr(parameter):
+    """Test the Parameter.set() function with expr.
+
+    Of note, this only tests for setting/removal of the expression; nothing
+    else gets evaluated here.... More specific tests will be present in the
+    Parameters class.
+
+    """
+    par, _ = parameter
+
+    par.set(expr='2.0*50.0')  # setting an expression, vary --> False
+    changed_attribute_values = ('a', 10.0, False, -100.0, 100.0, '2.0*50.0',
+                                5.0, 1)
+    assert_parameter_attributes(par, changed_attribute_values)
+
+    par.set(expr=None)  # nothing should change
+    assert_parameter_attributes(par, changed_attribute_values)
+
+    par.set(expr='')  # should remove the expression
+    changed_attribute_values = ('a', 10.0, False, -100.0, 100.0, None, 5.0, 1)
+    assert_parameter_attributes(par, changed_attribute_values)
+
+
+def test_parameter_set_brute_step(parameter):
+    """Test the Parameter.set() function with brute_step."""
+    par, initial_attribute_values = parameter
+
+    par.set(brute_step=None)  # nothing should change
+    assert_parameter_attributes(par, initial_attribute_values)
+
+    par.set(brute_step=0.0)  # brute_step set to None
+    changed_attribute_values = ('a', 10.0, True, -100.0, 100.0, None, None, 1)
+    assert_parameter_attributes(par, changed_attribute_values)
+
+    par.set(brute_step=1.0)
+    changed_attribute_values = ('a', 10.0, True, -100.0, 100.0, None, 1.0, 1)
+    assert_parameter_attributes(par, changed_attribute_values)
+
+
+def test_getstate(parameter):
+    """Test for the __getstate__ method."""
+    par, _ = parameter
+    assert par.__getstate__() == ('a', 10.0, True, None, -100.0, 100.0, 5.0,
+                                  None, None, 10, 1)
+
+
+def test_setstate(parameter):
+    """Test for the __setstate__ method."""
+    par, initial_attribute_values = parameter
+    state = par.__getstate__()
+
+    par_new = lmfit.Parameter('new')
+    attributes_new = ('new', -np.inf, True, -np.inf, np.inf, None, None, None)
+    assert_parameter_attributes(par_new, attributes_new)
+
+    par_new.__setstate__(state)
+    assert_parameter_attributes(par_new, initial_attribute_values)
+
+
+def test_repr():
+    """Tests for the __repr__ method."""
+    par = lmfit.Parameter(name='test', value=10.0, min=0.0, max=20.0)
+    assert par.__repr__() == "<Parameter 'test', value=10.0, bounds=[0.0:20.0]>"
+
+    par = lmfit.Parameter(name='test', value=10.0, vary=False)
+    assert par.__repr__() == "<Parameter 'test', value=10.0 (fixed), bounds=[-inf:inf]>"
+
+    par.set(vary=True)
+    par.stderr = 0.1
+    assert par.__repr__() == "<Parameter 'test', value=10.0 +/- 0.1, bounds=[-inf:inf]>"
+
+    par = lmfit.Parameter(name='test', expr='10.0*2.5')
+    assert par.__repr__() == "<Parameter 'test', value=-inf, bounds=[-inf:inf], expr='10.0*2.5'>"
+
+    par = lmfit.Parameter(name='test', brute_step=0.1)
+    assert par.__repr__() == "<Parameter 'test', value=-inf, bounds=[-inf:inf], brute_step=0.1>"
+
+
+def test_setup_bounds_and_scale_gradient_methods():
+    """Tests for the setup_bounds and scale_gradient methods.
+
+    Make use of the MINUIT-style transformation to obtain the the Parameter
+    values and scaling factor for the gradient.
+    See: https://lmfit.github.io/lmfit-py/bounds.html
+
+    """
+    # situation 1: no bounds
+    par_no_bounds = lmfit.Parameter('no_bounds', value=10.0)
+    assert_allclose(par_no_bounds.setup_bounds(), 10.0)
+    assert_allclose(par_no_bounds.scale_gradient(par_no_bounds.value), 1.0)
+
+    # situation 2: no bounds, min/max set to None after creating the parameter
+    # TODO: ideally this should never happen; perhaps use a setter here
+    par_no_bounds = lmfit.Parameter('no_bounds', value=10.0)
+    par_no_bounds.min = None
+    par_no_bounds.max = None
+    assert_allclose(par_no_bounds.setup_bounds(), 10.0)
+    assert_allclose(par_no_bounds.scale_gradient(par_no_bounds.value), 1.0)
+
+    # situation 3: upper bound
+    par_upper_bound = lmfit.Parameter('upper_bound', value=10.0, max=25.0)
+    assert_allclose(par_upper_bound.setup_bounds(), 15.968719422671311)
+    assert_allclose(par_upper_bound.scale_gradient(par_upper_bound.value),
+                    -0.99503719, rtol=1.e-6)
+
+    # situation 4: lower bound
+    par_lower_bound = lmfit.Parameter('upper_bound', value=10.0, min=-25.0)
+    assert_allclose(par_lower_bound.setup_bounds(), 35.98610843)
+    assert_allclose(par_lower_bound.scale_gradient(par_lower_bound.value),
+                    0.995037, rtol=1.e-6)
+
+    # situation 5: both lower and upper bounds
+    par_both_bounds = lmfit.Parameter('both_bounds', value=10.0, min=-25.0,
+                                      max=25.0)
+    assert_allclose(par_both_bounds.setup_bounds(), 0.4115168460674879)
+    assert_allclose(par_both_bounds.scale_gradient(par_both_bounds.value),
+                    -20.976788, rtol=1.e-6)
+
+
+def test__getval(parameter):
+    """Test _getval function."""
+    par, _ = parameter
+
+    # test uncertainties.core.Variable in _getval [deprecated]
+    par.set(value=un.ufloat(5.0, 0.2))
+    with pytest.warns(FutureWarning, match='removed in the next release'):
+        val = par.value
+    assert_allclose(val, 5.0)
+
+
+def test_value_setter(parameter):
+    """Tests for the value setter."""
+    par, initial_attribute_values = parameter
+    assert_parameter_attributes(par, initial_attribute_values)
+
+    par.set(value=200.0)  # above maximum
+    assert_allclose(par.value, 100.0)
+
+    par.set(value=-200.0)  # below minimum
+    assert_allclose(par.value, -100.0)
+
+
+# TODO: add tests for  setter/getter methods for VALUE, EXPR
+
+
+# Tests for magic methods of the Parameter class
+def test__array__(parameter):
+    """Test the __array__ magic method."""
+    par, _ = parameter
+    assert np.array(par) == np.array(10.0)
+
+
+def test__str__(parameter):
+    """Test the __str__ magic method."""
+    par, _ = parameter
+    assert str(par) == "<Parameter 'a', value=10.0, bounds=[-100.0:100.0], brute_step=5.0>"
+
+
+def test__abs__(parameter):
+    """Test the __abs__ magic method."""
+    par, _ = parameter
+    assert_allclose(abs(par), 10.0)
+    par.set(value=-10.0)
+    assert_allclose(abs(par), 10.0)
+
+
+def test__neg__(parameter):
+    """Test the __neg__ magic method."""
+    par, _ = parameter
+    assert_allclose(-par, -10.0)
+    par.set(value=-10.0)
+    assert_allclose(-par, 10.0)
+
+
+def test__pos__(parameter):
+    """Test the __pos__ magic method."""
+    par, _ = parameter
+    assert_allclose(+par, 10.0)
+    par.set(value=-10.0)
+    assert_allclose(+par, -10.0)
+
+
+def test__nonzero__(parameter):
+    """Test the __nonzero__ magic method; PY2 only."""
+    par, _ = parameter
+    assert bool(par)
+
+
+def test__bool__(parameter):
+    """Test the __bool__ magic method; PY3 only."""
+    par, _ = parameter
+    assert bool(par)
+
+
+def test__int__(parameter):
+    """Test the __int__ magic method."""
+    par, _ = parameter
+    assert isinstance(int(par), int)
+    assert_allclose(int(par), 10)
+
+
+def test__float__(parameter):
+    """Test the __float__ magic method."""
+    par, _ = parameter
+    par.set(value=5)
+    assert isinstance(float(par), float)
+    assert_allclose(float(par), 5.0)
+
+
+def test__trunc__(parameter):
+    """Test the __trunc__ magic method."""
+    par, _ = parameter
+    par.set(value=10.5)
+    assert isinstance(trunc(par), int)
+    assert_allclose(trunc(par), 10)
+
+
+def test__add__(parameter):
+    """Test the __add__ magic method."""
+    par, _ = parameter
+    assert_allclose(par + 5.25, 15.25)
+
+
+def test__sub__(parameter):
+    """Test the __sub__ magic method."""
+    par, _ = parameter
+    assert_allclose(par - 5.25, 4.75)
+
+
+def test__div__(parameter):
+    """Test the __div__ magic method; PY2 only."""
+    par, _ = parameter
+    assert_allclose(par / 1.25, 8.0)
+
+
+def test__truediv__(parameter):
+    """Test the __truediv__ magic method."""
+    par, _ = parameter
+    assert_allclose(par / 1.25, 8.0)
+
+
+def test__floordiv__(parameter):
+    """Test the __floordiv__ magic method."""
+    par, _ = parameter
+    par.set(value=5)
+    assert_allclose(par // 2, 2)
+
+
+def test__divmod__(parameter):
+    """Test the __divmod__ magic method."""
+    par, _ = parameter
+    assert_allclose(divmod(par, 3), (3, 1))
+
+
+def test__mod__(parameter):
+    """Test the __mod__ magic method."""
+    par, _ = parameter
+    assert_allclose(par % 2, 0)
+    assert_allclose(par % 3, 1)
+
+
+def test__mul__(parameter):
+    """Test the __mul__ magic method."""
+    par, _ = parameter
+    assert_allclose(par * 2.5, 25.0)
+    assert_allclose(par * -0.1, -1.0)
+
+
+def test__pow__(parameter):
+    """Test the __pow__ magic method."""
+    par, _ = parameter
+    assert_allclose(par ** 0.5, 3.16227766)
+    assert_allclose(par ** 4, 1e4)
+
+
+def test__gt__(parameter):
+    """Test the __gt__ magic method."""
+    par, _ = parameter
+    assert 11 > par
+    assert not 10 > par
+
+
+def test__ge__(parameter):
+    """Test the __ge__ magic method."""
+    par, _ = parameter
+    assert 11 >= par
+    assert 10 >= par
+    assert not 9 >= par
+
+
+def test__le__(parameter):
+    """Test the __le__ magic method."""
+    par, _ = parameter
+    assert 9 <= par
+    assert 10 <= par
+    assert not 11 <= par
+
+
+def test__lt__(parameter):
+    """Test the __lt__ magic method."""
+    par, _ = parameter
+    assert 9 < par
+    assert not 10 < par
+
+
+def test__eq__(parameter):
+    """Test the __eq__ magic method."""
+    par, _ = parameter
+    assert 10 == par
+    assert not 9 == par
+
+
+def test__ne__(parameter):
+    """Test the __ne__ magic method."""
+    par, _ = parameter
+    assert 9 != par
+    assert not 10 != par
+
+
+def test__radd__(parameter):
+    """Test the __radd__ magic method."""
+    par, _ = parameter
+    assert_allclose(5.25 + par, 15.25)
+
+
+def test__rdiv__(parameter):
+    """Test the __rdiv__ magic method; PY2 only."""
+    par, _ = parameter
+    assert_allclose(1.25 / par, 0.125)
+
+
+def test__rtruediv__(parameter):
+    """Test the __rtruediv__ magic method."""
+    par, _ = parameter
+    assert_allclose(1.25 / par, 0.125)
+
+
+def test__rdivmod__(parameter):
+    """Test the __rdivmod__ magic method."""
+    par, _ = parameter
+    assert_allclose(divmod(3, par), (0, 3))
+
+
+def test__rfloordiv__(parameter):
+    """Test the __rfloordiv__ magic method."""
+    par, _ = parameter
+    assert_allclose(2 // par, 0)
+    assert_allclose(20 // par, 2)
+
+
+def test__rmod__(parameter):
+    """Test the __rmod__ magic method."""
+    par, _ = parameter
+    assert_allclose(2 % par, 2)
+    assert_allclose(25 % par, 5)
+
+
+def test__rmul__(parameter):
+    """Test the __rmul__ magic method."""
+    par, _ = parameter
+    assert_allclose(2.5 * par, 25.0)
+    assert_allclose(-0.1 * par, -1.0)
+
+
+def test__rpow__(parameter):
+    """Test the __rpow__ magic method."""
+    par, _ = parameter
+    assert_allclose(0.5 ** par, 0.0009765625)
+    assert_allclose(4 ** par, 1048576)
+
+
+def test__rsub__(parameter):
+    """Test the __rsub__ magic method."""
+    par, _ = parameter
+    assert_allclose(5.25 - par, -4.75)
+
+
+def test_isParameter(parameter):
+    """Test function to check whether something is a Paramter [deprecated]."""
+    # TODO: this function isn't used anywhere in the codebase; useful at all?
+    par, _ = parameter
+    assert lmfit.parameter.isParameter(par)
+    assert not lmfit.parameter.isParameter('test')
+    with pytest.warns(FutureWarning, match='removed in the next release'):
+        lmfit.parameter.isParameter(par)


### PR DESCRIPTION
#### Description
While working on improving the coverage of the test-suite I came across some minor inconsistencies in the ```Parameter.__repr__``` function. 

Consider the following examples:
```
>>>import lmfit
>>>lmfit.Parameter(name=‘test’, value=10)
<Parameter 'test', 10, bounds=[-inf:inf]>

>>>lmfit.Parameter(name='test', value=10, vary=False)
<Parameter 'test', value=10 (fixed), bounds=[-inf:inf]>

>>>lmfit.Parameter()
<Parameter -inf, bounds=[-inf:inf]>
```
Currently, only when a Parameter is fixed or has a ```stderr``` attribute it will show “value”; otherwise is’t just the number.  Additionally, when no ```name``` is specified the output also looks different. 

I suggest to change the behavior so that “value” is always printed ahead of the parameter value, and that when no “name” is specified we show it as ''. So when this PR gets merged the first and last situation would give instead as output:
```
>>>lmfit.Parameter(name=‘test’, value=10)
<Parameter 'test', value=10, bounds=[-inf:inf]>

>>>lmfit.Parameter()
<Parameter '', value=-inf, bounds=[-inf:inf]>
```
Once we have switched to Python 3 only we should probably convert the using f-strings, which likely means the ```__repr__``` function can get a bit shorter.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [X] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.5 (default, Oct 16 2019, 10:21:13)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 0.9.14+23.g85b6341, scipy: 1.3.1, numpy: 1.17.2, asteval: 0.9.15, uncertainties: 3.1.2, six: 1.12.0

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes? Currently working on the test-suite, there will be tests included there