### PR TITLE
Add codespell pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,3 +38,13 @@ repos:
     rev: v1.5.1
     hooks:
     -   id: rst-backticks
+
+-   repo: https://github.com/codespell-project/codespell
+    rev: v1.16.0
+    hooks:
+    -   id: codespell
+        files: '.py|.rst'
+        exclude: 'doc/doc_examples_to_gallery.py'
+        # escaped characters currently do not work correctly
+        # so \nnumber is considered a spelling error....
+        args: [-L nnumber]

--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -475,7 +475,7 @@ plus a constant:
 After constructing step-like data, we first create a :class:`StepModel`
 telling it to use the ``erf`` form (see details above), and a
 :class:`ConstantModel`.  We set initial values, in one case using the data
-and :meth:`guess` method for the initial step function paramaters, and
+and :meth:`guess` method for the initial step function parameters, and
 :meth:`make_params` arguments for the linear component.
 After making a composite model, we run :meth:`fit` and report the
 results, which gives:

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -141,7 +141,7 @@ calculated model, that should be the case.
 Common sources of NaN
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you are seeing erros due to NaN values, you will need to figure out
+If you are seeing errors due to NaN values, you will need to figure out
 where they are coming from and eliminate them.  It is sometimes difficult
 to tell what causes NaN values.  Keep in mind that all values should be
 assumed to be either scalar values or numpy arrays of double precision real

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -117,7 +117,7 @@ the expected names::
     params = gmodel.make_params()
 
 This creates the :class:`~lmfit.parameter.Parameters` but does not
-automaticaly give them initial values since it has no idea what the scale
+automatically give them initial values since it has no idea what the scale
 should be.  You can set initial values for parameters with keyword
 arguments to :meth:`make_params`::
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -37,7 +37,7 @@ Various:
 Version 0.9.15 Release Notes
 ============================
 
-**Version 0.9.15 is the last release that supports Python 2.7**; it now also fully suports Python 3.8.
+**Version 0.9.15 is the last release that supports Python 2.7**; it now also fully supports Python 3.8.
 
 New features, improvements, and bug fixes:
 
@@ -250,7 +250,7 @@ so that the Parameter value does not need ``sigma = params['sigma'].value``.
 The older, explicit usage still works, but the docs, samples, and tests
 have been updated to use the simpler usage.
 
-Support for Python 2.6 and SciPy 0.13 is now explicitly deprecated and wil
+Support for Python 2.6 and SciPy 0.13 is now explicitly deprecated and will
 be dropped in version 0.9.5.
 
 .. _whatsnew_093_label:

--- a/examples/example_Model_interface.py
+++ b/examples/example_Model_interface.py
@@ -58,8 +58,8 @@ result.params.pretty_print()
 # **Specifying Bounds and Holding Parameters Constant**
 #
 # Above, the ``Model`` class implicitly builds ``Parameter`` objects from
-# keyword arguments of ``fit`` that match the argments of ``decay``. You can
-# build the ``Parameter`` objects explicity; the following is equivalent.
+# keyword arguments of ``fit`` that match the arguments of ``decay``. You can
+# build the ``Parameter`` objects explicitly; the following is equivalent.
 result = model.fit(data, t=t,
                    N=Parameter('N', value=10),
                    tau=Parameter('tau', value=1))
@@ -76,7 +76,7 @@ report_fit(result.params)
 ###############################################################################
 # **Defining Parameters in Advance**
 #
-# Passing parameters to ``fit`` can become unwieldly. As an alternative, you
+# Passing parameters to ``fit`` can become unwieldy. As an alternative, you
 # can extract the parameters from ``model`` like so, set them individually,
 # and pass them to ``fit``.
 params = model.make_params()
@@ -127,7 +127,7 @@ report_fit(result.params)
 ###############################################################################
 # *Handling Missing Data*
 #
-# By default, attemping to fit data that includes a ``NaN``, which
+# By default, attempting to fit data that includes a ``NaN``, which
 # conventionally indicates a "missing" observation, raises a lengthy exception.
 # You can choose to ``omit`` (i.e., skip over) missing values instead.
 data_with_holes = data.copy()

--- a/examples/example_brute.py
+++ b/examples/example_brute.py
@@ -118,13 +118,13 @@ print(result.brute_grid)
 print(result.brute_Jout)
 
 ###############################################################################
-# **Reassuringly, the obtained results are indentical to using the method in
+# **Reassuringly, the obtained results are identical to using the method in
 # SciPy directly!**
 
 ###############################################################################
 # Example 2: fit of a decaying sine wave
 #
-# In this example, will explain some of the options ot the algorithm.
+# In this example, we will explain some of the options of the algorithm.
 #
 # We start off by generating some synthetic data with noise for a decaying
 # sine wave, define an objective function and create a Parameter set.

--- a/lmfit/confidence.py
+++ b/lmfit/confidence.py
@@ -82,7 +82,7 @@ def conf_interval(minimizer, result, p_names=None, sigmas=[1, 2, 3],
     maxiter : int, optional
         Maximum of iteration to find an upper limit (default is 200).
     verbose: bool, optional
-        Print extra debuging information (default is False).
+        Print extra debugging information (default is False).
     prob_func : None or callable, optional
         Function to calculate the probability from the optimized chi-square.
         Default is None and uses the built-in f_compare (i.e., F-test).

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -1,7 +1,7 @@
 """Basic model line shapes and distribution functions."""
 
-from numpy import (arctan, cos, exp, finfo, float64, isnan, log, pi, sin, sqrt,
-                   where, real)
+from numpy import (arctan, cos, exp, finfo, float64, isnan, log, pi, real, sin,
+                   sqrt, where)
 from numpy.testing import assert_allclose
 from scipy.special import erf, erfc
 from scipy.special import gamma as gamfcn

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1727,7 +1727,7 @@ class Minimizer:
 
         Notes
         -----
-        The :meth:`brute` method evalutes the function at each point of a
+        The :meth:`brute` method evaluates the function at each point of a
         multidimensional grid of points. The grid points are generated from the
         parameter ranges using `Ns` and (optional) `brute_step`.
         The implementation in :scipydoc:`optimize.brute` requires finite bounds
@@ -2242,7 +2242,7 @@ def _nan_policy(arr, nan_policy='raise', handle_inf=True):
             with np.errstate(invalid='ignore'):
                 contains_nan = handler_func(np.sum(arr))
         except TypeError:
-            # If the check cannot be properly performed we fallback to omiting
+            # If the check cannot be properly performed we fallback to omitting
             # nan values and raising a warning. This can happen when attempting to
             # sum things that are not numbers (e.g. as in the function `mode`).
             contains_nan = False

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -9,8 +9,8 @@ from .lineshapes import (breit_wigner, damped_oscillator, dho, donaich,
                          expgaussian, exponential, gaussian, linear, lognormal,
                          lorentzian, moffat, parabolic, pearson7, powerlaw,
                          pvoigt, rectangle, skewed_gaussian, skewed_voigt,
-                         thermal_distribution, split_lorentzian, step,
-                         students_t, voigt)
+                         split_lorentzian, step, students_t,
+                         thermal_distribution, voigt)
 from .model import Model
 
 tiny = np.finfo(np.float).eps

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -251,7 +251,7 @@ ParabolicModel = QuadraticModel
 
 
 class PolynomialModel(Model):
-    r"""A polynomial model with up to 7 Parameters, specfied by ``degree``.
+    r"""A polynomial model with up to 7 Parameters, specified by ``degree``.
 
     .. math::
 

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -523,7 +523,7 @@ class Parameter:
     placed on the Parameter's value by setting its `min` and/or `max`
     attributes.  A Parameter can also have its value determined by a
     mathematical expression of other Parameter values held in the `expr`
-    attrribute.  Additional attributes include `brute_step` used as the step
+    attribute.  Additional attributes include `brute_step` used as the step
     size in a brute-force minimization, and `user_data` reserved
     exclusively for user's need.
 

--- a/lmfit/ui/basefitter.py
+++ b/lmfit/ui/basefitter.py
@@ -291,7 +291,7 @@ class MPLFitter(BaseFitter):
             ax.plot(indep_var, self._data, **_data_style)
         else:
             raise NotImplementedError("Cannot plot models with more than one "
-                                      "indepedent variable.")
+                                      "independent variable.")
         result = self.current_result  # alias for brevity
         if not result:
             ax.set(**_axes_style)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ Parameters.  The Levenberg-Marquardt (leastsq) is the default minimization
 algorithm, and provides estimated standard errors and correlations between
 varied Parameters.  Other minimization methods, including Nelder-Mead's
 downhill simplex, Powell's method, BFGS, Sequential Least Squares, and
-others are also supported.  Bounds and contraints can be placed on
+others are also supported.  Bounds and constraints can be placed on
 Parameters for all of these methods.
 
 In addition, methods for explicitly calculating confidence intervals are

--- a/tests/test_ampgo.py
+++ b/tests/test_ampgo.py
@@ -104,7 +104,7 @@ def test_ampgo_local_opts(minimizer_Alpine02):
     with pytest.raises(TypeError):
         minimizer_Alpine02.minimize(method='ampgo', **kws)
 
-    # for coverage: make sure that both occurences are reached
+    # for coverage: make sure that both occurrences are reached
     kws = {'local_opts': {'maxiter': 10}, 'maxfunevals': 50}
     minimizer_Alpine02.minimize(method='ampgo', **kws)
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -583,7 +583,7 @@ def test__rsub__(parameter):
 
 
 def test_isParameter(parameter):
-    """Test function to check whether something is a Paramter [deprecated]."""
+    """Test function to check whether something is a Parameter [deprecated]."""
     # TODO: this function isn't used anywhere in the codebase; useful at all?
     par, _ = parameter
     assert lmfit.parameter.isParameter(par)

--- a/tests/test_printfuncs.py
+++ b/tests/test_printfuncs.py
@@ -374,7 +374,7 @@ def test_ci_report_with_offset(confidence_interval):
 
 @pytest.mark.parametrize("ndigits", [3, 5, 7])
 def test_ci_report_with_ndigits(confidence_interval, ndigits):
-    """Verify output of CI report when specifiying ndigits."""
+    """Verify output of CI report when specifying ndigits."""
     report_split = ci_report(confidence_interval, ndigits=ndigits).split('\n')
     period_values = [val for val in report_split[2].split()[2:]]
     length = [len(val.split('.')[-1]) for val in period_values]


### PR DESCRIPTION
#### Description
This PR adds a `pre-commit` hook for `codespell` and correct typos reported by the tool. Additionally, correct the sorting of a few import statements. 

###### Type of Changes
- [X] Refactoring / maintenance

###### Tested on
Python: 3.8.2 (default, Feb 27 2020, 15:26:21)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 1.0.0+19.gbbb7f60, scipy: 1.4.1, numpy: 1.18.2, asteval: 0.9.18, uncertainties: 3.1.2


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
