### PR TITLE
Remove deprecated stuff

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -3,7 +3,6 @@
 from collections import OrderedDict
 from copy import deepcopy
 import json
-import warnings
 
 from asteval import Interpreter, get_ast_names, valid_symbol_name
 from numpy import arcsin, array, cos, inf, isclose, sin, sqrt
@@ -962,11 +961,3 @@ class Parameter:
     def __rsub__(self, other):
         """- (right)"""
         return other - self._getval()
-
-
-def isParameter(x):
-    """Test for Parameter-ness."""
-    msg = 'The isParameter function will be removed in the next release.'
-    warnings.warn(FutureWarning(msg))
-    return (isinstance(x, Parameter) or
-            x.__class__.__name__ == 'Parameter')

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -6,9 +6,8 @@ import json
 import warnings
 
 from asteval import Interpreter, get_ast_names, valid_symbol_name
-from numpy import arcsin, array, cos, inf, isclose, nan, sin, sqrt
+from numpy import arcsin, array, cos, inf, isclose, sin, sqrt
 import scipy.special
-import uncertainties
 
 from .jsonutils import decode4js, encode4js
 from .printfuncs import params_html_table
@@ -779,17 +778,6 @@ class Parameter:
         # _expr_eval.symtable is kept up-to-date.
         # If you just assign to self._val then _expr_eval.symtable[self.name]
         # becomes stale if parameter.expr is not None.
-        if (isinstance(self._val, uncertainties.core.Variable) and
-                self._val is not nan):
-            msg = ("Please make sure that the Parameter value is a number, "
-                   "not an instance of 'uncertainties.core.Variable'. This "
-                   "automatic conversion will be removed in the next release.")
-            warnings.warn(FutureWarning(msg))
-            try:
-                self.value = self._val.nominal_value
-            except AttributeError:
-                pass
-
         if self._expr is not None:
             if self._expr_ast is None:
                 self.__set_expression(self._expr)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -568,13 +568,3 @@ def test__rsub__(parameter):
     """Test the __rsub__ magic method."""
     par, _ = parameter
     assert_allclose(5.25 - par, -4.75)
-
-
-def test_isParameter(parameter):
-    """Test function to check whether something is a Parameter [deprecated]."""
-    # TODO: this function isn't used anywhere in the codebase; useful at all?
-    par, _ = parameter
-    assert lmfit.parameter.isParameter(par)
-    assert not lmfit.parameter.isParameter('test')
-    with pytest.warns(FutureWarning, match='removed in the next release'):
-        lmfit.parameter.isParameter(par)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -6,7 +6,6 @@ import pickle
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
-import uncertainties as un
 
 import lmfit
 
@@ -343,17 +342,6 @@ def test_setup_bounds_and_scale_gradient_methods():
     assert_allclose(par_both_bounds.setup_bounds(), 0.4115168460674879)
     assert_allclose(par_both_bounds.scale_gradient(par_both_bounds.value),
                     -20.976788, rtol=1.e-6)
-
-
-def test__getval(parameter):
-    """Test _getval function."""
-    par, _ = parameter
-
-    # test uncertainties.core.Variable in _getval [deprecated]
-    par.set(value=un.ufloat(5.0, 0.2))
-    with pytest.warns(FutureWarning, match='removed in the next release'):
-        val = par.value
-    assert_allclose(val, 5.0)
 
 
 def test_value_setter(parameter):


### PR DESCRIPTION
#### Description
This PR removes a feature and function, which were deprecated earlier in version 0.9.15.

###### Type of Changes
- [x] Refactoring / maintenance


###### Tested on
Python: 3.8.2 (default, Feb 27 2020, 15:26:21)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 1.0.0+19.gbbb7f60, scipy: 1.4.1, numpy: 1.18.2, asteval: 0.9.18, uncertainties: 3.1.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?