### PR TITLE
guess_from_peak and increasing vs. decreasing x

### DIFF
--- a/tests/test_lineshapes_models.py
+++ b/tests/test_lineshapes_models.py
@@ -270,3 +270,21 @@ def test_splitlorentzian_prefix():
     mod2 = models.SplitLorentzianModel(prefix='prefix_')
     par2 = mod2.make_params(amplitude=1.0, center=0.0, sigma=0.9, sigma_r=1.3)
     par2.update_constraints()
+
+
+def test_guess_from_peak():
+    x = np.linspace(-5, 5)
+    amplitude = 0.8
+    center = 1.7
+    sigma = 0.3
+    y = lineshapes.lorentzian(x, amplitude=amplitude, center=center, sigma=sigma)
+
+    model = models.LorentzianModel()
+    guess_increasing_x = model.guess(y, x=x)
+    guess_decreasing_x = model.guess(y[::-1], x=x[::-1])
+
+    assert guess_increasing_x == guess_decreasing_x
+
+    for param, value in zip(['amplitude', 'center', 'sigma'],
+                            [amplitude, center, sigma]):
+        assert np.abs((guess_increasing_x[param].value - value)/value) < 0.5


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
This ensures similar ``guess_from_peak`` behavior for increasing or decreasing ``x``.
Here are a few small things that I noticed about the function I think can be coded more clearly

1. `` imaxy`` was defined twice and only used once in the line after it is created
1. I think it's better to reply on native NumPy than the ``index_of`` function
1. ``halfmax_vals`` used to define the desired indices of x. It's more straightforward just to get the desired values and to use a more transparent name. 
1. It's better not to conflate the meaning of ``amp`, which is used to refer to both the peak hight and integrated intensity in the function. 

Note 
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->
Fix related to mailing list issue
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/lmfit-py/MUi1GphCxKE


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:\-->
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
Python: 3.8.2 (default, Mar 26 2020, 10:43:30) 
[Clang 4.0.1 (tags/RELEASE_401/final)]

lmfit: 1.0.0+24.gc528830.dirty, scipy: 1.4.1, numpy: 1.18.2, asteval: 0.9.18, uncertainties: 3.1.2



###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
No new functions
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
No docs are unchanged. 
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
One commit
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
A new test is added
- [ ] updated the documentation?
- [ ] added an example?
