### PR TITLE
Fix building the documentation/examples gallery

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -166,5 +166,4 @@ sphinx_gallery_conf = {
     'gallery_dirs': 'examples',
     'filename_pattern': '/documentation|/example_',
     'ignore_pattern': '/doc_',
-    'expected_failing_examples': ['../examples/documentation/model_loadmodel.py']
 }

--- a/doc/doc_examples_to_gallery.py
+++ b/doc/doc_examples_to_gallery.py
@@ -37,10 +37,7 @@ for fn in files:
 
     gallery_file = os.path.join(examples_documentation_dir, fn[4:])
     with open(gallery_file, 'w') as out:
-        msg = ""
-        if 'model_loadmodel.py' in fn:
-            msg = ('.. note:: This example *does* actually work, but running from within '
-                   ' sphinx-gallery fails to find symbols saved in the save file.')
+        msg = ""  # add optional message f
         out.write('"""\n{}\n{}\n\n{}\n"""\n'.format(fn, "="*len(fn), msg))
         out.write('##\nimport warnings\nwarnings.filterwarnings("ignore")\n##\n')
         out.write(script_text)
@@ -54,7 +51,6 @@ time.sleep(1.0)
 os.system('cp {}/*.dat {}'.format(examples_dir, examples_documentation_dir))
 os.system('cp {}/*.csv {}'.format(examples_dir, examples_documentation_dir))
 os.system('cp {}/*.sav {}'.format(examples_dir, examples_documentation_dir))
-#
 
 os.chdir(examples_documentation_dir)
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -20,6 +20,7 @@ Downloading and Installation
 .. _sphinx: https://www.sphinx-doc.org
 .. _jupyter_sphinx: https://jupyter-sphinx.readthedocs.io
 .. _ImageMagick: https://www.imagemagick.org/
+.. _Pillow: https://python-pillow.org/
 .. _release_notes: https://lmfit.github.io/lmfit-py/whatsnew.html
 
 
@@ -43,11 +44,12 @@ functionality requires the `emcee`_ (version 3+), `corner`_, `pandas`_, `Jupyter
 `matplotlib`_, `dill`_, or `numdifftools`_ packages.  These are not installed
 automatically, but we highly recommend each of these packages.
 
-For building the documentation, `matplotlib`_, `emcee`_ (version 3+), `corner`_,
-`Sphinx`_, `jupyter_sphinx`_, and `ImageMagick`_ are required (the latter
-one only when generating the PDF document).
+For building the documentation and generating the examples gallery,
+`matplotlib`_, `emcee`_ (version 3+), `corner`_, `Sphinx`_,
+`jupyter_sphinx`_, `Pillow`_ and `ImageMagick`_ are required (the
+latter one only when generating the PDF document).
 
-Please refer to  ``requirements-dev.txt`` for a list of all dependencies that
+Please refer to ``requirements-dev.txt`` for a list of all dependencies that
 are needed if you want to participate in the development of lmfit.
 
 Downloads

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,6 +9,7 @@ matplotlib
 numdifftools
 numpy>=1.16
 pandas
+Pillow
 pre-commit
 pytest
 scipy>=1.2


### PR DESCRIPTION
#### Description
This PR fixes recent errors when building the documentation and gallery. The ```Pillow``` dependency was made optional in a recent update of ```sphinx-gallery```, but we (apparently) use it. Solved by declaring the `Pillow` dependency explicitly.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples

###### Tested on
Python: 3.8.2 (default, Feb 27 2020, 15:26:21)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 1.0.0+24.gc528830, scipy: 1.4.1, numpy: 1.18.2, asteval: 0.9.18, uncertainties: 3.1.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] updated the documentation?

