### PR TITLE
FIX: guess_from_peak with pandas.[DataFrame|Series]

### DIFF
--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -55,7 +55,9 @@ def guess_from_peak(model, y, x, negative, ampscale=1.0, sigscale=1.0):
     height = (maxy - miny)*3.0
     sig = (maxx-minx)/6.0
 
-    x_halfmax = x[y > (maxy+miny)/2.0]
+    # the explicit conversion to a NumPy array is to make sure that the
+    # indexing on line 65 also works if the data is supplied as pandas.Series
+    x_halfmax = np.array(x[y > (maxy+miny)/2.0])
     if negative:
         height = -(maxy - miny)*3.0
         x_halfmax = x[y < (maxy+miny)/2.0]


### PR DESCRIPTION

#### Description
After merging #627 the example ```example_use_pandas.py``` fails. That's because `pandas.Series` cannot be indexed using, for example, '[-1]'. Explicitly convert `x_halfmax` to a NumPy array to make sure it always works correctly.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix

###### Tested on
Python: 3.8.2 (default, Feb 27 2020, 15:26:21)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 1.0.0+29.gd211c9b, scipy: 1.4.1, numpy: 1.18.2, asteval: 0.9.18, uncertainties: 3.1.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?