### PR TITLE
lineshapes: clean-up and improve tests coverage

### DIFF
--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -15,9 +15,9 @@ tiny = finfo(float64).eps
 functions = ('gaussian', 'lorentzian', 'voigt', 'pvoigt', 'moffat', 'pearson7',
              'breit_wigner', 'damped_oscillator', 'dho', 'logistic', 'lognormal',
              'students_t', 'expgaussian', 'donaich', 'skewed_gaussian',
-             'skewed_voigt', 'thermal_distribution', 'step', 'rectangle', 'erf',
-             'erfc', 'wofz', 'gamma', 'gammaln', 'exponential', 'powerlaw',
-             'linear', 'parabolic', 'sine', 'expsine', 'split_lorentzian')
+             'skewed_voigt', 'thermal_distribution', 'step', 'rectangle',
+             'exponential', 'powerlaw', 'linear', 'parabolic', 'sine',
+             'expsine', 'split_lorentzian')
 
 
 def gaussian(x, amplitude=1.0, center=0.0, sigma=1.0):

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -4,7 +4,7 @@ from numpy import (arctan, cos, exp, finfo, float64, isnan, log, pi, real, sin,
                    sqrt, where)
 from scipy.special import erf, erfc
 from scipy.special import gamma as gamfcn
-from scipy.special import gammaln, wofz
+from scipy.special import wofz
 
 log2 = log(2)
 s2pi = sqrt(2*pi)
@@ -408,43 +408,6 @@ def rectangle(x, amplitude=1.0, center1=0.0, sigma1=1.0,
         raise ValueError(msg)
 
     return amplitude*out
-
-
-def _erf(x):
-    """Return the error function.
-
-    erf = 2/sqrt(pi)*integral(exp(-t**2), t=[0, z])
-
-    """
-    return erf(x)
-
-
-def _erfc(x):
-    """Return the complementary error function.
-
-    erfc = 1 - erf(x)
-
-    """
-    return erfc(x)
-
-
-def _wofz(x):
-    """Return the fadeeva function for complex argument.
-
-    wofz = exp(-x**2)*erfc(-i*x)
-
-    """
-    return wofz(x)
-
-
-def _gamma(x):
-    """Return the gamma function."""
-    return gamfcn(x)
-
-
-def _gammaln(x):
-    """Return the log of absolute value of gamma function."""
-    return gammaln(x)
 
 
 def exponential(x, amplitude=1, decay=1):

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -195,8 +195,8 @@ def lognormal(x, amplitude=1.0, center=0., sigma=1):
         x = max(tiny, x)
     else:
         x[where(x <= tiny)] = tiny
-    return ((amplitude/(x*max(tiny, sigma*s2pi))) * exp(-(log(x)-center)**2
-            / max(tiny, (2*sigma**2))))
+    return ((amplitude/(x*max(tiny, sigma*s2pi))) *
+            exp(-(log(x)-center)**2 / max(tiny, (2*sigma**2))))
 
 
 def students_t(x, amplitude=1.0, center=0.0, sigma=1.0):

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -2,7 +2,6 @@
 
 from numpy import (arctan, cos, exp, finfo, float64, isnan, log, pi, real, sin,
                    sqrt, where)
-from numpy.testing import assert_allclose
 from scipy.special import erf, erfc
 from scipy.special import gamma as gamfcn
 from scipy.special import gammaln, wofz
@@ -471,11 +470,3 @@ def parabolic(x, a=0.0, b=0.0, c=0.0):
 
     """
     return a * x**2 + b * x + c
-
-
-def assert_results_close(actual, desired, rtol=1e-03, atol=1e-03,
-                         err_msg='', verbose=True):
-    """Check whether all actual and desired parameter values are close."""
-    for param_name, value in desired.items():
-        assert_allclose(actual[param_name], value, rtol,
-                        atol, err_msg, verbose)

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -120,6 +120,7 @@ def pearson7(x, amplitude=1.0, center=0.0, sigma=1.0, expon=1.0):
     and beta() is the beta function.
 
     """
+    expon = max(tiny, expon)
     arg = (x-center)/max(tiny, sigma)
     scale = amplitude * gamfcn(expon)/(gamfcn(0.5)*gamfcn(expon-0.5))
     return scale*(1+arg**2)**(-expon)/max(tiny, sigma)
@@ -179,7 +180,7 @@ def logistic(x, amplitude=1., center=0., sigma=1.):
         = amplitude*(1.  - 1. / (1 + exp((x-center)/sigma)))
 
     """
-    return amplitude*(1. - 1./(1. + exp((x-center)/sigma)))
+    return amplitude*(1. - 1./(1. + exp((x-center)/max(tiny, sigma))))
 
 
 def lognormal(x, amplitude=1.0, center=0., sigma=1):
@@ -442,6 +443,7 @@ def exponential(x, amplitude=1, decay=1):
     x -> amplitude * exp(-x/decay)
 
     """
+    decay = max(tiny, decay)
     return amplitude * exp(-x/decay)
 
 

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -356,13 +356,18 @@ def step(x, amplitude=1.0, center=0.0, sigma=1.0, form='linear'):
 
     if form == 'erf':
         out = 0.5*(1 + erf(out))
-    elif form.startswith('logi'):
+    elif form == 'logistic':
         out = (1. - 1./(1. + exp(out)))
     elif form in ('atan', 'arctan'):
         out = 0.5 + arctan(out)/pi
-    else:
+    elif form == 'linear':
         out[where(out < 0)] = 0.0
         out[where(out > 1)] = 1.0
+    else:
+        msg = "Invalid value ('%s') for argument 'form'; should be one of %s."\
+               % (form, "'erf', 'logistic', 'atan', 'arctan', or 'linear'")
+        raise ValueError(msg)
+
     return amplitude*out
 
 
@@ -387,16 +392,21 @@ def rectangle(x, amplitude=1.0, center1=0.0, sigma1=1.0,
 
     if form == 'erf':
         out = 0.5*(erf(arg1) + erf(arg2))
-    elif form.startswith('logi'):
+    elif form == 'logistic':
         out = (1. - 1./(1. + exp(arg1)) - 1./(1. + exp(arg2)))
     elif form in ('atan', 'arctan'):
         out = (arctan(arg1) + arctan(arg2))/pi
-    else:
+    elif form == 'linear':
         arg1[where(arg1 < 0)] = 0.0
         arg1[where(arg1 > 1)] = 1.0
         arg2[where(arg2 > 0)] = 0.0
         arg2[where(arg2 < -1)] = -1.0
         out = arg1 + arg2
+    else:
+        msg = "Invalid value ('%s') for argument 'form'; should be one of %s."\
+               % (form, "'erf', 'logistic', 'atan', 'arctan', or 'linear'")
+        raise ValueError(msg)
+
     return amplitude*out
 
 

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -54,6 +54,7 @@ def split_lorentzian(x, amplitude=1.0, center=0.0, sigma=1.0, sigma_r=1.0):
         [2*amplitude / (pi* (sigma + sigma_r)] *
          {  sigma**2   * (x<center)  / [sigma**2  + (x - center)**2]
           + sigma_r**2 * (x>=center) / [sigma_r**2+ (x - center)**2] }
+
     """
     s = max(tiny, sigma)
     r = max(tiny, sigma_r)
@@ -203,8 +204,8 @@ def students_t(x, amplitude=1.0, center=0.0, sigma=1.0):
 
     students_t(x, amplitude, center, sigma) =
 
-        gamma((sigma+1)/2)   (1 + (x-center)**2/sigma)^(-(sigma+1)/2)
-        -------------------------
+             gamma((sigma+1)/2)
+        ---------------------------- * (1 + (x-center)**2/sigma)^(-(sigma+1)/2)
         sqrt(sigma*pi)gamma(sigma/2)
 
     """
@@ -214,10 +215,11 @@ def students_t(x, amplitude=1.0, center=0.0, sigma=1.0):
 
 
 def expgaussian(x, amplitude=1, center=0, sigma=1.0, gamma=1.0):
-    """Return a exponentially modified Gaussian.
+    """Return an exponentially modified Gaussian.
 
-    expgaussian(x, amplitude, center, sigma, gamma=)
-        = (gamma/2) exp[center*gamma + (gamma*sigma)**2/2 - gamma*x] *
+    expgaussian(x, amplitude, center, sigma, gamma)
+        = amplitude * (gamma/2) *
+          exp[center*gamma + (gamma*sigma)**2/2 - gamma*x] *
           erfc[(center + gamma*sigma**2 - x)/(sqrt(2)*sigma)]
 
     https://en.wikipedia.org/wiki/Exponentially_modified_Gaussian_distribution
@@ -316,10 +318,10 @@ def thermal_distribution(x, amplitude=1.0, center=0.0, kt=1.0, form='bose'):
        = 1/(amplitude*exp((x - center)/kt) + 1)
 
     Notes:
-    - ``kt`` should be defined in the same units as ``x``. (The Boltzmann constant is
-    kB = 8.617e-5 eV/K).
+    - ``kt`` should be defined in the same units as ``x``. (The Boltzmann
+      constant is kB = 8.617e-5 eV/K).
     - set ``kt<0`` to implement the energy loss convention common in scattering
-    research.
+      research.
 
     see http://hyperphysics.phy-astr.gsu.edu/hbase/quantum/disfcn.html
 

--- a/tests/test_lineshapes.py
+++ b/tests/test_lineshapes.py
@@ -1,0 +1,75 @@
+"""Tests for lineshape functions."""
+
+import inspect
+
+import numpy as np
+import pytest
+
+import lmfit
+
+lineshapes_functions = [fnc_name for fnc_name in lmfit.lineshapes.functions if
+                        fnc_name not in ('gamma', 'gammaln', 'wofz', 'erf',
+                                         'erfc')]
+
+
+@pytest.mark.parametrize("lineshape", lineshapes_functions)
+def test_no_ZeroDivisionError_and_finite_output(lineshape):
+    """Tests for finite output and ZeroDivisionError is not raised."""
+    xvals = np.linspace(0, 10, 100)
+
+    func = getattr(lmfit.lineshapes, lineshape)
+    assert callable(func)
+    sig = inspect.signature(func)
+
+    # set the following function arguments:
+    #   x = xvals
+    #   center = 0.5*(max(xvals)-min(xvals))
+    #   center1 = 0.25*(max(xvals)-min(xvals))
+    #   center2 = 0.75*(max(xvals)-min(xvals))
+    #   form = default value (i.e., 'linear' or 'bose')
+    xvals_mid_range = xvals.mean()
+    zero_pars = [par_name for par_name in sig.parameters.keys() if par_name
+                 not in ('x', 'form')]
+
+    for par_zero in zero_pars:
+        fnc_args = []
+        for par in sig.parameters.keys():
+            if par == 'x':
+                fnc_args.append(xvals)
+            elif par == 'center':
+                fnc_args.append(0.5*xvals_mid_range)
+            elif par == 'center1':
+                fnc_args.append(0.25*xvals_mid_range)
+            elif par == 'center2':
+                fnc_args.append(0.75*xvals_mid_range)
+            elif par == par_zero:
+                fnc_args.append(0.0)
+            else:
+                fnc_args.append(sig.parameters[par].default)
+
+        fnc_output = func(*fnc_args)
+        assert len(xvals) == len(fnc_output)
+        assert np.all(np.isfinite(fnc_output))
+
+
+@pytest.mark.parametrize("lineshape", lineshapes_functions)
+def test_x_float_value(lineshape):
+    """Test lineshapes when x is not an array but a float."""
+    xval = 7.0
+
+    func = getattr(lmfit.lineshapes, lineshape)
+    sig = inspect.signature(func)
+
+    fnc_args = [xval]
+
+    for par in [par_name for par_name in sig.parameters.keys()
+                if par_name != 'x']:
+        fnc_args.append(sig.parameters[par].default)
+
+    if lineshape in ('step', 'rectangle'):
+        msg = r"'float' object does not support item assignment"
+        with pytest.raises(TypeError, match=msg):
+            fnc_output = func(*fnc_args)
+    else:
+        fnc_output = func(*fnc_args)
+        assert isinstance(fnc_output, float)

--- a/tests/test_lineshapes.py
+++ b/tests/test_lineshapes.py
@@ -7,12 +7,8 @@ import pytest
 
 import lmfit
 
-lineshapes_functions = [fnc_name for fnc_name in lmfit.lineshapes.functions if
-                        fnc_name not in ('gamma', 'gammaln', 'wofz', 'erf',
-                                         'erfc')]
 
-
-@pytest.mark.parametrize("lineshape", lineshapes_functions)
+@pytest.mark.parametrize("lineshape", lmfit.lineshapes.functions)
 def test_no_ZeroDivisionError_and_finite_output(lineshape):
     """Tests for finite output and ZeroDivisionError is not raised."""
     xvals = np.linspace(0, 10, 100)
@@ -52,7 +48,7 @@ def test_no_ZeroDivisionError_and_finite_output(lineshape):
         assert np.all(np.isfinite(fnc_output))
 
 
-@pytest.mark.parametrize("lineshape", lineshapes_functions)
+@pytest.mark.parametrize("lineshape", lmfit.lineshapes.functions)
 def test_x_float_value(lineshape):
     """Test lineshapes when x is not an array but a float."""
     xval = 7.0

--- a/tests/test_lineshapes.py
+++ b/tests/test_lineshapes.py
@@ -73,3 +73,56 @@ def test_x_float_value(lineshape):
     else:
         fnc_output = func(*fnc_args)
         assert isinstance(fnc_output, float)
+
+
+rising_form = ['erf', 'logistic', 'atan', 'arctan', 'linear', 'unknown']
+@pytest.mark.parametrize("form", rising_form)
+@pytest.mark.parametrize("lineshape", ['step', 'rectangle'])
+def test_form_argument_step_rectangle(form, lineshape):
+    """Test 'form' argument for step- and rectangle-functions."""
+    xvals = np.linspace(0, 10, 100)
+
+    func = getattr(lmfit.lineshapes, lineshape)
+    sig = inspect.signature(func)
+
+    fnc_args = [xvals]
+    for par in [par_name for par_name in sig.parameters.keys()
+                if par_name != 'x']:
+        if par == 'form':
+            fnc_args.append(form)
+        else:
+            fnc_args.append(sig.parameters[par].default)
+
+    if form == 'unknown':
+        msg = r"Invalid value .* for argument .*; should be one of .*"
+        with pytest.raises(ValueError, match=msg):
+            func(*fnc_args)
+    else:
+        fnc_output = func(*fnc_args)
+        assert len(fnc_output) == len(xvals)
+
+
+thermal_form = ['bose', 'maxwell', 'fermi', 'Bose-Einstein', 'unknown']
+@pytest.mark.parametrize("form", thermal_form)
+def test_form_argument_thermal_distribution(form):
+    """Test 'form' argument for thermal_distribution function."""
+    xvals = np.linspace(0, 10, 100)
+
+    func = lmfit.lineshapes.thermal_distribution
+    sig = inspect.signature(lmfit.lineshapes.thermal_distribution)
+
+    fnc_args = [xvals]
+    for par in [par_name for par_name in sig.parameters.keys()
+                if par_name != 'x']:
+        if par == 'form':
+            fnc_args.append(form)
+        else:
+            fnc_args.append(sig.parameters[par].default)
+
+    if form == 'unknown':
+        msg = r"Invalid value .* for argument .*; should be one of .*"
+        with pytest.raises(ValueError, match=msg):
+            func(*fnc_args)
+    else:
+        fnc_output = func(*fnc_args)
+        assert len(fnc_output) == len(xvals)


### PR DESCRIPTION
#### Description
This PR contains changes to `lineshapes.py` and its test-suite:
- remove unused `assert_results_close` function
- remove unused `_<func>` functions that shadow the ones in `scipy`
- separate tests for lineshapes and built-in models into two different files
- explicit checking/testing of `form` argument
- minor corrections in docstrings and fix a 'wrong continued indentation'
- use `max(tiny, [decay|expon|sigma])`, where `tiny = np.finfo(np.float64).eps` in `exponential`, `pearson7`, and `logistic` to make sure the functions always give a finite result and there is no `ZeroDivisionError`. I think it's correct like this, but please check.

I've been working on some more explicit for the individual lineshape function, but that's not completely finished yet. I'd prefer to see the response to this PR first and will finish up the test-suite later.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactoring / maintenance
- [x] Test-suite


###### Tested on
Python: 3.8.2 (default, Feb 27 2020, 15:26:21)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 1.0.0+37.g75a4ce8, scipy: 1.4.1, numpy: 1.18.2, asteval: 0.9.18, uncertainties: 3.1.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] included docstrings that follow PEP 257?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?