### PR TITLE
Remove PY2-compatibility code and fixes prompted by static-code analysis

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,11 +19,15 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
     -   id: requirements-txt-fixer
+    -   id: fix-encoding-pragma
+        args: [--remove]
+    -   id: mixed-line-ending
 
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:
     -   id: flake8
+        additional_dependencies: [flake8-deprecated, flake8-mutable]
 
 -   repo: local
     hooks:
@@ -48,3 +52,8 @@ repos:
         # escaped characters currently do not work correctly
         # so \nnumber is considered a spelling error....
         args: [-L nnumber]
+
+-   repo: https://github.com/asottile/yesqa
+    rev: v1.1.0
+    hooks:
+    -   id: yesqa

--- a/examples/doc_model_with_iter_callback.py
+++ b/examples/doc_model_with_iter_callback.py
@@ -6,8 +6,8 @@ from lmfit.lineshapes import gaussian
 from lmfit.models import GaussianModel, LinearModel
 
 
-def per_iteration(pars, iter, resid, *args, **kws):
-    print(" ITER ", iter, ["%.5f" % p for p in pars.values()])
+def per_iteration(pars, iteration, resid, *args, **kws):
+    print(" ITER ", iteration, ["%.5f" % p for p in pars.values()])
 
 
 x = linspace(0., 20, 401)

--- a/examples/example_Model_interface.py
+++ b/examples/example_Model_interface.py
@@ -25,7 +25,7 @@ def decay(t, N, tau):
 # The parameters are in no particular order. We'll need some example data. I
 # will use ``N=7`` and ``tau=3``, and add a little noise.
 t = np.linspace(0, 5, num=1000)
-data = decay(t, 7, 3) + np.random.randn(*t.shape)
+data = decay(t, 7, 3) + np.random.randn(t.size)
 
 ###############################################################################
 # **Simplest Usage**

--- a/examples/example_brute.py
+++ b/examples/example_brute.py
@@ -15,6 +15,7 @@ Global minimization using the ``brute`` method (a.k.a. grid search)
 import copy
 
 import matplotlib.pyplot as plt
+from matplotlib.colors import LogNorm
 import numpy as np
 
 from lmfit import Minimizer, Parameters, fit_report
@@ -56,19 +57,20 @@ params.add_many(
 def f1(p):
     par = p.valuesdict()
     return (par['a'] * par['x']**2 + par['b'] * par['x'] * par['y'] +
-            par['c'] * par['y']**2 + par['d']*par['x'] + par['e']*par['y'] + par['f'])
+            par['c'] * par['y']**2 + par['d']*par['x'] + par['e']*par['y'] +
+            par['f'])
 
 
 def f2(p):
     par = p.valuesdict()
     return (-1.0*par['g']*np.exp(-((par['x']-par['h'])**2 +
-            (par['y']-par['i'])**2) / par['scale']))
+                                   (par['y']-par['i'])**2) / par['scale']))
 
 
 def f3(p):
     par = p.valuesdict()
     return (-1.0*par['j']*np.exp(-((par['x']-par['k'])**2 +
-            (par['y']-par['l'])**2) / par['scale']))
+                                   (par['y']-par['l'])**2) / par['scale']))
 
 
 def f(params):
@@ -185,7 +187,8 @@ par_name = 'shift'
 indx_shift = result_brute.var_names.index(par_name)
 grid_shift = np.unique(result_brute.brute_grid[indx_shift].ravel())
 print("parameter = {}\nnumber of steps = {}\ngrid = {}".format(par_name,
-      len(grid_shift), grid_shift))
+                                                               len(grid_shift),
+                                                               grid_shift))
 
 ###############################################################################
 # If finite bounds are not set for a certain parameter then the user **must**
@@ -311,10 +314,8 @@ def plot_results_brute(result, best_vals=True, varlabels=None,
     output : str, optional
         Name of the output PDF file (default is 'None')
     """
-    from matplotlib.colors import LogNorm
-
     npars = len(result.var_names)
-    fig, axes = plt.subplots(npars, npars)
+    _fig, axes = plt.subplots(npars, npars)
 
     if not varlabels:
         varlabels = result.var_names
@@ -366,7 +367,7 @@ def plot_results_brute(result, best_vals=True, varlabels=None,
             # contour plots for all combinations of two parameters
             elif j > i:
                 ax = axes[j, i+1]
-                red_axis = tuple([a for a in range(npars) if a != i and a != j])
+                red_axis = tuple([a for a in range(npars) if a not in (i, j)])
                 X, Y = np.meshgrid(np.unique(result.brute_grid[i]),
                                    np.unique(result.brute_grid[j]))
                 lvls1 = np.linspace(result.brute_Jout.min(),

--- a/examples/example_complex_resonator_model.py
+++ b/examples/example_complex_resonator_model.py
@@ -32,7 +32,7 @@ import lmfit
 
 def linear_resonator(f, f_0, Q, Q_e_real, Q_e_imag):
     Q_e = Q_e_real + 1j*Q_e_imag
-    return (1 - (Q * Q_e**-1 / (1 + 2j * Q * (f - f_0) / f_0)))
+    return 1 - (Q * Q_e**-1 / (1 + 2j * Q * (f - f_0) / f_0))
 
 
 ###############################################################################

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -133,8 +133,6 @@ class MinimizerException(Exception):
 class AbortFitException(MinimizerException):
     """Raised when a fit is aborted by the user."""
 
-    pass
-
 
 SCALAR_METHODS = {'nelder': 'Nelder-Mead',
                   'powell': 'Powell',
@@ -693,7 +691,6 @@ class Minimizer:
         removes AST compilations of constraint expressions.
 
         """
-        pass
 
     def _calculate_covariance_matrix(self, fvars):
         """Calculate the covariance matrix.
@@ -1377,7 +1374,6 @@ class Minimizer:
             result.acor = self.sampler.get_autocorr_time()
         except AutocorrError as e:
             print(str(e))
-            pass
         result.acceptance_fraction = self.sampler.acceptance_fraction
 
         # Calculate the residual with the "best fit" parameters
@@ -1570,7 +1566,7 @@ class Minimizer:
             pass
 
         if not result.aborted:
-            _best, _cov, infodict, errmsg, ier = lsout
+            _best, _cov, _infodict, errmsg, ier = lsout
             result.residual = self.__residual(_best)
             result.nfev -= 1
         result._calculate_statistics()
@@ -1754,7 +1750,7 @@ class Minimizer:
         brute_kws = dict(full_output=1, finish=None, disp=False)
         # keyword 'workers' is introduced in SciPy v1.3
         # FIXME: remove this check after updating the requirement >= 1.3
-        major, minor, micro = scipy_version.split('.', 2)
+        major, minor, _micro = scipy_version.split('.', 2)
 
         if int(major) == 1 and int(minor) >= 3:
             brute_kws.update({'workers': workers})

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -36,7 +36,7 @@ def _align(var, mask, data):
 
 
 try:
-    import matplotlib  # noqa: F401
+    from matplotlib import pyplot as plt
     _HAS_MATPLOTLIB = True
 except Exception:
     _HAS_MATPLOTLIB = False
@@ -435,7 +435,6 @@ class Model:
 
     def _set_paramhints_prefix(self):
         """Reset parameter hints for prefix: intended to be overwritten."""
-        pass
 
     @property
     def param_names(self):
@@ -2036,7 +2035,6 @@ class ModelResult(Minimizer):
         ModelResult.plot_residuals : Plot the fit residuals using matplotlib.
 
         """
-        from matplotlib import pyplot as plt
         if data_kws is None:
             data_kws = {}
         if fit_kws is None:

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -5,7 +5,6 @@ from functools import wraps
 import inspect
 import json
 import operator
-import sys
 import warnings
 
 import numpy as np
@@ -467,7 +466,7 @@ class Model:
             for name, defval in self.func.kwargs:
                 kw_args[name] = defval
         # 2. modern, best-practice approach: use inspect.signature
-        elif sys.version_info > (3, 4):
+        else:
             pos_args = []
             kw_args = {}
             keywords_ = None
@@ -482,15 +481,6 @@ class Model:
                         kw_args[fnam] = fpar.default
                 elif fpar.kind == fpar.VAR_POSITIONAL:
                     raise ValueError("varargs '*%s' is not supported" % fnam)
-        # 3. Py2 compatible approach
-        else:
-            argspec = inspect.getargspec(self.func)
-            keywords_ = argspec.keywords
-            pos_args = argspec.args
-            kw_args = {}
-            if argspec.defaults is not None:
-                for val in reversed(argspec.defaults):
-                    kw_args[pos_args.pop()] = val
         # inspection done
 
         self._func_haskeywords = keywords_ is not None

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -19,8 +19,6 @@ tiny = np.finfo(np.float).eps
 class DimensionalError(Exception):
     """Raise exception when number of independent variables is not one."""
 
-    pass
-
 
 def _validate_1d(independent_vars):
     if len(independent_vars) != 1:
@@ -1325,4 +1323,3 @@ class ExpressionModel(Model):
         This prevents normal parsing of function for parameter names.
 
         """
-        pass

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ parentdir_prefix = lmfit-
 
 [isort]
 skip=versioneer.py,lmfit/_version.py,lmfit/__init__.py,doc/conf.py
-known_third_party=asteval,dill,emcee,IPython,matplotlib,numdifftools,numpy,NISTModels,pandas,pytest,scipy,six,uncertainties
+known_third_party=asteval,dill,emcee,IPython,matplotlib,numdifftools,numpy,NISTModels,pandas,pytest,scipy,uncertainties
 known_first_party=lmfit
 force_sort_within_sections=True
 

--- a/tests/lmfit_testutils.py
+++ b/tests/lmfit_testutils.py
@@ -5,8 +5,7 @@ from lmfit import Parameter
 
 def assert_paramval(param, val, tol=1.e-3):
     """assert that a named parameter's value is close to expected value"""
-
-    assert(isinstance(param, Parameter))
+    assert isinstance(param, Parameter)
     pval = param.value
 
     assert_allclose([pval], [val], rtol=tol, atol=tol,
@@ -15,20 +14,18 @@ def assert_paramval(param, val, tol=1.e-3):
 
 def assert_paramattr(param, attr, val):
     """assert that a named parameter's value is a value"""
-    assert(isinstance(param, Parameter))
-    assert(hasattr(param, attr))
-    assert(getattr(param, attr) == val)
+    assert isinstance(param, Parameter)
+    assert hasattr(param, attr)
+    assert getattr(param, attr) == val
 
 
 def assert_between(val, minval, maxval):
     """assert that a value is between minval and maxval"""
-    assert(val >= minval)
-    assert(val <= maxval)
+    assert val >= minval
+    assert val <= maxval
 
 
 def assert_param_between(param, minval, maxval):
-    """assert that a named parameter's value is
-    between minval and maxval"""
-
-    assert(isinstance(param, Parameter))
+    """assert that a named parameter's value is between minval and maxval"""
+    assert isinstance(param, Parameter)
     assert_between(param.value, minval, maxval)

--- a/tests/test_1variable.py
+++ b/tests/test_1variable.py
@@ -43,7 +43,7 @@ def test_1var():
     out = lmfit.minimize(linear_chisq, params, args=(x, y))
 
     assert_allclose(params['m'].value, 1.025, rtol=0.02, atol=0.02)
-    assert(len(params) == 2)
-    assert(out.nvarys == 1)
-    assert(out.chisqr > 0.01)
-    assert(out.chisqr < 5.00)
+    assert len(params) == 2
+    assert out.nvarys == 1
+    assert out.chisqr > 0.01
+    assert out.chisqr < 5.00

--- a/tests/test_basicfit.py
+++ b/tests/test_basicfit.py
@@ -31,9 +31,9 @@ def test_basic():
     # do fit, here with leastsq model
     result = minimize(fcn2min, params, args=(x, data))
 
-    assert(result.nfev > 5)
-    assert(result.nfev < 500)
-    assert(result.chisqr > 1)
-    assert(result.nvarys == 4)
+    assert result.nfev > 5
+    assert result.nfev < 500
+    assert result.chisqr > 1
+    assert result.nvarys == 4
     assert_paramval(result.params['amp'], 5.03, tol=0.05)
     assert_paramval(result.params['omega'], 2.0, tol=0.05)

--- a/tests/test_bounded_jacobian.py
+++ b/tests/test_bounded_jacobian.py
@@ -28,10 +28,10 @@ def test_bounded_jacobian():
 
     assert_paramval(out0.params['x0'], 1.2243, tol=0.02)
     assert_paramval(out0.params['x1'], 1.5000, tol=0.02)
-    assert(jac_count == 0)
+    assert jac_count == 0
 
     out1 = minimize(resid, pars, Dfun=jac)
 
     assert_paramval(out1.params['x0'], 1.2243, tol=0.02)
     assert_paramval(out1.params['x1'], 1.5000, tol=0.02)
-    assert(jac_count > 5)
+    assert jac_count > 5

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -23,7 +23,7 @@ def test_bounds():
         model = amp*sin(shift + x/per) * exp(-x*x*decay*decay)
         if data is None:
             return model
-        return (model - data)
+        return model - data
 
     n = 1500
     xmin = 0.
@@ -41,9 +41,9 @@ def test_bounds():
 
     out = minimize(residual, fit_params, args=(x,), kws={'data': data})
 
-    assert(out.nfev > 10)
-    assert(out.nfree > 50)
-    assert(out.chisqr > 1.0)
+    assert out.nfev > 10
+    assert out.nfree > 50
+    assert out.chisqr > 1.0
 
     assert_paramval(out.params['decay'], 0.01, tol=1.e-2)
     assert_paramval(out.params['shift'], 0.123, tol=1.e-2)

--- a/tests/test_covariance_matrix.py
+++ b/tests/test_covariance_matrix.py
@@ -12,7 +12,7 @@ from lmfit.models import ExponentialModel, VoigtModel
 
 def check(para, real_val, sig=3):
     err = abs(para.value - real_val)
-    assert(err < sig * para.stderr)
+    assert err < sig * para.stderr
 
 
 def test_bounded_parameters():

--- a/tests/test_custom_independentvar.py
+++ b/tests/test_custom_independentvar.py
@@ -33,13 +33,13 @@ def test_custom_independentvar():
     params = gmod.make_params(amplitude=2, center=5, sigma=8)
     out = gmod.fit(y, params, obj=obj)
 
-    assert(out.nvarys == 3)
-    assert(out.nfev > 10)
-    assert(out.chisqr > 1)
-    assert(out.chisqr < 100)
-    assert(out.params['sigma'].value < 3)
-    assert(out.params['sigma'].value > 2)
-    assert(out.params['center'].value > xmin)
-    assert(out.params['center'].value < xmax)
-    assert(out.params['amplitude'].value > 1)
-    assert(out.params['amplitude'].value < 5)
+    assert out.nvarys == 3
+    assert out.nfev > 10
+    assert out.chisqr > 1
+    assert out.chisqr < 100
+    assert out.params['sigma'].value < 3
+    assert out.params['sigma'].value > 2
+    assert out.params['center'].value > xmin
+    assert out.params['center'].value < xmax
+    assert out.params['amplitude'].value > 1
+    assert out.params['amplitude'].value < 5

--- a/tests/test_default_kws.py
+++ b/tests/test_default_kws.py
@@ -21,4 +21,4 @@ def test_default_inputs_gauss():
     result2 = g.fit(y, x=x, amplitude=1, center=0, sigma=0.5,
                     fit_kws=fit_option2)
 
-    assert(result1.values != result2.values)
+    assert result1.values != result2.values

--- a/tests/test_itercb.py
+++ b/tests/test_itercb.py
@@ -29,9 +29,9 @@ pars['peak_center'].set(min=5, max=10)
 pars['peak_sigma'].set(min=0.5, max=2)
 
 
-def per_iteration(pars, iter, resid, *args, **kws):
+def per_iteration(pars, iteration, resid, *args, **kws):
     """Iteration callback, will abort at iteration 23."""
-    return iter == 23
+    return iteration == 23
 
 
 @pytest.mark.parametrize("calc_covar", calc_covar_options)

--- a/tests/test_manypeaks_speed.py
+++ b/tests/test_manypeaks_speed.py
@@ -25,11 +25,11 @@ def test_manypeaks_speed():
     t1 = time.time()
     pars = model.make_params()
     t2 = time.time()
-    cpars = deepcopy(pars)  # noqa: F841
+    _cpars = deepcopy(pars)  # noqa: F841
     t3 = time.time()
 
     # these are very conservative tests that
     # should be satisfied on nearly any machine
-    assert((t3-t2) < 0.5)
-    assert((t2-t1) < 0.5)
-    assert((t1-t0) < 5.0)
+    assert (t3-t2) < 0.5
+    assert (t2-t1) < 0.5
+    assert (t1-t0) < 5.0

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -234,10 +234,6 @@ class CommonTests:
 class TestUserDefiniedModel(CommonTests, unittest.TestCase):
     # mainly aimed at checking that the API does what it says it does
     # and raises the right exceptions or warnings when things are not right
-    import six
-    if six.PY2:
-        from six import assertRaisesRegex
-
     def setUp(self):
         self.true_values = lambda: dict(amplitude=7.1, center=1.1, sigma=2.40)
         self.guess = lambda: dict(amplitude=5, center=2, sigma=4)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -47,7 +47,7 @@ class CommonTests:
 
     def setUp(self):
         np.random.seed(1)
-        self.noise = 0.0001*np.random.randn(*self.x.shape)
+        self.noise = 0.0001*np.random.randn(self.x.size)
         # Some Models need args (e.g., polynomial order), and others don't.
         try:
             args = self.args
@@ -347,7 +347,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
             set_prefix_failed = False
         except AttributeError:
             set_prefix_failed = True
-        except:  # noqa: E722
+        except Exception:
             set_prefix_failed = None
         self.assertFalse(set_prefix_failed)
 
@@ -495,7 +495,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         self.assertTrue(abs(result.params['g1_center'].value - 1.1) < 0.2)
         self.assertTrue(abs(result.params['g2_center'].value - 2.5) < 0.2)
 
-        for name, par in pars.items():
+        for _, par in pars.items():
             assert len(repr(par)) > 5
 
     def test_composite_plotting(self):
@@ -561,7 +561,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         m2 = models.GaussianModel(prefix='m2_')
         params.update(m2.make_params())
 
-        m = m1 + m2  # noqa: F841
+        _m = m1 + m2  # noqa: F841
 
         param_values = {name: p.value for name, p in params.items()}
         self.assertTrue(param_values['m1_intercept'] < -0.0)

--- a/tests/test_model_uncertainties.py
+++ b/tests/test_model_uncertainties.py
@@ -74,8 +74,8 @@ def test_gauss_sigmalevel():
     dely_sigma2 = ret.eval_uncertainty(sigma=2)
     dely_sigma3 = ret.eval_uncertainty(sigma=3)
 
-    assert(dely_sigma3.mean() > 1.5*dely_sigma2.mean())
-    assert(dely_sigma2.mean() > 1.5*dely_sigma1.mean())
+    assert dely_sigma3.mean() > 1.5*dely_sigma2.mean()
+    assert dely_sigma2.mean() > 1.5*dely_sigma1.mean()
 
 
 def test_gauss_noiselevel():

--- a/tests/test_multidatasets.py
+++ b/tests/test_multidatasets.py
@@ -18,7 +18,7 @@ def gauss_dataset(params, i, x):
 def objective(params, x, data):
     """ calculate total residual for fits to several data sets held
     in a 2-D array, and modeled by Gaussian functions"""
-    ndata, nx = data.shape
+    ndata, _ = data.shape
     resid = 0.0*data[:]
     # make residual per data set
     for i in range(ndata):
@@ -31,7 +31,7 @@ def test_multidatasets():
     # create 5 datasets
     x = np.linspace(-1, 2, 151)
     data = []
-    for i in np.arange(5):
+    for _ in np.arange(5):
         amp = 2.60 + 1.50*np.random.rand()
         cen = -0.20 + 1.50*np.random.rand()
         sig = 0.25 + 0.03*np.random.rand()
@@ -41,11 +41,11 @@ def test_multidatasets():
 
     # data has shape (5, 151)
     data = np.array(data)
-    assert(data.shape) == (5, 151)
+    assert data.shape == (5, 151)
 
     # create 5 sets of parameters, one per data set
     pars = Parameters()
-    for iy, y in enumerate(data):
+    for iy, _ in enumerate(data):
         pars.add('amp_%i' % (iy+1), value=0.5, min=0.0, max=200)
         pars.add('cen_%i' % (iy+1), value=0.4, min=-2.0, max=2.0)
         pars.add('sig_%i' % (iy+1), value=0.3, min=0.01, max=3.0)
@@ -58,10 +58,10 @@ def test_multidatasets():
     # run the global fit to all the data sets
     out = minimize(objective, pars, args=(x, data))
 
-    assert(len(pars) == 15)
-    assert(out.nvarys == 11)
-    assert(out.nfev > 15)
-    assert(out.chisqr > 1.0)
-    assert(pars['amp_1'].value > 0.1)
-    assert(pars['sig_1'].value > 0.1)
-    assert(pars['sig_2'].value == pars['sig_1'].value)
+    assert len(pars) == 15
+    assert out.nvarys == 11
+    assert out.nfev > 15
+    assert out.chisqr > 1.0
+    assert pars['amp_1'].value > 0.1
+    assert pars['sig_1'].value > 0.1
+    assert pars['sig_2'].value == pars['sig_1'].value

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -2,8 +2,8 @@ import unittest
 
 import numpy as np
 from numpy import pi
-from numpy.testing import (assert_, assert_allclose, assert_almost_equal,
-                           assert_equal, dec)
+from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
+                           dec)
 import pytest
 from uncertainties import ufloat
 
@@ -15,12 +15,12 @@ from lmfit.minimizer import (HAS_EMCEE, SCALAR_METHODS, MinimizerResult,
 
 def check(para, real_val, sig=3):
     err = abs(para.value - real_val)
-    assert(err < sig * para.stderr)
+    assert err < sig * para.stderr
 
 
 def check_wo_stderr(para, real_val, sig=0.1):
     err = abs(para.value - real_val)
-    assert(err < sig)
+    assert err < sig
 
 
 def check_paras(para_fit, para_real, sig=3):
@@ -79,7 +79,7 @@ def test_lbfgsb():
         model = amp * np.sin(shift + x / per) * np.exp(-x * x * decay * decay)
         if data is None:
             return model
-        return (model - data)
+        return model - data
 
     n = 2500
     xmin = 0.
@@ -150,7 +150,7 @@ def test_peakfit():
         model = g1 + g2
         if data is None:
             return model
-        return (model - data)
+        return model - data
 
     n = 601
     xmin = 0.
@@ -219,17 +219,17 @@ def test_scalar_minimize_has_no_uncertainties():
 
     mini = Minimizer(fcn2min, params, fcn_args=(x, data))
     out = mini.minimize()
-    assert_(np.isfinite(out.params['amp'].stderr))
+    assert np.isfinite(out.params['amp'].stderr)
     assert out.errorbars
     out2 = mini.minimize(method='nelder-mead')
-    assert_(out2.params['amp'].stderr is None)
-    assert_(out2.params['decay'].stderr is None)
-    assert_(out2.params['shift'].stderr is None)
-    assert_(out2.params['omega'].stderr is None)
-    assert_(out2.params['amp'].correl is None)
-    assert_(out2.params['decay'].correl is None)
-    assert_(out2.params['shift'].correl is None)
-    assert_(out2.params['omega'].correl is None)
+    assert out2.params['amp'].stderr is None
+    assert out2.params['decay'].stderr is None
+    assert out2.params['shift'].stderr is None
+    assert out2.params['omega'].stderr is None
+    assert out2.params['amp'].correl is None
+    assert out2.params['decay'].correl is None
+    assert out2.params['shift'].correl is None
+    assert out2.params['omega'].correl is None
     assert not out2.errorbars
 
 
@@ -282,7 +282,7 @@ def test_multidimensional_fit_GH205():
                                           np.cos(yv * lambda2))
 
     data = f(xv, yv, 0.3, 3)
-    assert_(data.ndim, 2)
+    assert data.ndim, 2
 
     def fcn2min(params, xv, yv, data):
         """model decaying sine wave, subtract data"""
@@ -414,12 +414,12 @@ class CommonMinimizerTest(unittest.TestCase):
     def test_nan_policy_function(self):
         a = np.array([0, 1, 2, 3, np.nan])
         pytest.raises(ValueError, _nan_policy, a)
-        assert_(np.isnan(_nan_policy(a, nan_policy='propagate')[-1]))
+        assert np.isnan(_nan_policy(a, nan_policy='propagate')[-1])
         assert_equal(_nan_policy(a, nan_policy='omit'), [0, 1, 2, 3])
 
         a[-1] = np.inf
         pytest.raises(ValueError, _nan_policy, a)
-        assert_(np.isposinf(_nan_policy(a, nan_policy='propagate')[-1]))
+        assert np.isposinf(_nan_policy(a, nan_policy='propagate')[-1])
         assert_equal(_nan_policy(a, nan_policy='omit'), [0, 1, 2, 3])
         assert_equal(_nan_policy(a, handle_inf=False), a)
 
@@ -516,11 +516,11 @@ class CommonMinimizerTest(unittest.TestCase):
 
         # if you've run the sampler the Minimizer object should have a _lastpos
         # attribute
-        assert_(hasattr(self.mini, '_lastpos'))
+        assert hasattr(self.mini, '_lastpos')
 
         # now try and re-use sampler
         out2 = self.mini.emcee(steps=10, reuse_sampler=True)
-        assert_(out2.chain.shape == (35, 20, 4))
+        assert out2.chain.shape == (35, 20, 4)
 
         # you shouldn't be able to reuse the sampler if nvarys has changed.
         self.mini.params['amp'].vary = False
@@ -563,23 +563,23 @@ class CommonMinimizerTest(unittest.TestCase):
         except ImportError:
             return True
         out = self.mini.emcee(nwalkers=10, steps=20, burn=5, thin=2)
-        assert_(isinstance(out, MinimizerResult))
-        assert_(isinstance(out.flatchain, DataFrame))
+        assert isinstance(out, MinimizerResult)
+        assert isinstance(out.flatchain, DataFrame)
 
         # check that we can access the chains via parameter name
         # print( out.flatchain['amp'].shape[0],  200)
-        assert_(out.flatchain['amp'].shape[0] == 70)
+        assert out.flatchain['amp'].shape[0] == 70
         assert out.errorbars
-        assert_(np.isfinite(out.params['amp'].correl['period']))
+        assert np.isfinite(out.params['amp'].correl['period'])
 
         # the lnprob array should be the same as the chain size
-        assert_(np.size(out.chain)//out.nvarys == np.size(out.lnprob))
+        assert np.size(out.chain)//out.nvarys == np.size(out.lnprob)
 
         # test chain output shapes
         print(out.lnprob.shape, out.chain.shape, out.flatchain.shape)
-        assert_(out.lnprob.shape == (7, 10))
-        assert_(out.chain.shape == (7, 10, 4))
-        assert_(out.flatchain.shape == (70, 4))
+        assert out.lnprob.shape == (7, 10)
+        assert out.chain.shape == (7, 10, 4)
+        assert out.flatchain.shape == (70, 4)
 
     @dec.slow
     def test_emcee_float(self):
@@ -642,4 +642,4 @@ def residual_for_multiprocessing(pars, x, data=None):
     model = amp*np.sin(shift + x/per) * np.exp(-x*x*decay*decay)
     if data is None:
         return model
-    return (model - data)
+    return model - data

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,24 @@
+"""Tests for using data in pandas.[DataFrame|Series]."""
+import os
+
+import numpy as np
+import pytest
+
+import lmfit
+
+pandas = pytest.importorskip('pandas')
+
+
+def test_pandas_guess_from_peak():
+    """Regression test for failure in guess_from_peak with pandas (GH #629)."""
+    data = pandas.read_csv(os.path.join(os.path.dirname(__file__), '..',
+                                        'examples', 'peak.csv'))
+    xdat, ydat = np.loadtxt(os.path.join(os.path.dirname(__file__), '..',
+                                         'examples', 'peak.csv'),
+                            unpack=True, skiprows=1, delimiter=',')
+
+    model = lmfit.models.LorentzianModel()
+    guess_pd = model.guess(data['y'], x=data['x'])
+    guess = model.guess(ydat, x=xdat)
+
+    assert guess_pd == guess

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -187,7 +187,7 @@ def test_parameter_set_expr(parameter):
 
 def test_parameters_set_value_with_expr(parameters):
     """Test the Parameter.set() function with value in presence of expr."""
-    pars, init_attr_values_A, init_attr_values_B = parameters
+    pars, _, _ = parameters
 
     pars['a'].set(value=5.0)
     pars.update_constraints()  # update constraints/expressions
@@ -207,7 +207,7 @@ def test_parameters_set_value_with_expr(parameters):
 
 def test_parameters_set_vary_with_expr(parameters):
     """Test the Parameter.set() function with vary in presence of expr."""
-    pars, init_attr_values_A, init_attr_values_B = parameters
+    pars, init_attr_values_A, _ = parameters
 
     pars['b'].set(vary=True)  # expression should get cleared
     pars.update_constraints()  # update constraints/expressions
@@ -277,7 +277,7 @@ def test_setstate(parameter):
 
 def test_parameter_pickle_(parameter):
     """Test that we can pickle a Parameter."""
-    par, initial_attribute_values = parameter
+    par, _ = parameter
     pkl = pickle.dumps(par)
     loaded_par = pickle.loads(pkl)
 
@@ -477,45 +477,45 @@ def test__pow__(parameter):
 def test__gt__(parameter):
     """Test the __gt__ magic method."""
     par, _ = parameter
-    assert 11 > par
-    assert not 10 > par
+    assert par < 11
+    assert not par < 10
 
 
 def test__ge__(parameter):
     """Test the __ge__ magic method."""
     par, _ = parameter
-    assert 11 >= par
-    assert 10 >= par
-    assert not 9 >= par
+    assert par <= 11
+    assert par <= 10
+    assert not par <= 9
 
 
 def test__le__(parameter):
     """Test the __le__ magic method."""
     par, _ = parameter
-    assert 9 <= par
-    assert 10 <= par
-    assert not 11 <= par
+    assert par >= 9
+    assert par >= 10
+    assert not par >= 11
 
 
 def test__lt__(parameter):
     """Test the __lt__ magic method."""
     par, _ = parameter
-    assert 9 < par
-    assert not 10 < par
+    assert par > 9
+    assert not par > 10
 
 
 def test__eq__(parameter):
     """Test the __eq__ magic method."""
     par, _ = parameter
-    assert 10 == par
-    assert not 9 == par
+    assert par == 10
+    assert not par == 9
 
 
 def test__ne__(parameter):
     """Test the __ne__ magic method."""
     par, _ = parameter
-    assert 9 != par
-    assert not 10 != par
+    assert par != 9
+    assert not par != 10
 
 
 def test__radd__(parameter):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -45,7 +45,7 @@ def test_check_ast_errors():
         pars.add('par1', expr='2.0*par2')
 
 
-def test_parameters_init(parameters):
+def test_parameters_init():
     """Test for initialization of the Parameters class"""
     ast_int = asteval.Interpreter()
     pars = lmfit.Parameters(asteval=ast_int, usersyms={'test': np.sin})
@@ -74,7 +74,7 @@ def test_parameters_copy(parameters):
 
 def test_parameters_deepcopy(parameters):
     """Tests for deepcopy of a Parameters class."""
-    pars, exp_attr_values_A, exp_attr_values_B = parameters
+    pars, _, _ = parameters
 
     deepcopy_pars = deepcopy(pars)
     assert isinstance(deepcopy_pars, lmfit.Parameters)
@@ -124,7 +124,7 @@ def test_parameters_update(parameters):
 
 def test_parameters__setitem__(parameters):
     """Tests for __setitem__ method of a Parameters class."""
-    pars, exp_attr_values_A, exp_attr_values_B = parameters
+    pars, _, exp_attr_values_B = parameters
 
     msg = r"'10' is not a valid Parameters name"
     with pytest.raises(KeyError, match=msg):
@@ -185,7 +185,7 @@ def test_parameters__iadd__(parameters):
     assert_parameter_attributes(pars['d'], exp_attr_values_D)
 
 
-def test_parameters_add_with_symtable(parameters):
+def test_parameters_add_with_symtable():
     """Regression test for GitHub Issue 607."""
     pars1 = lmfit.Parameters()
     pars1.add('a', value=1.0)

--- a/tests/test_stepmodel.py
+++ b/tests/test_stepmodel.py
@@ -23,15 +23,15 @@ def test_stepmodel_linear():
 
     out = mod.fit(y, pars, x=x)
 
-    assert(out.nfev > 5)
-    assert(out.nvarys == 4)
-    assert(out.chisqr > 1)
-    assert(out.params['c'].value > 3)
-    assert(out.params['center'].value > 1)
-    assert(out.params['center'].value < 4)
-    assert(out.params['sigma'].value > 0.5)
-    assert(out.params['sigma'].value < 3.5)
-    assert(out.params['amplitude'].value > 50)
+    assert out.nfev > 5
+    assert out.nvarys == 4
+    assert out.chisqr > 1
+    assert out.params['c'].value > 3
+    assert out.params['center'].value > 1
+    assert out.params['center'].value < 4
+    assert out.params['sigma'].value > 0.5
+    assert out.params['sigma'].value < 3.5
+    assert out.params['amplitude'].value > 50
 
 
 def test_stepmodel_erf():
@@ -44,12 +44,12 @@ def test_stepmodel_erf():
 
     out = mod.fit(y, pars, x=x)
 
-    assert(out.nfev > 5)
-    assert(out.nvarys == 4)
-    assert(out.chisqr > 1)
-    assert(out.params['c'].value > 3)
-    assert(out.params['center'].value > 1)
-    assert(out.params['center'].value < 4)
-    assert(out.params['amplitude'].value > 50)
-    assert(out.params['sigma'].value > 0.2)
-    assert(out.params['sigma'].value < 1.5)
+    assert out.nfev > 5
+    assert out.nvarys == 4
+    assert out.chisqr > 1
+    assert out.params['c'].value > 3
+    assert out.params['center'].value > 1
+    assert out.params['center'].value < 4
+    assert out.params['amplitude'].value > 50
+    assert out.params['sigma'].value > 0.2
+    assert out.params['sigma'].value < 1.5


### PR DESCRIPTION
#### Description
This PR does the following:
- remove PY2 compatibility code
- adds a test file for `pandas` related tests, with an initial regression test for `guess_from_peak`
- adds a few `pre-commit` hooks
- style fixes and maintenance of many `.py` files

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples

###### Tested on
Python: 3.8.2 (default, Feb 27 2020, 15:26:21)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 1.0.0+50.g9990d4e, scipy: 1.4.1, numpy: 1.18.2, asteval: 0.9.18, uncertainties: 3.1.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?

