### PR TITLE
Fixed #636: updating a parameter with a new value and bounds uses the new bounds

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -631,10 +631,6 @@ class Parameter:
             par.set(brute_step=0)     # removes brute_step
 
         """
-        if value is not None:
-            self.value = value
-            self.__set_expression('')
-
         if vary is not None:
             self.vary = vary
             if vary:
@@ -645,6 +641,12 @@ class Parameter:
 
         if max is not None:
             self.max = max
+
+        # need to set this after min and max, so that it will use new
+        # bounds in the setter for value
+        if value is not None:
+            self.value = value
+            self.__set_expression("")
 
         if expr is not None:
             self.__set_expression(expr)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -8,7 +8,6 @@ from numpy.testing import assert_allclose
 import pytest
 
 import lmfit
-from lmfit_testutils import assert_paramval
 
 
 @pytest.fixture
@@ -126,14 +125,10 @@ def test_parameter_set_value(parameter):
     changed_attribute_values = ('a', 5.0, True, -100.0, 100.0, None, 5.0, 1)
     assert_parameter_attributes(par, changed_attribute_values)
 
-
-def test_parameter_change_value():
-    """Test if value can be set to a value that was previous out of bounds"""
-    p = lmfit.Parameter("test", value=5, min=4, max=10)
-    assert_paramval(p, 5, tol=1.0e-2)
-
-    p.set(value=22, min=20, max=30)
-    assert_paramval(p, 22, tol=1.0e-2)
+    # check if set value works with new bounds, see issue#636
+    par.set(value=500.0, min=400, max=600)
+    changed_attribute_values2 = ('a', 500.0, True, 400.0, 600.0, None, 5.0, 1)
+    assert_parameter_attributes(par, changed_attribute_values2)
 
 
 def test_parameter_set_vary(parameter):

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_allclose
 import pytest
 
 import lmfit
+from lmfit_testutils import assert_paramval
 
 
 @pytest.fixture
@@ -124,6 +125,15 @@ def test_parameter_set_value(parameter):
     par.set(value=5.0)
     changed_attribute_values = ('a', 5.0, True, -100.0, 100.0, None, 5.0, 1)
     assert_parameter_attributes(par, changed_attribute_values)
+
+
+def test_parameter_change_value():
+    """Test if value can be set to a value that was previous out of bounds"""
+    p = lmfit.Parameter("test", value=5, min=4, max=10)
+    assert_paramval(p, 5, tol=1.0e-2)
+
+    p.set(value=22, min=20, max=30)
+    assert_paramval(p, 22, tol=1.0e-2)
 
 
 def test_parameter_set_vary(parameter):


### PR DESCRIPTION
#### Description
fixes #636. The value got set first and only afterwards the new bounds got set.

I tried adding a test and then fixed the problem by just moving the code that sets the value to be executed after the new bounds have been set. 

###### Type of Changes

- [x ] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.7.6 (default, Jan  8 2020, 13:42:34) 
[Clang 4.0.1 (tags/RELEASE_401/final)]

lmfit: 1.0.0+44.g1607727.dirty, scipy: 1.4.1, numpy: 1.18.1, asteval: 0.9.18, uncertainties: 3.0.3

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x ] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ x] added or updated existing tests to cover the changes?
- [ ] updated the documentation?
- [ ] added an example?
