### PR TITLE
Add result call kws

### DIFF
--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -268,6 +268,8 @@ Goodness-of-Fit Statistics
 +----------------------+----------------------------------------------------------------------------+
 |    init_vals         | list of initial values for variable parameters                             |
 +----------------------+----------------------------------------------------------------------------+
+|    call_kws          | dict of keyword arguments sent to underlying solver                        |
++----------------------+----------------------------------------------------------------------------+
 
 Note that the calculation of chi-square and reduced chi-square assume
 that the returned residual function is scaled properly to the

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -726,6 +726,10 @@ comparing different models, including ``chisqr``, ``redchi``, ``aic``, and ``bic
 
    String naming fitting method for :func:`~lmfit.minimizer.minimize`.
 
+.. attribute::  call_kws
+
+   Dict of keyword arguments actually send to underlying solver with :func:`~lmfit.minimizer.minimize`.
+
 .. attribute::  model
 
    Instance of :class:`Model` used for model.

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -364,6 +364,7 @@ class MinimizerResult:
             self.nfree = 1
         self.redchi = self.chisqr / max(1, self.nfree)
         # this is -2*loglikelihood
+        self.chisqr = max(self.chisqr, 1.e-250*self.ndata)
         _neg2_log_likel = self.ndata * np.log(self.chisqr / self.ndata)
         self.aic = _neg2_log_likel + 2 * self.nvarys
         self.bic = _neg2_log_likel + np.log(self.ndata) * self.nvarys

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -697,6 +697,7 @@ class Minimizer:
         result.init_vals = []
         result.params.update_constraints()
         result.nfev = 0
+        result.call_kws = {}
         result.errorbars = False
         result.aborted = False
         for name, par in self.result.params.items():
@@ -971,12 +972,15 @@ class Minimizer:
                 if k in kwargs:
                     kwargs[k] = v
 
+            fmin_kws = kwargs
+            result.call_kws = fmin_kws
             try:
-                ret = differential_evolution(self.penalty, _bounds, **kwargs)
+                ret = differential_evolution(self.penalty, _bounds, **fmin_kws)
             except AbortFitException:
                 pass
 
         else:
+            result.call_kws = fmin_kws
             try:
                 ret = scipy_minimize(self.penalty, variables, **fmin_kws)
             except AbortFitException:
@@ -1430,6 +1434,7 @@ class Minimizer:
         result.errorbars = True
         result.nvarys = len(result.var_names)
         result.nfev = nwalkers*steps
+
         try:
             result.acor = self.sampler.get_autocorr_time()
         except AutocorrError as e:
@@ -1513,6 +1518,7 @@ class Minimizer:
             lower_bounds.append(replace_none(par.min, -1))
             upper_bounds.append(replace_none(par.max, 1))
 
+        result.call_kws = kws
         try:
             ret = least_squares(self.__residual, start_vals,
                                 bounds=(lower_bounds, upper_bounds),
@@ -1631,7 +1637,7 @@ class Minimizer:
         # suppress runtime warnings during fit and error analysis
         orig_warn_settings = np.geterr()
         np.seterr(all='ignore')
-
+        result.call_kws = lskws
         try:
             lsout = scipy_leastsq(self.__residual, variables, **lskws)
         except AbortFitException:
@@ -1722,7 +1728,7 @@ class Minimizer:
         basinhopping_kws.update(kws)
 
         x0 = result.init_vals
-
+        result.call_kws = basinhopping_kws
         try:
             ret = scipy_basinhopping(self.penalty, x0, **basinhopping_kws)
         except AbortFitException:
@@ -1829,7 +1835,7 @@ class Minimizer:
         result = self.prepare_fit(params=params)
         result.method = 'brute'
 
-        brute_kws = dict(full_output=1, finish=None, disp=False)
+        brute_kws = dict(full_output=1, finish=None, disp=False, Ns=Ns)
         # keyword 'workers' is introduced in SciPy v1.3
         # FIXME: remove this check after updating the requirement >= 1.3
         major, minor, _micro = scipy_version.split('.', 2)
@@ -1868,9 +1874,9 @@ class Minimizer:
                                  'least an initial value and brute_step for '
                                  'parameter "{}".'.format(result.var_names[i]))
             ranges.append(par_range)
-
+        result.call_kws = brute_kws
         try:
-            ret = scipy_brute(self.penalty, tuple(ranges), Ns=Ns, **brute_kws)
+            ret = scipy_brute(self.penalty, tuple(ranges), **brute_kws)
         except AbortFitException:
             pass
 
@@ -2000,7 +2006,7 @@ class Minimizer:
 
         values = result.init_vals
         result.method = "ampgo, with {} as local solver".format(ampgo_kws['local'])
-
+        result.call_kws = ampgo_kws
         try:
             ret = ampgo(self.penalty, values, **ampgo_kws)
         except AbortFitException:
@@ -2074,7 +2080,7 @@ class Minimizer:
         varying = np.asarray([par.vary for par in self.params.values()])
         bounds = np.asarray([(par.min, par.max) for par in
                              self.params.values()])[varying]
-
+        result.call_kws = shgo_kws
         try:
             ret = scipy_shgo(self.penalty, bounds, **shgo_kws)
         except AbortFitException:
@@ -2149,7 +2155,7 @@ class Minimizer:
         if not np.all(np.isfinite(bounds)):
             raise ValueError('dual_annealing requires finite bounds for all'
                              ' varying parameters')
-
+        result.call_kws = da_kws
         try:
             ret = scipy_dual_annealing(self.penalty, bounds, **da_kws)
         except AbortFitException:

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -267,6 +267,8 @@ class MinimizerResult:
         True if uncertainties were estimated, otherwise False.
     message : str
         Message about fit success.
+    call_kws : dict
+        Dict of keyword arguments sent to underlying solver method.
     ier : int
         Integer error value from :scipydoc:`optimize.leastsq` (`leastsq` only).
     lmdif_message : str

--- a/tests/test_default_kws.py
+++ b/tests/test_default_kws.py
@@ -13,12 +13,12 @@ def test_default_inputs_gauss():
 
     g = GaussianModel()
 
-    fit_option1 = {'max_nfev': 5000, 'xtol': 1e-2}
+    fit_option1 = {'xtol': 1e-2}
     result1 = g.fit(y, x=x, amplitude=1, center=0, sigma=0.5,
-                    fit_kws=fit_option1)
+                    max_nfev=5000, fit_kws=fit_option1)
 
-    fit_option2 = {'max_nfev': 5000, 'xtol': 1e-6}
+    fit_option2 = {'xtol': 1e-6}
     result2 = g.fit(y, x=x, amplitude=1, center=0, sigma=0.5,
-                    fit_kws=fit_option2)
+                    max_nfev=5000, fit_kws=fit_option2)
 
     assert result1.values != result2.values

--- a/tests/test_default_kws.py
+++ b/tests/test_default_kws.py
@@ -13,11 +13,11 @@ def test_default_inputs_gauss():
 
     g = GaussianModel()
 
-    fit_option1 = {'maxfev': 5000, 'xtol': 1e-2}
+    fit_option1 = {'max_nfev': 5000, 'xtol': 1e-2}
     result1 = g.fit(y, x=x, amplitude=1, center=0, sigma=0.5,
                     fit_kws=fit_option1)
 
-    fit_option2 = {'maxfev': 5000, 'xtol': 1e-6}
+    fit_option2 = {'max_nfev': 5000, 'xtol': 1e-6}
     result2 = g.fit(y, x=x, amplitude=1, center=0, sigma=0.5,
                     fit_kws=fit_option2)
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

This adds a `call_kws` attribute to `MinimizerResult` that contains the keyword arguments sent to the underlying solver. 

There are also a few tweaks to tests.

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

This is basically to inform the user what keywords were actually sent to the solver.

Inspired by https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/lmfit-py/W5nFfIsfSow/DHQHqExqAgAJ

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [*] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

Python: 3.7.7 (default, Mar 23 2020, 17:31:31)
[Clang 4.0.1 (tags/RELEASE_401/final)]

lmfit: 1.0.0+79.g382ce5f, scipy: 1.4.1, numpy: 1.18.1, asteval: 0.9.18, uncertainties: 3.1.2

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [*] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [*] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [*] updated the documentation?
- [ ] added an example?
