### PR TITLE
fix documentation build + pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@ exclude: 'versioneer.py|lmfit/_version|doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.3.0
+    rev: v2.4.4
     hooks:
     -   id: pyupgrade
         # for now don't force to change from %-operator to {}
         args: [--keep-percent-format, --py3-plus]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.1.0
     hooks:
     -   id: check-ast
     -   id: check-builtin-literals
@@ -24,7 +24,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+    rev: 3.8.2
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-deprecated, flake8-mutable]
@@ -44,7 +44,7 @@ repos:
     -   id: rst-backticks
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: v1.16.0
+    rev: v1.17.1
     hooks:
     -   id: codespell
         files: '.py|.rst'

--- a/doc/sphinx/ext_imgmath.py
+++ b/doc/sphinx/ext_imgmath.py
@@ -7,5 +7,5 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx.ext.todo',
               'IPython.sphinxext.ipython_console_highlighting',
-              'jupyter_sphinx.execute',
+              'jupyter_sphinx',
               'sphinx.ext.imgconverter']

--- a/doc/sphinx/ext_mathjax.py
+++ b/doc/sphinx/ext_mathjax.py
@@ -7,5 +7,5 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx.ext.todo',
               'IPython.sphinxext.ipython_console_highlighting',
-              'jupyter_sphinx.execute',
+              'jupyter_sphinx',
               'sphinx_gallery.gen_gallery']

--- a/lmfit/_ampgo.py
+++ b/lmfit/_ampgo.py
@@ -103,8 +103,8 @@ def ampgo(objfun, x0, args=(), local='L-BFGS-B', local_opts=None, bounds=None,
         raise ValueError('length of x0 != length of bounds')
 
     bounds = [b if b is not None else (None, None) for b in bounds]
-    _bounds = [(-np.inf if l is None else l, np.inf if u is None else u)
-               for l, u in bounds]
+    _bounds = [(-np.inf if lb is None else lb, np.inf if ub is None else ub)
+               for lb, ub in bounds]
     low, up = np.array(_bounds).T
 
     if maxfunevals is None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ corner
 coverage
 dill
 emcee>=3.0.0
-jupyter_sphinx
+jupyter_sphinx>=0.2.4
 matplotlib
 numdifftools
 numpy>=1.16

--- a/tests/NISTModels.py
+++ b/tests/NISTModels.py
@@ -172,7 +172,7 @@ def ReadNistData(dataset):
     line numbers being significant!
     """
     finp = open(os.path.join(NIST_DIR, "%s.dat" % dataset))
-    lines = [l[:-1] for l in finp.readlines()]
+    lines = [line[:-1] for line in finp.readlines()]
     finp.close()
     ModelLines = lines[30:39]
     ParamLines = lines[40:58]

--- a/tests/test_lineshapes.py
+++ b/tests/test_lineshapes.py
@@ -72,6 +72,8 @@ def test_x_float_value(lineshape):
 
 
 rising_form = ['erf', 'logistic', 'atan', 'arctan', 'linear', 'unknown']
+
+
 @pytest.mark.parametrize("form", rising_form)
 @pytest.mark.parametrize("lineshape", ['step', 'rectangle'])
 def test_form_argument_step_rectangle(form, lineshape):
@@ -99,6 +101,8 @@ def test_form_argument_step_rectangle(form, lineshape):
 
 
 thermal_form = ['bose', 'maxwell', 'fermi', 'Bose-Einstein', 'unknown']
+
+
 @pytest.mark.parametrize("form", thermal_form)
 def test_form_argument_thermal_distribution(form):
     """Test 'form' argument for thermal_distribution function."""


### PR DESCRIPTION
#### Description
A few small maintenance commits to
- update the `pre-commit hooks` and fix a few issues reported by the updated hooks 
- update the extension name from `jupyter_sphinx.execute` to `jupyter_sphinx`, as a consequence we should now also depend on version >=0.24. This was also changed in #642 but in an totally unrelated commit; it's preferable to keep those separated.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.8.3 (default, May 15 2020, 21:43:01)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 1.0.1+3.gdea715a, scipy: 1.4.1, numpy: 1.18.4, asteval: 0.9.18, uncertainties: 3.1.2


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
