### PR TITLE
FIX: ModelResult.eval_uncertainty should use provided Parameters

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1471,15 +1471,15 @@ class ModelResult(Minimizer):
 
         nvarys = self.nvarys
         # ensure fjac and df2 are correct size if independent var updated by kwargs
-        ndata = self.model.eval(self.params, **userkws).size
+        ndata = self.model.eval(params, **userkws).size
         covar = self.covar
         fjac = np.zeros((nvarys, ndata))
         df2 = np.zeros(ndata)
-        if any([p.stderr is None for p in self.params.values()]):
+        if any([p.stderr is None for p in params.values()]):
             return df2
 
         # find derivative by hand!
-        pars = self.params.copy()
+        pars = params.copy()
         for i in range(nvarys):
             pname = self.var_names[i]
             val0 = pars[pname].value


### PR DESCRIPTION
#### Description
The function `eval_uncertainty` in `model.py` currently does:
```
if params is None:
    params = self.params
```
which suggests to me that the intention is to use `params` if provided by the user. However, in the remainder of function it always uses `self.params`, so if a Parameters class is provided by the user it will not be used.

This PR fixes that by replacing `self.params` in the remainder by `params`. If I'm misunderstanding the intention here, please let me know. 


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.8.3 (default, May 15 2020, 21:43:01)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 1.0.1+6.g47deb52, scipy: 1.4.1, numpy: 1.18.4, asteval: 0.9.18, uncertainties: 3.1.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
