### PR TITLE
DEP: add deprecation warnings to donaich lineshape and DonaichModel

### DIFF
--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -1,5 +1,7 @@
 """Basic model line shapes and distribution functions."""
 
+import warnings
+
 from numpy import (arctan, cos, exp, finfo, float64, isnan, log, pi, real, sin,
                    sqrt, where)
 from scipy.special import erf, erfc
@@ -263,7 +265,18 @@ def doniach(x, amplitude=1.0, center=0, sigma=1.0, gamma=0.0):
     return scale*cos(pi*gamma/2 + gm1*arctan(arg))/(1 + arg**2)**(gm1/2)
 
 
-donaich = doniach   # for back-compat
+def donaich(x, amplitude=1.0, center=0, sigma=1.0, gamma=0.0):
+    """Return a Doniach Sunjic asymmetric lineshape, used for photo-emission.
+
+    Function added here for backwards-compatibility, will emit a FutureWarning
+    when used.
+
+    """
+    msg = ('Please correct the name of your lineshape function: donaich --> '
+           'doniach. The incorrect spelling will be removed in a later '
+           'release.')
+    warnings.warn(FutureWarning(msg))
+    return doniach(x, amplitude, center, sigma, gamma)
 
 
 def skewed_gaussian(x, amplitude=1.0, center=0.0, sigma=1.0, gamma=0.0):

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1,4 +1,5 @@
 """Module containing built-in fitting models."""
+import warnings
 import time
 
 from asteval import Interpreter, get_ast_names
@@ -1117,7 +1118,21 @@ class DoniachModel(Model):
     guess.__doc__ = COMMON_GUESS_DOC
 
 
-DonaichModel = DoniachModel   # for back-compat
+class DonaichModel(DoniachModel):
+    """A model of an Doniach Sunjic asymmetric lineshape.
+
+    Model added here for backwards-compatibility, will emit a FutureWarning
+    when used.
+
+    """
+    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
+                 **kwargs):
+
+        msg = ('Please correct the name of your built-in model: DonaichModel '
+               '--> DoniachModel. The incorrect spelling will be removed in '
+               'a later release.')
+        warnings.warn(FutureWarning(msg))
+        super().__init__(**kwargs)
 
 
 class PowerLawModel(Model):

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -4,6 +4,7 @@ import inspect
 
 import numpy as np
 from numpy.testing import assert_allclose
+import pytest
 from scipy.optimize import fsolve
 
 from lmfit import lineshapes, models
@@ -281,3 +282,12 @@ def test_guess_from_peak2d():
 
     for param, value in zip(['centerx', 'centery'], [centerx, centery]):
         assert np.abs((guess_increasing_x[param].value - value)/value) < 0.5
+
+
+def test_DonaichModel_emits_futurewarning():
+    """Assert that using the wrong spelling emits a FutureWarning."""
+    msg = ('Please correct the name of your built-in model: DonaichModel --> '
+           'DoniachModel. The incorrect spelling will be removed in a later '
+           'release.')
+    with pytest.warns(FutureWarning, match=msg):
+        models.DonaichModel()

--- a/tests/test_lineshapes.py
+++ b/tests/test_lineshapes.py
@@ -126,3 +126,14 @@ def test_form_argument_thermal_distribution(form):
     else:
         fnc_output = func(*fnc_args)
         assert len(fnc_output) == len(xvals)
+
+
+def test_donaich_emits_futurewarning():
+    """Assert that using the wrong spelling emits a FutureWarning."""
+    xvals = np.linspace(0, 10, 100)
+
+    msg = ('Please correct the name of your lineshape function: donaich --> '
+           'doniach. The incorrect spelling will be removed in a later '
+           'release.')
+    with pytest.warns(FutureWarning, match=msg):
+        lmfit.lineshapes.donaich(xvals)


### PR DESCRIPTION
#### Description
The current option for backwards-compatibility does not warn the user to correct the typo in the lineshape/model name. This commit changes that and emits a `FutureWarning`, which will allows us to remove the incorrectly spelled lineshape/model function in an upcoming release.

See commit f3af0d4c052ca8ae4a4927581ba485c659f18d3c


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.8.3 (default, May 15 2020, 21:43:01)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 1.0.1+6.g47deb52, scipy: 1.4.1, numpy: 1.18.4, asteval: 0.9.18, uncertainties: 3.1.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?