### PR TITLE
install latest version of requirements on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_install:
 
 install:
     - if [[ $version == minimum ]]; then pip install asteval==0.9.16 numpy==1.16 scipy==1.2 uncertainties==3.0.1 pytest coverage codecov; fi
-    - if [[ $version == latest ]]; then pip install -r requirements-dev.txt ; fi
+    - if [[ $version == latest ]]; then pip install -r requirements-dev.txt -U; fi
     - python setup.py install
     - pip list
 


### PR DESCRIPTION
#### Description
It turns out that we currently do not always test with the most recent packages on Travis CI. For example, inspecting [this build-job](https://travis-ci.org/github/lmfit/lmfit-py/jobs/695727370) shows that `numpy 1.17.2` is being used, whereas the latest upstream version is 1.18.5. This PR corrects that situation.

###### Type of Changes
- [x] Testing

###### Tested on
Python: 3.8.3 (default, May 15 2020, 21:43:01)
[Clang 10.0.1 (clang-1001.0.46.4)]

lmfit: 1.0.1+31.gc30d5ff, scipy: 1.4.1, numpy: 1.18.5, asteval: 0.9.18, uncertainties: 3.1.4


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
