### PR TITLE
Numdiff restore vals

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -764,7 +764,8 @@ class Minimizer:
         """
         warnings.filterwarnings(action="ignore", module="scipy",
                                 message="^internal gelsd")
-
+        vbest = np.atleast_1d([self.result.params[name].value for name in
+                               self.result.var_names])
         nfev = deepcopy(self.result.nfev)
         try:
             Hfun = ndt.Hessian(self.penalty, step=1.e-4)
@@ -774,7 +775,9 @@ class Minimizer:
             return None
         finally:
             self.result.nfev = nfev
-
+        # restore original values
+        for val, nam in zip(vbest, self.result.var_names):
+            self.result.params[nam].value = val
         return cov_x
 
     def _int2ext_cov_x(self, cov_int, fvars):


### PR DESCRIPTION

#### Description

This addresses #655 by explicitly saving and restoring the best-fit values after the `numdifftools` calculation of the covariance matrix. 

A test is added, and the tests in `test_covariance_matrix.py` are tweaked to use an explicit (and apparently now important?) setting of the random seed.


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.7.7 (default, Mar 23 2020, 22:36:06) 
[GCC 7.3.0]

lmfit: 1.0.1+2.gf09313e, scipy: 1.4.1, numpy: 1.18.1, asteval: 0.9.18, uncertainties: 3.1.2


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation?
- [ ] added an example?

