### PR TITLE
Restore vals at calc covar

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -784,6 +784,8 @@ class Minimizer:
                                 message="^internal gelsd")
 
         nfev = deepcopy(self.result.nfev)
+        best_vals = self.result.params.valuesdict()
+
         try:
             Hfun = ndt.Hessian(self.penalty, step=1.e-4)
             hessian_ndt = Hfun(fvars)
@@ -793,6 +795,9 @@ class Minimizer:
         finally:
             self.result.nfev = nfev
 
+        # restore original values
+        for name in self.result.var_names:
+            self.result.params[name].value = best_vals[name]
         return cov_x
 
     def _int2ext_cov_x(self, cov_int, fvars):

--- a/tests/test_covariance_matrix.py
+++ b/tests/test_covariance_matrix.py
@@ -7,7 +7,7 @@ import pytest
 
 from lmfit import Parameters, minimize
 from lmfit.lineshapes import exponential
-from lmfit.models import ExponentialModel, VoigtModel
+from lmfit.models import ExponentialModel, VoigtModel, LinearModel
 
 
 def check(para, real_val, sig=3):
@@ -225,3 +225,19 @@ def test_numdifftools_calc_covar_false():
 
     assert result_ndt.covar is None
     assert result_ndt.errorbars is False
+
+def test_final_parameter_values():
+    model = LinearModel()
+    params = model.make_params()
+    params['intercept'].set(value=-1, min=-20, max=0)
+    params['slope'].set(value=1, min=-100, max=400)
+
+    np.random.seed(78281)
+    x = np.linspace(0, 9, 10)
+    y = x* 1.34 - 4.5 + np.random.normal(scale=0.05, size=x.size)
+
+    result = model.fit(y, x=x, method='nelder', params=params)
+
+    assert_almost_equal(result.chisqr, 0.014625543, decimal=6)
+    assert_almost_equal(result.params['intercept'].value, -4.511087126, decimal=6)
+    assert_almost_equal(result.params['slope'].value, 1.339685514, decimal=6)


### PR DESCRIPTION

#### Description

This addresses #655 by explicitly saving and restoring the best-fit values after the numdifftools calculation of the covariance matrix.  A test is added.



###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on

Python: 3.7.7 (default, Mar 23 2020, 22:36:06) 
[GCC 7.3.0]

lmfit: 1.0.1+48.g5cb52a0, scipy: 1.4.1, numpy: 1.18.1, asteval: 0.9.18, uncertainties: 3.1.2

Also, numdifftools 0.9.39

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation?
- [ ] added an example?

