### PR TITLE
Register models

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -191,10 +191,10 @@ class Model:
     _invalid_par = "Invalid parameter name ('%s') for function %s"
     _invalid_hint = "unknown parameter hint '%s' for param '%s'"
     _hint_names = ('value', 'vary', 'min', 'max', 'expr')
-    forms = []
+    valid_forms = ()
 
     def __init__(self, func, independent_vars=None, param_names=None,
-                 nan_policy='raise', prefix='', name=None, **kws):
+                 nan_policy='raise', prefix='', name=None, form=None, **kws):
         """
         The model function will normally take an independent variable
         (generally, the first argument) and a series of arguments that are
@@ -218,6 +218,8 @@ class Model:
         name : str, optional
             Name for the model. When None (default) the name is the same
             as the model function (`func`).
+        form : str, optional
+            Additional 
         **kws : dict, optional
             Additional keyword arguments to pass to model function.
 

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -194,7 +194,7 @@ class Model:
     valid_forms = ()
 
     def __init__(self, func, independent_vars=None, param_names=None,
-                 nan_policy='raise', prefix='', name=None, form=None, **kws):
+                 nan_policy='raise', prefix='', name=None, **kws):
         """
         The model function will normally take an independent variable
         (generally, the first argument) and a series of arguments that are
@@ -218,8 +218,6 @@ class Model:
         name : str, optional
             Name for the model. When None (default) the name is the same
             as the model function (`func`).
-        form : str, optional
-            Additional 
         **kws : dict, optional
             Additional keyword arguments to pass to model function.
 

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -191,6 +191,7 @@ class Model:
     _invalid_par = "Invalid parameter name ('%s') for function %s"
     _invalid_hint = "unknown parameter hint '%s' for param '%s'"
     _hint_names = ('value', 'vary', 'min', 'max', 'expr')
+    forms = []
 
     def __init__(self, func, independent_vars=None, param_names=None,
                  nan_policy='raise', prefix='', name=None, **kws):

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1109,7 +1109,7 @@ class ThermalDistributionModel(Model):
 
     """
 
-    forms = ('bose', 'maxwell', 'fermi')
+    valid_forms = ('bose', 'maxwell', 'fermi')
 
     def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  form='bose', **kwargs):
@@ -1292,7 +1292,7 @@ class StepModel(Model):
 
     """
 
-    forms = ('linear', 'atan', 'arctan', 'erf', 'logistic')
+    valid_forms = ('linear', 'atan', 'arctan', 'erf', 'logistic')
 
     def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  form='linear', **kwargs):
@@ -1354,7 +1354,7 @@ class RectangleModel(Model):
 
     """
 
-    forms = ('linear', 'atan', 'arctan', 'erf', 'logistic')
+    valid_forms = ('linear', 'atan', 'arctan', 'erf', 'logistic')
 
     def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  form='linear', **kwargs):

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1109,6 +1109,8 @@ class ThermalDistributionModel(Model):
 
     """
 
+    forms = ('bose', 'maxwell', 'fermi')
+
     def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  form='bose', **kwargs):
         kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
@@ -1290,6 +1292,8 @@ class StepModel(Model):
 
     """
 
+    forms = ('linear', 'atan', 'arctan', 'erf', 'logistic')
+
     def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  form='linear', **kwargs):
         kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
@@ -1349,6 +1353,8 @@ class RectangleModel(Model):
     :math:`\alpha_2 = -(x - \mu_2)/{\sigma_2}`.
 
     """
+
+    forms = ('linear', 'atan', 'arctan', 'erf', 'logistic')
 
     def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
                  form='linear', **kwargs):

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1491,3 +1491,34 @@ class ExpressionModel(Model):
         This prevents normal parsing of function for parameter names.
 
         """
+
+lmfit_models = {'Constant': ConstantModel,
+                'Complex Constant': ComplexConstantModel,
+                'Linear': LinearModel,
+                'Quadratic': QuadraticModel,
+                'Polynomial': PolynomialModel,
+                'Gaussian': GaussianModel,
+                'Gaussian-2D': Gaussian2dModel,
+                'Lorentzian': LorentzianModel,
+                'Split-Lorentzian': SplitLorentzianModel,
+                'Voigt': VoigtModel,
+                'PseudoVoigt': PseudoVoigtModel,
+                'Moffat': MoffatModel,
+                'Pearson7': Pearson7Model,
+                'StudentsT': StudentsTModel,
+                'Breit-Wigner': BreitWignerModel,
+                'Log-Normal': LognormalModel,
+                'Damped Oscillator': DampedOscillatorModel,
+                'Damped Harmonic Oscillator': DampedHarmonicOscillatorModel,
+                'Exponential Gaussian': ExponentialGaussianModel,
+                'Skewed Gaussian': SkewedGaussianModel,
+                'Skewed Voigt': SkewedVoigtModel,
+                'Thermal Distribution': ThermalDistributionModel,
+                'Doniach': DoniachModel,
+                'Power Law': PowerLawModel,
+                'Exponential': ExponentialModel,
+                'Step': StepModel,
+                'Rectangle': RectangleModel,
+                'Expression': ExpressionModel}
+                    
+    

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -294,10 +294,14 @@ class PolynomialModel(Model):
     MAX_DEGREE = 7
     DEGREE_ERR = "degree must be an integer less than %d."
 
-    def __init__(self, degree, independent_vars=['x'], prefix='',
+    valid_forms = (0, 1, 2, 3, 4, 5, 6, 7)
+
+    def __init__(self, degree=7, independent_vars=['x'], prefix='',
                  nan_policy='raise', **kwargs):
         kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'independent_vars': independent_vars})
+        if 'form' in kwargs:
+            degree = int(kwargs.pop('form'))
         if not isinstance(degree, int) or degree > self.MAX_DEGREE:
             raise TypeError(self.DEGREE_ERR % self.MAX_DEGREE)
 


### PR DESCRIPTION
#### Description
This PR is based on a post I made to the lmfit Google group (https://groups.google.com/forum/?#!topic/lmfit-py/U3XwKBSLrUQ). Its purpose is to allow third-party packages to determine programmatically all the models defined within lmfit in `models.py` and all the valid forms available to modify some of those models. It makes the following changes:

-  A new variable, `lmfit_models`, which contains a dictionary of all the models, can be directly imported from `models.py`.
- A new Model class attribute, `valid_forms`, contains a tuple of allowed forms. It is empty by default.
- The positional argument, `degree`, of the PolynomialModel constructor is converted to a keyword argument of the same name. This allows the polynomial degree to be set by a `form` keyword argument that would override the `degree` argument. However, the `degree` argument is first and can still be entered as a positional argument as before.

I have tested the functionality of these changes in NeXpy (https://nexpy.github.io/nexpy/), which has a GUI interface to the lmfit library. The new dictionary and class attributes have been used successfully to generate pull-down menus allowing the model and, if appropriate, its form to be chosen. 

Here is an example of the changes in action. Note that the change to the PolynomialModel does not change the existing call signature.

```
>>> from lmfit.models import lmfit_models, PolynomialModel
>>> lmfit_models['Step'].valid_forms
('linear', 'atan', 'arctan', 'erf', 'logistic')
>>> lmfit_models['Polynomial']
lmfit.models.PolynomialModel
>>> p=PolynomialModel(4, prefix='P1')
>>> p.poly_degree
4
>>> p.prefix
'P1'
>>> p=PolynomialModel(4, form='5')
>>> p.poly_degree
5
``` 

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples

###### Tested on
Python: 3.8.0 (default, Nov  6 2019, 15:49:01) 
[Clang 4.0.1 (tags/RELEASE_401/final)]
lmfit: 1.0.1+53.gb2f308e.dirty (forked from the latest development version in the Master branch)
scipy: 1.4.1, numpy: 1.18.1, asteval: 0.9.16, uncertainties: 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] included docstrings that follow PEP 257?

I haven't added the new class attributes to the docstrings, because none are currently defined, and I don't know what the lmfit convention is.

- [x] referenced existing Issue and/or provided relevant link to mailing list?

- [x] verified that existing tests pass locally?

Running pytest generates 3 errors and 7 warnings, but as far as I can tell, none of them relate to the code changes. I assume this is an issue with the development version. 

- [ ] verified that the documentation builds locally?

I haven't changed the documentation. 

- [x] squashed/minimized your commits and written descriptive commit messages?

- [ ] added or updated existing tests to cover the changes?

It is unlikely that my changes will be covered by existing tests. 

- [ ] updated the documentation?
- [ ] added an example?

I'm happy to do this, but I would need some guidance on how to do these.
