### PR TITLE
save last internal values

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1415,7 +1415,7 @@ class Minimizer:
         else:
             p0 = 1 + rng.randn(nwalkers, self.nvarys) * 1.e-4
             p0 *= var_arr
-            sampler_kwargs['pool'] = auto_pool
+            sampler_kwargs.setdefault('pool',auto_pool)
             self.sampler = emcee.EnsembleSampler(nwalkers, self.nvarys,
                                                  self._lnprob, **sampler_kwargs)
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -580,6 +580,7 @@ class Minimizer:
             self.max_nfev = np.inf
 
         self.result.nfev += 1
+        self.result.last_internal_values = fvars
         if self.result.nfev > self.max_nfev:
             self.result.aborted = True
             m = "number of function evaluations > %d" % self.max_nfev
@@ -1032,8 +1033,7 @@ class Minimizer:
             result.residual = self.__residual(result.x)
             result.nfev -= 1
         else:
-            result.x = np.array([self.result.params[p].value
-                                 for p in self.result.var_names])
+            result.x = result.last_internal_values
             self.result.nfev -= 2
             self._abort = False
             result.residual = self.__residual(result.x)
@@ -1693,8 +1693,7 @@ class Minimizer:
         if not result.aborted:
             _best, _cov, _infodict, errmsg, ier = lsout
         else:
-            _best = np.array([self.result.params[p].value
-                              for p in self.result.var_names])
+            _best = result.last_internal_values
             _cov = None
             ier = -1
             errmsg = 'Fit aborted.'

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -368,7 +368,7 @@ class CommonMinimizerTest(unittest.TestCase):
 
         # but only if a parameter is not fixed
         self.fit_params['decay'].vary = False
-        self.mini.scalar_minimize(method='differential_evolution', maxiter=1)
+        self.mini.scalar_minimize(method='differential_evolution', max_nfev=1)
 
     def test_scalar_minimizers(self):
         # test all the scalar minimizers

--- a/tests/test_nose.py
+++ b/tests/test_nose.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy import pi
 from numpy.testing import (assert_allclose, assert_almost_equal, assert_equal,
                            dec)
+from scipy.optimize import rosen_der
 import pytest
 from uncertainties import ufloat
 
@@ -632,6 +633,34 @@ class CommonMinimizerTest(unittest.TestCase):
             _ = self.mini.emcee(params=self.fit_params, ntemps=5)
 
 
+    def test_emcee_custom_pool(self):
+        # tests use of a custom pool
+
+        if not HAS_EMCEE:
+            return True
+        
+        global emcee_counter
+        emcee_counter = 0
+        
+        class my_pool:
+            def map(self, f, arg):
+                global emcee_counter
+                emcee_counter += 1
+                return map(f, arg)
+
+        def cost_fun(params, **kwargs):
+            return rosen_der([params['a'],params['b']])
+      
+        params = Parameters()
+        params.add('a', 1,min=-5,max=5,vary=True)
+        params.add('b', 1,min=-5,max=5,vary=True)
+        
+        fitter = Minimizer(cost_fun,params)
+        MC_results = fitter.emcee(workers= my_pool(), steps=1000, nwalkers=100)
+        assert emcee_counter > 500
+
+        
+
 def residual_for_multiprocessing(pars, x, data=None):
     # a residual function defined in the top level is needed for
     # multiprocessing. bound methods don't work.
@@ -646,3 +675,5 @@ def residual_for_multiprocessing(pars, x, data=None):
     if data is None:
         return model
     return model - data
+
+


### PR DESCRIPTION
## Description


This makes two separate fairly small changes as bug-fixes to address #665 and #666.

The changes are small, and sort of follow the discussion in the linked issue.  

To solve #665, the values of the 'internal variables' are saved at each call of `__residual()` and then used to set 'best values' if the fit terminates early or unexpectedly. That is slightly different from the solution suggested in #665, but I think it is more obvious and clearer.

To solve #666, the proposed solution was followed and a test added.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->


Python: 3.7.7 (default, Mar 23 2020, 17:31:31)
[Clang 4.0.1 (tags/RELEASE_401/final)]

lmfit: 1.0.1+61.gfc0cf36.dirty, scipy: 1.4.1, numpy: 1.18.1, asteval: 0.9.18, uncertainties: 3.1.2


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation?
- [ ] added an example?
