### PR TITLE
Fix nist strd

### DIFF
--- a/tests/NISTModels.py
+++ b/tests/NISTModels.py
@@ -22,119 +22,134 @@ def Bennet5(b, x, y=0):
 
 def BoxBOD(b, x, y=0):
     b = read_params(b)
-    return y - b[0]*(1-exp(-b[1]*x))
+    model = b[0]*(1-exp(-b[1]*x))
+    return model -y
 
 
 def Chwirut(b, x, y=0):
     b = read_params(b)
-    return y - exp(-b[0]*x)/(b[1]+b[2]*x)
+    model = exp(-b[0]*x)/(b[1]+b[2]*x)
+    return model - y
 
 
 def DanWood(b, x, y=0):
     b = read_params(b)
-    return y - b[0]*x**b[1]
+    model = b[0]*x**b[1]
+    return model - y
 
 
 def ENSO(b, x, y=0):
     b = read_params(b)
     pi = 3.141592653589793238462643383279
-
-    return y - b[0] + (b[1]*cos(2*pi*x/12) + b[2]*sin(2*pi*x/12) +
-                       b[4]*cos(2*pi*x/b[3]) + b[5]*sin(2*pi*x/b[3]) +
-                       b[7]*cos(2*pi*x/b[6]) + b[8]*sin(2*pi*x/b[6]))
-
+    model = b[0] + (b[1]*cos(2*pi*x/12) + b[2]*sin(2*pi*x/12) +
+                    b[4]*cos(2*pi*x/b[3]) + b[5]*sin(2*pi*x/b[3]) +
+                    b[7]*cos(2*pi*x/b[6]) + b[8]*sin(2*pi*x/b[6]))
+    return model - y
 
 def Eckerle4(b, x, y=0):
     b = read_params(b)
-    return y - (b[0]/b[1]) * exp(-0.5*((x-b[2])/b[1])**2)
+    model = (b[0]/b[1]) * exp(-0.5*((x-b[2])/b[1])**2)
+    return model - y
 
 
 def Gauss(b, x, y=0):
     b = read_params(b)
-    return y - b[0]*exp(-b[1]*x) + (b[2]*exp(-(x-b[3])**2 / b[4]**2) +
-                                    b[5]*exp(-(x-b[6])**2 / b[7]**2))
+    model = (b[0]*exp(-b[1]*x) + (b[2]*exp(-(x-b[3])**2 / b[4]**2) +
+                                  b[5]*exp(-(x-b[6])**2 / b[7]**2)))
+    return model - y
 
 
 def Hahn1(b, x, y=0):
     b = read_params(b)
-    return y - ((b[0]+b[1]*x+b[2]*x**2+b[3]*x**3) /
-                (1+b[4]*x+b[5]*x**2+b[6]*x**3))
-
+    model = (b[0]+b[1]*x+b[2]*x**2+b[3]*x**3) /(1+b[4]*x+b[5]*x**2+b[6]*x**3)
+    return model - y
 
 def Kirby(b, x, y=0):
     b = read_params(b)
-    return y - (b[0] + b[1]*x + b[2]*x**2) / (1 + b[3]*x + b[4]*x**2)
+    model = (b[0] + b[1]*x + b[2]*x**2) / (1 + b[3]*x + b[4]*x**2)
+    return model - y
 
 
 def Lanczos(b, x, y=0):
     b = read_params(b)
-    return y - b[0]*exp(-b[1]*x) + b[2]*exp(-b[3]*x) + b[4]*exp(-b[5]*x)
+    model = b[0]*exp(-b[1]*x) + b[2]*exp(-b[3]*x) + b[4]*exp(-b[5]*x)
+    return model - y 
 
 
 def MGH09(b, x, y=0):
     b = read_params(b)
-    return y - b[0]*(x**2+x*b[1]) / (x**2+x*b[2]+b[3])
+    model = b[0]*(x**2+x*b[1]) / (x**2+x*b[2]+b[3])
+    return model - y
 
 
 def MGH10(b, x, y=0):
     b = read_params(b)
-    return y - b[0] * exp(b[1]/(x+b[2]))
+    model = b[0] * exp(b[1]/(x+b[2]))
+    return model - y
 
 
 def MGH17(b, x, y=0):
     b = read_params(b)
-    return y - b[0] + b[1]*exp(-x*b[3]) + b[2]*exp(-x*b[4])
+    model = b[0] + b[1]*exp(-x*b[3]) + b[2]*exp(-x*b[4])
+    return model - y
 
 
 def Misra1a(b, x, y=0):
     b = read_params(b)
-    return y - b[0]*(1-exp(-b[1]*x))
+    model = b[0]*(1-exp(-b[1]*x))
+    return model - y
 
 
 def Misra1b(b, x, y=0):
     b = read_params(b)
-    return y - b[0] * (1-(1+b[1]*x/2)**(-2))
+    model = b[0] * (1-(1+b[1]*x/2)**(-2))
+    return model - y
 
 
 def Misra1c(b, x, y=0):
     b = read_params(b)
-    return y - b[0] * (1-(1+2*b[1]*x)**(-.5))
+    model = b[0] * (1-(1+2*b[1]*x)**(-.5))
+    return model - y
 
 
 def Misra1d(b, x, y=0):
     b = read_params(b)
-    return y - b[0]*b[1]*x*((1+b[1]*x)**(-1))
+    model = b[0]*b[1]*x*((1+b[1]*x)**(-1))
+    return model - y
 
 
 def Nelson(b, x, y=None):
     b = read_params(b)
     x1 = x[:, 0]
     x2 = x[:, 1]
-    if y is None:
-        return - exp(b[0] - b[1]*x1 * exp(-b[2]*x2))
-    return log(y) - (b[0] - b[1]*x1 * exp(-b[2]*x2))
+    model = b[0] - b[1]*x1 * exp(-b[2]*x2)
+    return model - log(y)
 
 
 def Rat42(b, x, y=0):
     b = read_params(b)
-    return y - b[0] / (1+exp(b[1]-b[2]*x))
+    model = b[0] / (1+exp(b[1]-b[2]*x))
+    return model - y
 
 
 def Rat43(b, x, y=0):
     b = read_params(b)
-    return y - b[0] / ((1+exp(b[1]-b[2]*x))**(1/b[3]))
+    model = b[0] / ((1+exp(b[1]-b[2]*x))**(1/b[3]))
+    return model - y
 
 
 def Roszman1(b, x, y=0):
     b = read_params(b)
     pi = 3.141592653589793238462643383279
-    return y - b[0] - b[1]*x - arctan(b[2]/(x-b[3]))/pi
+    model = b[0] - b[1]*x - arctan(b[2]/(x-b[3]))/pi
+    return model - y
 
 
 def Thurber(b, x, y=0):
     b = read_params(b)
-    return y - ((b[0] + b[1]*x + b[2]*x**2 + b[3]*x**3) /
-                (1 + b[4]*x + b[5]*x**2 + b[6]*x**3))
+    model = ((b[0] + b[1]*x + b[2]*x**2 + b[3]*x**3) /
+             (1 + b[4]*x + b[5]*x**2 + b[6]*x**3))
+    return model - y
 
 
 #  Model name        fcn,    #fitting params, dim of x


### PR DESCRIPTION


#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

This fixes the functions for the NIST Strd reference tests so that they first calculate the NIST model function and then subtract the optional `y` values.  There were several functions with sign errors of the type `y - m1 + m2` instead of `y - (m1 + m2)`. 

See:  https://groups.google.com/g/lmfit-py/c/leJvx2M4DkM/m/fWdBapj1AAAJ



###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

```
Python: 3.7.7 (default, Mar 23 2020, 17:31:31)
[Clang 4.0.1 (tags/RELEASE_401/final)]

lmfit: 1.0.1+65.gead6aaa, scipy: 1.4.1, numpy: 1.18.1, asteval: 0.9.18, uncertainties: 3.1.2
```

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation?
- [ ] added an example?
