### PR TITLE
Make docs build cross platform

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -166,8 +166,8 @@ image_converter_args=["-density", "300"]
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',
     'gallery_dirs': 'examples',
-    'filename_pattern': '/documentation|/example_',
-    'ignore_pattern': '/doc_',
+    'filename_pattern': r'(\\|/)documentation|(\\|/)example_',
+    'ignore_pattern': r'(\\|/)doc_',
     'ignore_repr_types': r'matplotlib',
 }
 

--- a/doc/doc_examples_to_gallery.py
+++ b/doc/doc_examples_to_gallery.py
@@ -11,55 +11,65 @@ Process the examples in the documentation for inclusion in the Gallery:
 - copy the data files
 
 """
+
 import os
-import time
+import shlex
+import subprocess
 
-basedir = os.getcwd()
+from pathlib import Path
+from shutil import copy2
 
-examples_dir = os.path.abspath(os.path.join(basedir, '..', 'examples'))
-files = [fn for fn in os.listdir(examples_dir) if fn.startswith('doc_')]
 
-examples_documentation_dir = os.path.join(examples_dir, 'documentation')
-os.makedirs(examples_documentation_dir, exist_ok=True)
+def copy_data_files(src_dir, dest_dir):
+    """Copy files with datafile extension from src_dir to dest_dir."""
+    data_file_extension = [".dat", ".csv", ".sav"]
+
+    for file in src_dir.glob("*"):
+        if file.suffix in data_file_extension:
+            copy2(file, dest_dir)
+
+
+doc_dir = Path(__file__).parent.absolute()
+
+examples_dir = doc_dir.parent / "examples"
+files = examples_dir.glob("doc[_]*.py")
+
+examples_documentation_dir = examples_dir / "documentation"
+examples_documentation_dir.mkdir(exist_ok=True)
 
 
 scripts_to_run = []
 
-with open(os.path.join(examples_documentation_dir, 'README.txt'), 'w') as out:
-    out.write("Examples from the documentation\n")
-    out.write("===============================\n\n")
-    out.write("Below are all the examples that are part of the lmfit documentation.")
+(examples_documentation_dir / "README.txt").write_text(
+    "Examples from the documentation\n"
+    "===============================\n\n"
+    "Below are all the examples that are part of the lmfit documentation."
+)
 
 for fn in files:
-    inp_path = os.path.join(examples_dir, fn)
-    with open(inp_path) as inp:
-        script_text = inp.read()
 
-    gallery_file = os.path.join(examples_documentation_dir, fn[4:])
-    with open(gallery_file, 'w') as out:
-        msg = ""  # add optional message f
-        out.write('"""\n{}\n{}\n\n{}\n"""\n'.format(fn, "="*len(fn), msg))
-        out.write(script_text)
+    script_text = fn.read_text()
+
+    gallery_file = examples_documentation_dir / fn.name[4:]
+    msg = ""  # add optional message f
+    gallery_file.write_text(
+        '"""\n{}\n{}\n\n{}\n"""\n{}'.format(
+            fn.name, "=" * len(fn.name), msg, script_text
+        )
+    )
 
     # make sure the saved Models and ModelResult are available
-    if 'save' in fn:
-        scripts_to_run.append(fn[4:])
+    if "save" in fn.name:
+        scripts_to_run.append(gallery_file)
 
-time.sleep(1.0)
-
-os.system('cp {}/*.dat {}'.format(examples_dir, examples_documentation_dir))
-os.system('cp {}/*.csv {}'.format(examples_dir, examples_documentation_dir))
-os.system('cp {}/*.sav {}'.format(examples_dir, examples_documentation_dir))
+copy_data_files(examples_dir, examples_documentation_dir)
 
 os.chdir(examples_documentation_dir)
 
 for script in scripts_to_run:
-    os.system('python {}'.format(script))
+    subprocess.call(shlex.split("python {}".format(script.as_posix())))
 
-os.chdir(basedir)
+os.chdir(doc_dir)
 
-time.sleep(1.0)
-# data files for the other Gallery examples
-os.system('cp {}/*.dat .'.format(examples_documentation_dir))
-os.system('cp {}/*.csv .'.format(examples_documentation_dir))
-os.system('cp {}/*.sav .'.format(examples_documentation_dir))
+# # data files for the other Gallery examples
+copy_data_files(examples_documentation_dir, doc_dir)

--- a/doc/doc_examples_to_gallery.py
+++ b/doc/doc_examples_to_gallery.py
@@ -67,7 +67,7 @@ copy_data_files(examples_dir, examples_documentation_dir)
 os.chdir(examples_documentation_dir)
 
 for script in scripts_to_run:
-    subprocess.call(shlex.split("python {}".format(script.as_posix())))
+    subprocess.run(shlex.split("python {}".format(script.as_posix())), check=True)
 
 os.chdir(doc_dir)
 

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -1,0 +1,43 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=python -msphinx
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+set SPHINXOPTS=-W
+
+if "%1" == "" goto help
+
+if "%1" == "html" (
+	python doc_examples_to_gallery.py
+	copy %~dp0sphinx\ext_mathjax.py %~dp0extensions.py
+	%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+	goto end
+)
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The Sphinx module was not found. Make sure you have Sphinx installed,
+	echo.then set the SPHINXBUILD environment variable to point to the full
+	echo.path of the 'sphinx-build' executable. Alternatively you may add the
+	echo.Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-asteval>=0.9.16
+-r requirements.txt
 codecov
 corner
 coverage
@@ -7,13 +7,10 @@ emcee>=3.0.0
 jupyter_sphinx>=0.2.4
 matplotlib
 numdifftools
-numpy>=1.16
 pandas
 Pillow
 pre-commit
 pytest
-scipy>=1.2
 Sphinx
 sphinx-gallery
 sympy
-uncertainties>=3.0.1


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
As promised some time ago, here is the PR to make the docs build cross platform.
I think the main problem with building the docs on Windows were the `RegEx`s for the paths in `sphinx_gallery_conf ` (at least with git bash).
Rewriting `doc/doc_examples_to_gallery.py` to use python to copy files instead of relieing on sys calls to `cp` makes it work on `cmd` and `powershell`.
A positive side effect is that the execution time is only half of what it used to be (5s vs. 10s before).



###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

Windows 10
```
Python: 3.8.5 | packaged by conda-forge | (default, Jul 31 2020, 01:53:45) [MSC v.1916 64 bit (AMD64)]
lmfit: 1.0.1+71.gc67d55e, scipy: 1.5.2, numpy: 1.19.1, asteval: 0.9.18, uncertainties: 3.1.4
```
With:
- `cmd`
- `powershell`
- `git-bash`

Building the docs on Windows with `cmd` or `powershell` can be done by calling `/doc/make.bat html`.
I only changed the build instructions for html, to mimic the Makefile ones, since it suffices as test if the docs still build properly.


Ubuntu 20.04
```
Python: 3.8.5 (default, Sep  4 2020, 07:30:14)[GCC 7.3.0]
lmfit: 1.0.1+71.gc67d55e, scipy: 1.5.2, numpy: 1.19.2, asteval: 0.9.19, uncertainties: 3.1.4
```
With:
- `bash`

###### Verification <!-- (delete not applicable items) -->
Have you
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->

###### Heads-up about numpy problems on Windows 2004
I hope this helps to identify reported errors with `lmfit` on Windows, which aren't problems with `lmfit` but a windows update breaking parts of `numpy`.
Sadly, after [Windows 10 update to 2004 broke numpy polyfit and eig regression](https://github.com/numpy/numpy/issues/16744), I again can't build the docs on Windows and the tests suite fails.
Before that update it worked fine, but now it crashes when evaluating `examples\documentation\model_savemodelresult2.py` with `numpy.linalg.LinAlgError: SVD did not converge in Linear Least Squares`, which is exactly the problem described in the numpy issue.

