### PR TITLE
relax module name check in test_check_ast_errors for python 3.9

### DIFF
--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -40,7 +40,7 @@ def test_check_ast_errors():
     """Assert that an exception is raised upon AST errors."""
     pars = lmfit.Parameters()
 
-    msg = r"at expr='<_ast.Module object at"
+    msg = r"at expr='<_?ast.Module object at"
     with pytest.raises(NameError, match=msg):
         pars.add('par1', expr='2.0*par2')
 


### PR DESCRIPTION
Fixes #674


<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description

The tests fail on Python 3.9. I should have looked at the failure
message more closely, it's just that _ast.Module is ast.Module now.

###### Type of Changes
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on

```
Python: 3.9.0rc1 (default, Sep  3 2020, 19:31:07) 
[GCC 9.3.0]

lmfit: 1.0.1+74.gbc2975e, scipy: 1.5.3, numpy: 1.19.2, asteval: 0.9.19, uncertainties: 3.1.4
```

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] squashed/minimized your commits and written descriptive commit messages?