### PR TITLE
Fix #677

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1625,6 +1625,9 @@ class ModelResult(Minimizer):
             if isinstance(val, np.bool_):
                 val = bool(val)
             out[attr] = encode4js(val)
+
+        out['message'] = str(out.get('message', ''))
+
         return json.dumps(out, **kws)
 
     def dump(self, fp, **kws):

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1624,9 +1624,12 @@ class ModelResult(Minimizer):
                 continue
             if isinstance(val, np.bool_):
                 val = bool(val)
+
             out[attr] = encode4js(val)
 
-        out['message'] = str(out.get('message', ''))
+        val = out.get('message', '')
+        if isinstance(val, bytes):
+            out['message'] = str(val, encoding='ASCII')
 
         return json.dumps(out, **kws)
 

--- a/tests/test_saveload.py
+++ b/tests/test_saveload.py
@@ -186,7 +186,7 @@ def test_saveload_modelresult_exception():
 
 
 @pytest.mark.parametrize("method", ['leastsq', 'nelder', 'powell', 'cobyla',
-                                    'bfgsb', 'differential_evolution', 'brute',
+                                    'bfgs', 'lbfgsb', 'differential_evolution', 'brute',
                                     'basinhopping', 'ampgo', 'shgo',
                                     'dual_annealing'])
 def test_saveload_modelresult_roundtrip(method):


### PR DESCRIPTION
#### Description
Fixes #677 where dumping a fit using the lbfgsb method would barf.  scipy.optimize was returning a bytes object instead of string. 
I added a conversion of the key "message" to str(kwargs.get('message', '')).  Explicit use of "utf-8" in str() would let the lbfgsb method work, but cause the other methods to fail.  Using 'utf-8' was not needed in the end.


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples
- [x] Workaround for scipy.optimize bug


###### Tested on
```
Python: 3.8.6 (default, Oct  8 2020, 14:07:53) 
[Clang 11.0.0 (clang-1100.0.33.17)]

lmfit: 1.0.1+84.g7b45bbb.dirty, scipy: 1.5.2, numpy: 1.19.2, asteval: 0.9.19, uncertainties: 3.1.4
```

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257? N/A
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list? N/A
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
I had two fails which I doubt are related to my PR.
FAILED tests/test_models.py::TestSineModel::test_less_than_1_period[1] - AssertionError: wrong fit for parameter frequency: expected 0.65, fitted 0.9133860189041971.
FAILED tests/test_models.py::TestSineModel::test_typical_regime[6] - AssertionError: wrong fit for parameter amplitude: expected 23.5, fitted 22.529682640337313.

<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally? N/A
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes? test_saveload
- [ ] updated the documentation?
- [ ] added an example?
