### PR TITLE
Fix use of callable Jacobian for scalar methods

### DIFF
--- a/tests/test_bounded_jacobian.py
+++ b/tests/test_bounded_jacobian.py
@@ -35,3 +35,36 @@ def test_bounded_jacobian():
     assert_paramval(out1.params['x0'], 1.2243, tol=0.02)
     assert_paramval(out1.params['x1'], 1.5000, tol=0.02)
     assert jac_count > 5
+
+
+def test_bounded_jacobian_CG():
+    pars = Parameters()
+    pars.add('x0', value=2.0)
+    pars.add('x1', value=2.0, min=1.5)
+
+    global jac_count
+
+    jac_count = 0
+
+    def resid(params):
+        x0 = params['x0']
+        x1 = params['x1']
+        return np.array([10 * (x1 - x0*x0), 1-x0])
+
+    def jac(params):
+        global jac_count
+        jac_count += 1
+        x0 = params['x0']
+        # Jacobian of the *error*, i.e. the summed squared residuals
+        return 2 * np.sum(np.array([[-20 * x0, 10],
+                                    [-1, 0]]).T * resid(params), axis=1)
+
+    out0 = minimize(resid, pars, method='CG')
+    assert_paramval(out0.params['x0'], 1.2243, tol=0.02)
+    assert_paramval(out0.params['x1'], 1.5000, tol=0.02)
+    assert jac_count == 0
+
+    out1 = minimize(resid, pars, method='CG', Dfun=jac)
+    assert_paramval(out1.params['x0'], 1.2243, tol=0.02)
+    assert_paramval(out1.params['x1'], 1.5000, tol=0.02)
+    assert jac_count > 5


### PR DESCRIPTION
#### Description
The "scalar" methods (i.e. all except for `leastsq`) do not seem to correctly wrap the provided Jacobian to deal with parameter bounds. In addition, the code seems to attempt to translate the `Dfun` argument to `jac` for these methods, but the code to do so can never succeed (if `jac` is not in `fmin_kws`, popping it will raise an error):
https://github.com/lmfit/lmfit-py/blob/c3d07725a0ca1bcb3241182904f8a3338035edaf/lmfit/minimizer.py#L975-L977

From looking at #80, I think this came about by mixing up the two issues.

This PR should fix the issues, I added a very basic test that basically copies `test_bounded_jac` but uses the `CG` method instead. I guess an additional example or more details in the documentation would be helpful as well, but it'd take me a bit more time to provide this.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.8.5 (default, Sep  4 2020, 07:30:14) 
[GCC 7.3.0]
lmfit: 1.0.1+89.ga70ef7e, scipy: 1.5.4, numpy: 1.19.4, asteval: 0.9.21, uncertainties: 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you
- [X] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [X] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [X] added or updated existing tests to cover the changes?
- [ ] updated the documentation?

