### PR TITLE
Require numpy>=1.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
 
 # test with the minium required and latest versions of dependencies
 env:
-    - version=minimum  # asteval>=0.9.21 numpy>=1.16 scipy>=1.3 uncertainties>=3.0.1
+    - version=minimum  # asteval>=0.9.21 numpy>=1.18 scipy>=1.3 uncertainties>=3.0.1
     - version=latest  # latest version of packages available on PyPI; from requirements-dev.txt
 
 # these packages are needed to compile SciPy, when wheels are not available on PyPI.
@@ -55,16 +55,13 @@ jobs:
       after_success: skip
   allow_failures:
     - python: nightly
-    - python: 3.9
-      env:
-        - version=minimum
   fast_finish: true
 
 before_install:
     - python -m pip install --upgrade pip setuptools
 
 install:
-    - if [[ $version == minimum ]]; then pip install asteval==0.9.21 numpy==1.16 scipy==1.3 uncertainties==3.0.1 pytest coverage codecov; fi
+    - if [[ $version == minimum ]]; then pip install asteval==0.9.21 numpy==1.18 scipy==1.3 uncertainties==3.0.1 pytest coverage codecov; fi
     - if [[ $version == latest ]]; then pip install -r requirements-dev.txt -U; fi
     - python setup.py install
     - pip list

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,8 @@ before_install:
     - python -m pip install --upgrade pip setuptools
 
 install:
-    - if [[ $version == minimum ]]; then pip install asteval==0.9.21 numpy==1.18 scipy==1.3 uncertainties==3.0.1 pytest coverage codecov; fi
+    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION == 3.9 ]]; then pip install asteval==0.9.21 numpy==1.18 scipy==1.3.2 uncertainties==3.0.1 pytest coverage codecov ; fi
+    - if [[ $version == minimum && $TRAVIS_PYTHON_VERSION != 3.9 ]]; then pip install asteval==0.9.21 numpy==1.18 scipy==1.3 uncertainties==3.0.1 pytest coverage codecov ; fi
     - if [[ $version == latest ]]; then pip install -r requirements-dev.txt -U; fi
     - python setup.py install
     - pip list

--- a/INSTALL
+++ b/INSTALL
@@ -8,10 +8,10 @@ To install the lmfit Python module, use::
 
 For lmfit 1.0.X, the following versions are required:
   Python: 3.6 or higher
-  NumPy: 1.16 or higher
+  NumPy: 1.18 or higher
   SciPy: 1.3 or higher
   asteval: 0.9.21 or higher
   uncertainties: 3.0.1 or higher
 
 Matt Newville <newville@cars.uchicago.edu>
-Last Update: 2020-December-12
+Last Update: 2020-December-16

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -32,7 +32,7 @@ Lmfit works with `Python`_ versions 3.6 and higher. Version
 0.9.15 is the final version to support Python 2.7.
 
 Lmfit requires the following Python packages, with versions given:
-   * `NumPy`_ version 1.16 or higher.
+   * `NumPy`_ version 1.18 or higher.
    * `SciPy`_ version 1.3 or higher.
    * `asteval`_ version 0.9.21 or higher.
    * `uncertainties`_ version 3.0.1 or higher.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 asteval>=0.9.21
-numpy>=1.16
+numpy>=1.18
 scipy>=1.3
 uncertainties>=3.0.1


### PR DESCRIPTION
#### Description
This PR bumps the minimum required `numpy` version to 1.18.0. Secondly, to make Travis CI with Python 3.9 and minimum dependency versions build successfully we need to use `scipy==1.3.2`. 

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.9.1 (default, Dec  8 2020, 20:10:16)
[Clang 12.0.0 (clang-1200.0.32.27)]

lmfit: 1.0.1+133.g80220c3, scipy: 1.5.4, numpy: 1.19.4, asteval: 0.9.21, uncertainties: 3.1.5


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] updated the documentation?
