### PR TITLE
Add the run_mcmc_kwargs argument to Minimizer.emcee

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1151,7 +1151,8 @@ class Minimizer:
 
     def emcee(self, params=None, steps=1000, nwalkers=100, burn=0, thin=1,
               ntemps=1, pos=None, reuse_sampler=False, workers=1,
-              float_behavior='posterior', is_weighted=True, seed=None, progress=True):
+              float_behavior='posterior', is_weighted=True, seed=None,
+              progress=True, run_mcmc_kwargs={}):
         r"""Bayesian sampling of the posterior distribution.
 
         The method uses the ``emcee`` Markov Chain Monte Carlo package and
@@ -1240,6 +1241,9 @@ class Minimizer:
             `seed` for repeatable minimizations.
         progress : bool, optional
             Print a progress bar to the console while running.
+        run_mcmc_kwargs : dict, optional
+            Additional (optional) keyword arguments that are passed to
+            ``emcee.EnsembleSampler.run_mcmc``.
 
         Returns
         -------
@@ -1443,9 +1447,12 @@ class Minimizer:
         if seed is not None:
             self.sampler.random_state = rng.get_state()
 
+        if not isinstance(run_mcmc_kwargs, dict):
+            raise ValueError('run_mcmc_kwargs should be a dict of keyword arguments')
+
         # now do a production run, sampling all the time
         try:
-            output = self.sampler.run_mcmc(p0, steps, progress=progress)
+            output = self.sampler.run_mcmc(p0, steps, progress=progress, **run_mcmc_kwargs)
             self._lastpos = output.coords
         except AbortFitException:
             result.aborted = True


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

The [`emcee.EnsembleSampler.run_mcmc`](https://emcee.readthedocs.io/en/stable/user/sampler/#emcee.EnsembleSampler.run_mcmc) function that is used in `Minimizer.emcee` passes keyword
arguments to the [`emcee.EnsembleSampler.sample`](https://emcee.readthedocs.io/en/stable/user/sampler/#emcee.EnsembleSampler.sample) function. Several of these keywords could be useful to change, for example,
`skip_initial_state_check` or `tune`.

In order to facilitate this, I have added an optional parameter to `Minimizer.emcee` called `run_mcmc_kwargs`,
which is a `dict` that will be passed to the `emcee.EnsembleSampler.run_mcmc` function. In this way,
all extra keyword arguments are supported and this code does not need to be updated when extra keyword arguments
are added to `emcee.EnsembleSampler.run_mcmc` or `emcee.EnsembleSampler.sample`.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.8.5 (default, Jul 28 2020, 12:59:40) 
[GCC 9.3.0]

lmfit: 1.0.1+135.g709757d, scipy: 1.5.2, numpy: 1.19.1, asteval: 0.9.21, uncertainties: 3.1.4

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list? **I think this is not necessary because this was my own idea and I've described it above.**
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes? **I think this is not necessary because it is a very small change, that only passes on keyword arguments. It is covered by the existing tests.**
- [x] updated the documentation? 
- [ ] added an example? **I think this is not necessary because it is a very small change.**

Please let me know if I need to make changes / you have any questions. And thanks for this awesome package!