### PR TITLE
Relax epsilon, some testing updates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,6 +50,7 @@ mailing list, but many questions are not Issues. We will try our best to engage
 in all discussions, but we may simply close GitHub Issues that are actually
 questions.
 
+
 ## Providing an Example with GitHub Issues
 
 If you are reporting a bug with GitHub Issues, we do expect a small, complete,
@@ -77,9 +78,23 @@ print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties
       asteval.__version__, uncertainties.__version__, six.__version__))
 ```
 
+
 ## Using IPython Notebooks to Show Examples
 
 IPython Notebooks are very useful for showing code snippets and outcomes,
 and are a good way to demonstrate a question or raise an issue. Please
 see the above about providing examples. The notebook you provide will be
 *read*, but will probably not be run.
+
+
+## Secret Code for First Time Issues
+
+If you have not done so in the past, and are going to submit a GitHub Issue,
+you will need to include the phrase
+
+```
+Yes, I read the instructions and I am sure this is a GitHub Issue.
+```
+
+as the First Time Issue Code. If you do not copy and paste this in verbatim,
+we will know that you did not read the instructions.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,24 +1,34 @@
 ### DO NOT IGNORE ###
 
-If you have not submitted a GitHub Issue to lmfit before, please read
+READ THESE INSTRUCTIONS FULLY. IF YOU DO NOT, YOUR ISSUE WILL BE CLOSED.
+
+If you have not submitted a GitHub Issue to lmfit before, read
 [this](https://github.com/lmfit/lmfit-py/blob/master/.github/CONTRIBUTING.md) first.
 
-In short, it says: ***do NOT use GitHub Issues for questions, it is only for bugs!***
+***DO NOT USE GitHub Issues for questions, it is only for bugs!***
 
-We are happy to help, but please use the [mailing list](https://groups.google.com/group/lmfit-py)
-for questions about lmfit. If you decide to ignore this and do post a question
-as a GitHub Issue anyway, your Issue will be closed and not answered.
+If you **think** something is an Issue, it probably is not an Issue.
+Getting a "bad fit" does NOT qualify as an Issue! Issues here are
+concerned with errors or problems in the lmfit code.
 
-However, if you discovered a bug, please do proceed and provide ALL of the following information:
+Use the [mailing list](https://groups.google.com/group/lmfit-py) for
+questions about lmfit or things you think might be problems. If you ignore
+this advice and post a question as a GitHub Issue anyway, your Issue will
+be closed and not answered. If you have any doubt, start with the mailing
+list.
+
+To submit an Issue, you MUST provide ALL of the following information. If
+you delete any of these sections, your Issue may be closed. If you think one
+of the sections does not apply to your Issue, state that explicitly.
+
+#### First Time Issue Code
+<!-- If this is your first Issue, you will write down the Secret Code for First Time Issues from the CONTRIBUTING.md file linked to above -->
 
 #### Description
-<!-- Provide a short description of the issue, describe the expected outcome, and give
-        the actual result -->
-
+<!-- Provide a short description of the issue, describe the expected outcome, and give the actual result -->
 
 ###### A Minimal, Complete, and Verifiable example
 <!-- see, for example, https://stackoverflow.com/help/mcve on how to do this. -->
-
 
 ###### Error message:
 <!-- If any, paste the *full* error message inside a code block (starting from line Traceback) -->
@@ -29,7 +39,6 @@ Traceback (most recent call last):
   ...
 ```
 
-
 ###### Version information
 <!-- Generate version information with this command in the Python shell and copy the output here:
 import sys, lmfit, numpy, scipy, asteval, uncertainties
@@ -37,7 +46,6 @@ print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties
       .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
       asteval.__version__, uncertainties.__version__))
  -->
-
 
 ###### Link(s)
 <!--If you started a discussion on the lmfit mailing list or Stack Overflow, please provide

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -2,8 +2,8 @@
 
 import warnings
 
-from numpy import (arctan, copysign, cos, exp, finfo, float64, isnan, log, pi,
-                   real, sin, sqrt, where)
+from numpy import (arctan, copysign, cos, exp, isnan, log, pi, real, sin, sqrt,
+                   where)
 from scipy.special import erf, erfc
 from scipy.special import gamma as gamfcn
 from scipy.special import wofz
@@ -12,7 +12,9 @@ log2 = log(2)
 s2pi = sqrt(2*pi)
 spi = sqrt(pi)
 s2 = sqrt(2.0)
-tiny = finfo(float64).eps
+# tiny had been numpy.finfo(numpy.float64).eps ~=2.2e16.
+# here, we explicitly set it to 1.e-15 == numpy.finfo(numpy.float64).resolution
+tiny = 1.0e-15
 
 functions = ('gaussian', 'gaussian2d', 'lorentzian', 'voigt', 'pvoigt',
              'moffat', 'pearson7', 'breit_wigner', 'damped_oscillator',

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -526,12 +526,12 @@ class Minimizer:
 
         If `max_nfev` is None, use the provided `default_value`.
 
-        >>> self.set_max_nfev(max_nfev, 1000*(result.nvarys+1))
+        >>> self.set_max_nfev(max_nfev, 2000*(result.nvarys+1))
 
         """
         if max_nfev is not None:
             self.max_nfev = max_nfev
-        elif self.max_nfev in (None, np.inf):
+        if self.max_nfev in (None, np.inf):
             self.max_nfev = default_value
 
     @property
@@ -576,7 +576,7 @@ class Minimizer:
         params.update_constraints()
 
         if self.max_nfev is None:
-            self.max_nfev = np.inf
+            self.max_nfev = 200000*(len(fvars)+1)
 
         self.result.nfev += 1
         self.result.last_internal_values = fvars
@@ -921,7 +921,7 @@ class Minimizer:
             Parameters to use as starting point.
         max_nfev : int or None, optional
             Maximum number of function evaluations. Defaults to
-            ``1000*(nvars+1)``, where ``nvars`` is the number of variable
+            ``2000*(nvars+1)``, where ``nvars`` is the number of variable
             parameters.
         **kws : dict, optional
             Minimizer options pass to :scipydoc:`optimize.minimize`.
@@ -954,7 +954,7 @@ class Minimizer:
         variables = result.init_vals
         params = result.params
 
-        self.set_max_nfev(max_nfev, 1000*(result.nvarys+1))
+        self.set_max_nfev(max_nfev, 2000*(result.nvarys+1))
         fmin_kws = dict(method=method, options={'maxiter': 2*self.max_nfev})
         fmin_kws.update(self.kws)
 
@@ -1543,7 +1543,7 @@ class Minimizer:
             Parameters to use as starting point.
         max_nfev : int or None, optional
             Maximum number of function evaluations. Defaults to
-            ``1000*(nvars+1)``, where ``nvars`` is the number of variable
+            ``2000*(nvars+1)``, where ``nvars`` is the number of variable
             parameters.
         **kws : dict, optional
             Minimizer options to pass to :scipydoc:`optimize.least_squares`.
@@ -1563,7 +1563,7 @@ class Minimizer:
         result.method = 'least_squares'
 
         replace_none = lambda x, sign: sign*np.inf if x is None else x
-        self.set_max_nfev(max_nfev, 1000*(result.nvarys+1))
+        self.set_max_nfev(max_nfev, 2000*(result.nvarys+1))
 
         start_vals, lower_bounds, upper_bounds = [], [], []
         for vname in result.var_names:
@@ -1749,7 +1749,7 @@ class Minimizer:
 
         return result
 
-    def basinhopping(self, params=None, **kws):
+    def basinhopping(self, params=None, max_nfev=None, **kws):
         """Use the `basinhopping` algorithm to find the global minimum.
 
         This method calls :scipydoc:`optimize.basinhopping` using the
@@ -1762,6 +1762,9 @@ class Minimizer:
         params : Parameters, optional
             Contains the Parameters for the model. If None, then the
             Parameters used to initialize the Minimizer object are used.
+        max_nfev : int or None, optional
+            Maximum number of function evaluations (default is None). Defaults
+            to ``200000*(nvarys+1)``.
         **kws : dict, optional
             Minimizer options to pass to :scipydoc:`optimize.basinhopping`.
 
@@ -1777,7 +1780,7 @@ class Minimizer:
         """
         result = self.prepare_fit(params=params)
         result.method = 'basinhopping'
-
+        self.set_max_nfev(max_nfev, 200000*(result.nvarys+1))
         basinhopping_kws = dict(niter=100, T=1.0, stepsize=0.5,
                                 minimizer_kwargs={}, take_step=None,
                                 accept_test=None, callback=None, interval=50,
@@ -1810,7 +1813,7 @@ class Minimizer:
 
         return result
 
-    def brute(self, params=None, Ns=20, keep=50, workers=1):
+    def brute(self, params=None, Ns=20, keep=50, workers=1, max_nfev=None):
         """Use the `brute` method to find the global minimum of a function.
 
         The following parameters are passed to :scipydoc:`optimize.brute`
@@ -1848,6 +1851,9 @@ class Minimizer:
         workers : int or map-like callable, optional
             For parallel evaluation of the grid (see :scipydoc:`optimize.brute`
             for more details).
+        max_nfev : int or None, optional
+            Maximum number of function evaluations (default is None). Defaults
+            to ``200000*(nvarys+1)``.
 
         Returns
         -------
@@ -1896,6 +1902,7 @@ class Minimizer:
         """
         result = self.prepare_fit(params=params)
         result.method = 'brute'
+        self.set_max_nfev(max_nfev, 200000*(result.nvarys+1))
 
         brute_kws = dict(full_output=1, finish=None, disp=False, Ns=Ns,
                          workers=workers)
@@ -2066,7 +2073,7 @@ class Minimizer:
 
         """
         result = self.prepare_fit(params=params)
-        self.set_max_nfev(max_nfev, 1000000*(result.nvarys+1))
+        self.set_max_nfev(max_nfev, 200000*(result.nvarys+1))
 
         ampgo_kws = dict(local='L-BFGS-B', local_opts=None, maxfunevals=None,
                          totaliter=20, maxiter=5, glbtol=1e-5, eps1=0.02,
@@ -2121,7 +2128,7 @@ class Minimizer:
             Parameters used to initialize the Minimizer object are used.
         max_nfev : int or None, optional
             Maximum number of function evaluations. Defaults to
-            ``1e6*(nvars+1)``, where ``nvars`` is the number of variable
+            ``200000*(nvars+1)``, where ``nvars`` is the number of variable
             parameters.
         **kws : dict, optional
             Minimizer options to pass to the SHGO algorithm.
@@ -2142,7 +2149,7 @@ class Minimizer:
         result = self.prepare_fit(params=params)
         result.method = 'shgo'
 
-        self.set_max_nfev(max_nfev, 1000000*(result.nvarys+1))
+        self.set_max_nfev(max_nfev, 200000*(result.nvarys+1))
 
         shgo_kws = dict(constraints=None, n=100, iters=1, callback=None,
                         minimizer_kwargs=None, options=None,
@@ -2193,7 +2200,8 @@ class Minimizer:
             Contains the Parameters for the model. If None, then the
             Parameters used to initialize the Minimizer object are used.
         max_nfev : int or None, optional
-            Maximum number of function evaluations. Defaults to 1e7.
+            Maximum number of function evaluations. Defaults to
+            ``200000*(nvars+1)``, where ``nvars`` is the number of variables.
         **kws : dict, optional
             Minimizer options to pass to the dual_annealing algorithm.
 
@@ -2212,7 +2220,7 @@ class Minimizer:
         """
         result = self.prepare_fit(params=params)
         result.method = 'dual_annealing'
-        self.set_max_nfev(max_nfev, 1.e7)
+        self.set_max_nfev(max_nfev, 200000*(result.nvarys+1))
 
         da_kws = dict(maxiter=1000, local_search_options={},
                       initial_temp=5230.0, restart_temp_ratio=2e-05,
@@ -2446,8 +2454,8 @@ def minimize(fcn, params, method='leastsq', args=None, kws=None, iter_cb=None,
     """Perform the minimization of the objective function.
 
     The minimize function takes an objective function to be minimized,
-    a dictionary (:class:`~lmfit.parameter.Parameters` ; Parameters) containing the
-    model parameters, and several optional arguments including the fitting
+    a dictionary (:class:`~lmfit.parameter.Parameters` ; Parameters) containing
+    the model parameters, and several optional arguments including the fitting
     method.
 
     Parameters

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -12,10 +12,9 @@ from .lineshapes import (breit_wigner, damped_oscillator, dho, doniach,
                          linear, lognormal, lorentzian, moffat, parabolic,
                          pearson7, powerlaw, pvoigt, rectangle, sine,
                          skewed_gaussian, skewed_voigt, split_lorentzian, step,
-                         students_t, thermal_distribution, voigt)
+                         students_t, thermal_distribution, tiny, voigt)
 from .model import Model
 
-tiny = np.finfo(np.float64).eps
 tau = 2.0 * np.pi
 
 

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -352,7 +352,7 @@ class SineModel(Model):
     def _set_paramhints_prefix(self):
         self.set_param_hint('amplitude', min=0)
         self.set_param_hint('frequency', min=0)
-        self.set_param_hint('shift', min=0, max=tau)
+        self.set_param_hint('shift', min=-tau-1.e-5, max=tau+1.e-5)
 
     def guess(self, data, x, **kwargs):
         """Estimate initial model parameter values from the FFT of the data."""

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -10,6 +10,7 @@ from numpy import arcsin, array, cos, inf, isclose, sin, sqrt
 import scipy.special
 
 from .jsonutils import decode4js, encode4js
+from .lineshapes import tiny
 from .printfuncs import params_html_table
 
 SCIPY_FUNCTIONS = {'gamfcn': scipy.special.gamma}
@@ -772,6 +773,8 @@ class Parameter:
             self.from_internal = lambda val: self.min + (sin(val) + 1) * \
                                  (self.max - self.min) / 2.0
             _val = arcsin(2*(self._val - self.min)/(self.max - self.min) - 1)
+        if abs(_val) < tiny:
+            _val = 0.0
         return _val
 
     def scale_gradient(self, val):

--- a/tests/test_max_nfev.py
+++ b/tests/test_max_nfev.py
@@ -56,9 +56,6 @@ def minimizerGaussian(modelGaussian):
 @pytest.mark.parametrize("method", methods)
 def test_max_nfev_Minimizer(minimizerGaussian, method):
     """Test the max_nfev argument for all solvers using Minimizer interface."""
-    if method in ('brute', 'basinhopping'):
-        pytest.xfail(f'max_nfev not yet supported in {method}')  # FIXME
-
     result = minimizerGaussian.minimize(method=method, max_nfev=10)
     assert minimizerGaussian.max_nfev == 10
     assert result.nfev < 15
@@ -82,20 +79,17 @@ def test_max_nfev_Model(modelGaussian, minimizerGaussian, method):
 
 @pytest.mark.parametrize("method, default_max_nfev",
                          [('leastsq', 2000*(nvarys+1)),
-                          ('least_squares', 1000*(nvarys+1)),
-                          ('nelder', 1000*(nvarys+1)),
-                          ('brute', np.inf),
-                          ('ampgo', 1000000*(nvarys+1)),
-                          ('basinhopping', 2000*(nvarys+1)),
-                          ('differential_evolution', 1000*(nvarys+1)),
-                          ('shgo', 1000000*(nvarys+1)),
-                          ('dual_annealing', 1.e7)])
+                          ('least_squares', 2000*(nvarys+1)),
+                          ('nelder', 2000*(nvarys+1)),
+                          ('differential_evolution', 2000*(nvarys+1)),
+                          ('ampgo', 200000*(nvarys+1)),
+                          ('brute', 200000*(nvarys+1)),
+                          ('basinhopping', 200000*(nvarys+1)),
+                          ('shgo', 200000*(nvarys+1)),
+                          ('dual_annealing', 200000*(nvarys+1))])
 def test_default_max_nfev(modelGaussian, minimizerGaussian, method,
                           default_max_nfev):
     """Test the default values when setting max_nfev=None."""
-    if method in ('brute', 'basinhopping'):
-        pytest.xfail(f'max_nfev not yet supported in {method}')  # FIXME
-
     x, y, mod, pars = modelGaussian
     result = mod.fit(y, pars, x=x, method=method, max_nfev=None)
     assert result.max_nfev == default_max_nfev

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -101,3 +101,19 @@ def testSineManyShifts():
                                  intercept=10, slope=0)
 
         check_fit(mod, params, x, y, pars, noise_scale=0.02)
+
+
+def testSineModel_guess():
+    mod = lmfit.models.SineModel()
+    x = np.linspace(-10, 10, 201)
+    pars = dict(amplitude=1.5, frequency=0.5, shift=0.4)
+
+    y = pars['amplitude']*np.sin(x*pars['frequency'] + pars['shift'])
+
+    params = mod.guess(y, x=x)
+    assert params['amplitude'] > 0.5
+    assert params['amplitude'] < 5.0
+    assert params['frequency'] > 0.1
+    assert params['frequency'] < 1.5
+    assert params['shift'] > 0.0
+    assert params['shift'] < 1.0

--- a/tests/test_saveload.py
+++ b/tests/test_saveload.py
@@ -142,7 +142,7 @@ def test_save_load_modelresult(dill):
     text = ''
     with open(SAVE_MODELRESULT) as fh:
         text = fh.read()
-    assert 13300 < len(text) < 13900  # depending on whether dill is present
+    assert 12000 < len(text) < 15000  # depending on whether dill is present
 
     # load the saved ModelResult from file and compare results
     result_saved = load_modelresult(SAVE_MODELRESULT)


### PR DESCRIPTION


#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

This addresses #700 and also a couple of other oddities.  Basically, many of the modules use

`tiny = 2.2e-16` which is "smallest double-precision delta" to mean "very small value" in divide-by-zero tests, etc.   This can lead to frustrating-if-not-exactly-buggy behavior.  

So, this PR increases that "tiny value" to 1.e-15 (coincidentally, `=numpy.finfo(numpy.float64).resolution`).    It also adds an explicit check for "tiny internal value" for bounded parameters and sets that to 0, avoiding "parameter not moving from initial value" as seen in #700. 

A test is added. 

This PR also relaxes the bounds "hint" for the `shift` of SineModel (from [0, 2pi] to [-2pi, 2pi], and extending by a small amount).  Related to that model, it also greatly simplifies the tests of SineModel in `test_models.py` which I found to be too-clever-by-half and very prone to failure.



###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.8.5 (default, Sep  4 2020, 02:22:02)
[Clang 10.0.0 ]

lmfit: 1.0.1+157.gd5e6ec4, scipy: 1.5.2, numpy: 1.19.2, asteval: 0.9.21, uncertainties: 3.1.5

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?

