### PR TITLE
DOC: last changes for new release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'versioneer.py|lmfit/_version|doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.8.0
+    rev: v2.9.0
     hooks:
     -   id: pyupgrade
         # for now don't force to change from %-operator to {}
@@ -21,7 +21,6 @@ repos:
     -   id: requirements-txt-fixer
     -   id: fix-encoding-pragma
         args: [--remove]
-    -   id: mixed-line-ending
 
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -54,7 +54,7 @@ nmearl, Gustavo Pasquevich, Clemens Prescher, LiCode, Ben Gamari, Yoav
 Roam, Alexander Stark, Alexandre Beelen, Andrey Aristov, Nicholas Zobrist,
 Ethan Welty, Julius Zimmermann, Mark Dean, Arun Persaud, Ray Osborn, @lneuhaus,
 Marcel Stimberg, Yoshiera Huang, Leon Foks, Sebastian Weigand, Florian LB,
-Michael Hudson-Doyle, and many others.
+Michael Hudson-Doyle, Ruben Verweij, @jedzill4, and many others.
 
 The lmfit code obviously depends on, and owes a very large debt to the code
 in scipy.optimize.  Several discussions on the SciPy-user and lmfit mailing

--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -1,7 +1,7 @@
 <h3 style="text-align:center;">Getting LMFIT</h3>
-<p>Current version: <b>{{ release }}</b></p>
+<p>Current version: <b><a href="whatsnew.html">{{ release }}</b></a></p>
 <p>Install:  &nbsp; <tt>pip install lmfit</tt>
-<p>Download: &nbsp; <a href="http://pypi.python.org/pypi/lmfit/">PyPI</a>
+<p>Download: &nbsp; <a href="https://pypi.python.org/pypi/lmfit/">PyPI</a>
 <p>Develop:  &nbsp; <a href="https://github.com/lmfit/lmfit-py/">GitHub</a> <br>
 
 <h3 style="text-align:center;">Questions?</h3>

--- a/doc/_templates/indexsidebar.html
+++ b/doc/_templates/indexsidebar.html
@@ -12,8 +12,8 @@
 
 <h3 style="text-align:center;">Static, off-line docs</h3>
 
-&nbsp; &nbsp; &nbsp;[ <a href="https://cars9.uchicago.edu/software/python/lmfit/lmfit.pdf">PDF</a>
-| <a href="https://cars9.uchicago.edu/software/python/lmfit/lmfit.epub">EPUB</a>
-| <a href="https://cars9.uchicago.edu/software/python/lmfit/lmfit_doc.zip">HTML (zip)</a> ]
+&nbsp; &nbsp; &nbsp;[ <a href="lmfit.pdf">PDF</a>
+| <a href="lmfit.epub">EPUB</a>
+| <a href="lmfit_doc.zip">HTML (zip)</a> ]
 
 <p>

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -15,10 +15,10 @@ consult the `lmfit GitHub repository`_.
 .. _whatsnew_1XX_label:
 
 
-Version 1.X.X Release Notes (unreleased)
+Version 1.0.2 Release Notes (unreleased)
 ========================================
 
-Version 1.X.X officially supports Python 3.9 and has dropped support for Python 3.5. The minimum version
+Version 1.0.2 officially supports Python 3.9 and has dropped support for Python 3.5. The minimum version
 of the following dependencies were updated: asteval>=0.9.21, numpy>=1.18, and scipy>=1.3.
 
 New features:
@@ -26,13 +26,14 @@ New features:
 - added two-dimensional Gaussian lineshape and model (PR #642; @mpmdean)
 - all built-in models are now registered in lmfit.models.lmfit_models; new Model class attribute "valid_forms" (PR #663; @rayosborn)
 - added a SineModel (PR #676; @lneuhaus)
+- add the ``run_mcmc_kwargs argument`` to ``Minimizer.emcee`` to pass to the ``emcee.EnsembleSampler.run_mcmc`` function (PR #694; @rbnvrw)
 
 Bug fixes:
 
-- ModelResult.eval_uncertainty should use provided Parameters (PR #646)
+- ``ModelResult.eval_uncertainty`` should use provided Parameters (PR #646)
 - center in lognormal model can be negative (Issue #644, PR #645; @YoshieraHuang)
 - restore best-fit values after calculation of covariance matrix (Issue #655, PR #657)
-- add helper-function 'not_zero' to prevent ZeroDivisionError in lineshapes and use in exponential lineshape (Issue #631, PR #664; @s-weigand)
+- add helper-function ``not_zero`` to prevent ZeroDivisionError in lineshapes and use in exponential lineshape (Issue #631, PR #664; @s-weigand)
 - save last_internal_values and use to restore internal values if fit is aborted (PR #667)
 - dumping a fit using the lbfgsb method now works, convert bytes to string if needed (Issue #677, PR #678; @leonfoks)
 - fix use of callable Jacobian for scalar methods (PR #681; @mstimberg)
@@ -49,6 +50,10 @@ Various:
 - make building of documentation cross-platform (PR #673; @s-weigand)
 - relax module name check in test_check_ast_errors for Python 3.9 (Issue #674, PR #675; @mwhudson)
 - fix/update layout of documentation, now uses the sphinx13 theme (PR #687)
+- fixed DeprecationWarnings reported by NumPy v1.2.0 (PR #699)
+- increase value of ``tiny`` and check for it in bounded parameters to avoid "parameter not moving from initial value" (Issue #700, PR #701)
+- add ``max_nfev`` to ``basinhopping`` and ``brute`` (now supported everywhere in lmfit) and set to more uniform default values (PR #701)
+- use Azure Pipelines for CI, drop Travis (PRs #696 and #702)
 
 
 .. _whatsnew_101_label:

--- a/publish_docs.sh
+++ b/publish_docs.sh
@@ -1,21 +1,16 @@
-installdir='/www/apache/htdocs/software/python/lmfit'
-docbuild='doc/_build'
+#!/usr/bin/env sh
+
+# shell script for building the documentation and updating GitHub Pages
 
 cd doc
-echo '# Making docs'
+echo '# Building lmfit documentation (PDF/EPUB/HTML)'
+make clean
 make all
 cd ../
 
-echo '# Building tarball of docs'
-mkdir _tmpdoc
-cp -pr doc/lmfit.pdf     _tmpdoc/lmfit.pdf
-cp -pr doc/_build/html/*    _tmpdoc/.
-cd _tmpdoc
-tar czf ../../lmfit_docs.tar.gz .
-cd ..
-rm -rf _tmpdoc
+echo '# Building tarball of documentation'
+tar czf lmfit_docs.tar.gz doc/_build/html/* -C doc/_build/html .
 
-#
 echo "# Switching to gh-pages branch"
 git checkout gh-pages
 
@@ -24,36 +19,24 @@ if  [ $? -ne 0 ]  ; then
   exit
 fi
 
-tar xzf ../lmfit_docs.tar.gz .
+echo '# Clean-up old documentation files'
+rm -rf *.html *.js
+rm -rf _download _images _sources _static
 
-echo "# commit changes to gh-pages branch"
-git commit -am "changed docs"
+echo '# Unpack new documentation files'
+tar xzf lmfit_docs.tar.gz
+rm -f lmfit_docs.tar.gz
+rm -f .buildinfo
 
-if  [ $? -ne 0 ]  ; then
-  echo ' failed.'
-  exit
-fi
-
-echo "# Pushing docs to github"
-git push
-
-
-echo "# switch back to master branch"
-git checkout master
+echo '# Commit changes to gh-pages branch'
+export version=`git tag | sort | tail -1`
+git add *
+git commit -am "DOC: update documentation for ${version}"
 
 if  [ $? -ne 0 ]  ; then
   echo ' failed.'
   exit
 fi
 
-# install locally
-echo "# Installing docs to CARS web pages"
-cp ../lmfit_docs.tar.gz $installdir/..
-
-cd $installdir
-if  [ $? -ne 0 ]  ; then
-  echo ' failed.'
-  exit
-fi
-
-tar xvzf ../lmfit_docs.tar.gz
+echo '# Please check the commit and if everything looks good, push the changes:'
+echo 'for example by doing: `git push` or `git push upstream`'


### PR DESCRIPTION
#### Description
A few small changes to the documentation, making this -hopefully- ready for a new release:
- update `whatsnew.rst` and link the version number in the sidebar to that document
- link to EPUB/PDF/HTML documentation on `gh-pages` instead of `https://cars9.uchicago.edu/software/python/lmfit/`
- update `publish_docs.sh` to build all documentation on `master`, then switch to `gh-pages`. Once on that branch clean-up all the old files first, unpack the latest documentation, and commit with adding the latest `tag` to the commit message. After checking that the commit is indeed correct it can be pushed to `upstream`. 

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.9.1 (default, Dec  8 2020, 20:10:16)
[Clang 12.0.0 (clang-1200.0.32.27)]

lmfit: 1.0.1+161.gc8ed043, scipy: 1.6.0, numpy: 1.20.0, asteval: 0.9.21, uncertainties: 3.1.5


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
