### PR TITLE
CI: get testing with Python3.10-devel to work

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,6 +123,8 @@ stages:
         - script: |
             python -m pip install --upgrade pip setuptools wheel
             pip install -r requirements-dev.txt
+            # temporarily install asteval from master branch to avoid NumPy v1.20 DeprecationWarnings
+            pip install git+https://github.com/newville/asteval@master
           displayName: 'Install latest available version of Python dependencies'
         - script: |
             python setup.py install
@@ -183,6 +185,8 @@ stages:
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
             pip3.10 install asteval uncertainties dill emcee numdifftools
+            # temporarily install asteval from master branch to avoid NumPy v1.20 DeprecationWarnings
+            pip3.10 install git+https://github.com/newville/asteval@master
           displayName: 'Install latest available version of Python dependencies'
         - script: |
             python3.10 setup.py install --user

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,7 @@ stages:
         - script: |
             python -m pip install --upgrade pip setuptools wheel
             pip install -r requirements-dev.txt
-          displayName: 'Install latest available versions of Python dependencies'
+          displayName: 'Install latest available version of Python dependencies'
         - script: |
             python setup.py install
           displayName: 'Install lmfit'
@@ -160,16 +160,40 @@ stages:
             export PATH=/home/vsts/.local/bin:$PATH
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             python3.10 get-pip.py --user
-            pip3.10 install -r requirements-dev.txt -U --user || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
-          displayName: 'Install latest available versions of Python dependencies'
+            pip3.10 install -U pip setuptools wheel pybind11
+            # install Cython from GitHub to fix "undefined symbol: _PyGen_Send" error
+            pip3.10 install git+https://github.com/cython/cython@0.29.x
+          displayName: 'Install pip, setuptools, wheel, pybind11 cython'
         - script: |
-            python3.10 setup.py install --user || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
+            export PATH=/home/vsts/.local/bin:$PATH
+            wget https://github.com/numpy/numpy/releases/download/v1.20.0/numpy-1.20.0.tar.gz
+            tar xzvf numpy-1.20.0.tar.gz
+            cd numpy-1.20.0
+            python3.10 setup.py install --user
+          displayName: 'Install latest available version of NumPy'
+        - script: |
+            export PATH=/home/vsts/.local/bin:$PATH
+            wget https://github.com/scipy/scipy/releases/download/v1.6.0/scipy-1.6.0.tar.gz
+            tar xzvf scipy-1.6.0.tar.gz
+            cd scipy-1.6.0
+            # force Cythonizing code in attempt to avoid "undefined symbol: _PyGen_Send" error
+            rm -f PKG-INFO cythonize.dat
+            python3.10 setup.py install --user
+          displayName: 'Install latest available version of SciPy'
+        - script: |
+            export PATH=/home/vsts/.local/bin:$PATH
+            pip3.10 install asteval uncertainties dill emcee numdifftools
+          displayName: 'Install latest available version of Python dependencies'
+        - script: |
+            python3.10 setup.py install --user
           displayName: 'Install lmfit'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
             pip3.10 list
           displayName: 'List installed Python packages'
         - script: |
-            pip3.10 install pytest-azurepipelines --user
+            export PATH=/home/vsts/.local/bin:$PATH
+            pip3.10 install pytest pytest-azurepipelines
+            cd $(Agent.BuildDirectory)/s/tests
             pytest || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
           displayName: 'Run test-suite'


### PR DESCRIPTION
#### Description
Another attempt to get the pipeline for Python3.10-dev to work... Install the latest version of `NumPy` and `SciPy` with `python setup.py install` instead of `pip`. Not sure if it's completely working correctly yet as I get some weirdness when running the actual `lmfit` test-suite... but the building/installing all packages now works. 

No rush to merge this, does not need to be part of the upcoming release. Let's just leave it open until it's all tested and fixed.