### PR TITLE
better support for save/load of ExpressionModel

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -15,8 +15,8 @@ consult the `lmfit GitHub repository`_.
 .. _whatsnew_1XX_label:
 
 
-Version 1.0.2 Release Notes (unreleased)
-========================================
+Version 1.0.2 Release Notes
+===========================
 
 Version 1.0.2 officially supports Python 3.9 and has dropped support for Python 3.5. The minimum version
 of the following dependencies were updated: asteval>=0.9.21, numpy>=1.18, and scipy>=1.3.
@@ -38,6 +38,7 @@ Bug fixes:
 - dumping a fit using the lbfgsb method now works, convert bytes to string if needed (Issue #677, PR #678; @leonfoks)
 - fix use of callable Jacobian for scalar methods (PR #681; @mstimberg)
 - preserve float/int types when encoding for JSON (PR #696; @jedzill4)
+- better support for saving/loading of ExpressionModels and assure that ``init_params`` and ``init_fit`` are set when loading a ``ModelResult`` (PR #706)
 
 Various:
 


### PR DESCRIPTION
better support for save/load of ExpressionModel, make sure init_params and init_fit get restored for modelresult

<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

This does two things:

  1.  make a special case for save/load of ExpressionModels - they're weird enough to need it
  2. make sure that init_params and init_fit are correct for a loaded ModelResult.
 
Basically using the example from https://groups.google.com/g/lmfit-py/c/osukDLEbYT8/m/ATUEu-9rBgAJ

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.8.5 (default, Sep  4 2020, 02:22:02)
[Clang 10.0.0 ]

lmfit: 1.0.1+173.gbaf4676, scipy: 1.5.2, numpy: 1.19.2, asteval: 0.9.21, uncertainties: 3.1.5


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [ ] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
