### PR TITLE
a few minor updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'versioneer.py|lmfit/_version|doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.9.0
+    rev: v2.10.0
     hooks:
     -   id: pyupgrade
         # for now don't force to change from %-operator to {}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ stages:
           displayName: 'Install dependencies'
         - script: |
             python -m pip install --upgrade pip setuptools wheel
-            pip install asteval==0.9.21 numpy==1.18 scipy==1.3.2 uncertainties==3.0.1 pytest coverage codecov
+            pip install asteval==0.9.22 numpy==1.18 scipy==1.3.2 uncertainties==3.0.1 pytest coverage codecov
           displayName: 'Install minimum required version of dependencies'
         - script: |
             python setup.py install
@@ -123,8 +123,6 @@ stages:
         - script: |
             python -m pip install --upgrade pip setuptools wheel
             pip install -r requirements-dev.txt
-            # temporarily install asteval from master branch to avoid NumPy v1.20 DeprecationWarnings
-            pip install git+https://github.com/newville/asteval@master
           displayName: 'Install latest available version of Python dependencies'
         - script: |
             python setup.py install
@@ -185,8 +183,6 @@ stages:
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
             pip3.10 install asteval uncertainties dill emcee numdifftools
-            # temporarily install asteval from master branch to avoid NumPy v1.20 DeprecationWarnings
-            pip3.10 install git+https://github.com/newville/asteval@master
           displayName: 'Install latest available version of Python dependencies'
         - script: |
             python3.10 setup.py install --user

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -33,7 +33,7 @@ Lmfit works with `Python`_ versions 3.6 and higher. Version
 Lmfit requires the following Python packages, with versions given:
    * `NumPy`_ version 1.18 or higher.
    * `SciPy`_ version 1.3 or higher.
-   * `asteval`_ version 0.9.21 or higher.
+   * `asteval`_ version 0.9.22 or higher.
    * `uncertainties`_ version 3.0.1 or higher.
 
 All of these are readily available on PyPI, and should be installed

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -23,6 +23,7 @@ Bug fixes:
 
 Various:
 - update asteval dependency to >=0.9.22 to avoid DeprecationWarnings from NumPy v1.20.0 (PR #707)
+- remove incorrectly spelled ``DonaichModel`` and ``donaich`` lineshape, deprecated in version 1.0.1 (PR #707)
 
 
 .. _whatsnew_102_label:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -12,10 +12,23 @@ to be a comprehensive list of changes. For such a complete record,
 consult the `lmfit GitHub repository`_.
 
 
+.. _whatsnew_103_label:
+
+Version 1.0.3 Release Notes (unreleased)
+========================================
+
+New features:
+
+Bug fixes:
+
+Various:
+- update asteval dependency to >=0.9.22 to avoid DeprecationWarnings from NumPy v1.20.0 (PR #707)
+
+
 .. _whatsnew_102_label:
 
-Version 1.0.2 Release Notes
-===========================
+Version 1.0.2 Release Notes (February 7, 2021)
+==============================================
 
 Version 1.0.2 officially supports Python 3.9 and has dropped support for Python 3.5. The minimum version
 of the following dependencies were updated: asteval>=0.9.21, numpy>=1.18, and scipy>=1.3.

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -1,7 +1,5 @@
 """Basic model line shapes and distribution functions."""
 
-import warnings
-
 from numpy import (arctan, copysign, cos, exp, isnan, log, pi, real, sin, sqrt,
                    where)
 from scipy.special import erf, erfc
@@ -19,7 +17,7 @@ tiny = 1.0e-15
 functions = ('gaussian', 'gaussian2d', 'lorentzian', 'voigt', 'pvoigt',
              'moffat', 'pearson7', 'breit_wigner', 'damped_oscillator',
              'dho', 'logistic', 'lognormal', 'students_t', 'expgaussian',
-             'doniach', 'donaich', 'skewed_gaussian', 'skewed_voigt',
+             'doniach', 'skewed_gaussian', 'skewed_voigt',
              'thermal_distribution', 'step', 'rectangle', 'exponential',
              'powerlaw', 'linear', 'parabolic', 'sine', 'expsine',
              'split_lorentzian')
@@ -287,20 +285,6 @@ def doniach(x, amplitude=1.0, center=0, sigma=1.0, gamma=0.0):
     gm1 = (1.0 - gamma)
     scale = amplitude/max(tiny, (sigma**gm1))
     return scale*cos(pi*gamma/2 + gm1*arctan(arg))/(1 + arg**2)**(gm1/2)
-
-
-def donaich(x, amplitude=1.0, center=0, sigma=1.0, gamma=0.0):
-    """Return a Doniach Sunjic asymmetric lineshape.
-
-    Function added here for backwards-compatibility, will emit a
-    `FutureWarning` when used.
-
-    """
-    msg = ('Please correct the name of your lineshape function: donaich --> '
-           'doniach. The incorrect spelling will be removed in a later '
-           'release.')
-    warnings.warn(FutureWarning(msg))
-    return doniach(x, amplitude, center, sigma, gamma)
 
 
 def skewed_gaussian(x, amplitude=1.0, center=0.0, sigma=1.0, gamma=0.0):

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1,7 +1,6 @@
 """Module containing built-in fitting models."""
 
 import time
-import warnings
 
 from asteval import Interpreter, get_ast_names
 import numpy as np
@@ -1227,24 +1226,6 @@ class DoniachModel(Model):
 
     __init__.__doc__ = COMMON_INIT_DOC
     guess.__doc__ = COMMON_GUESS_DOC
-
-
-class DonaichModel(DoniachModel):
-    """A model of an Doniach Sunjic asymmetric lineshape.
-
-    Model added here for backwards-compatibility, will emit a
-    `FutureWarning` when used.
-
-    """
-
-    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
-                 **kwargs):
-
-        msg = ('Please correct the name of your built-in model: DonaichModel '
-               '--> DoniachModel. The incorrect spelling will be removed in '
-               'a later release.')
-        warnings.warn(FutureWarning(msg))
-        super().__init__(**kwargs)
 
 
 class PowerLawModel(Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asteval>=0.9.21
+asteval>=0.9.22
 numpy>=1.18
 scipy>=1.3
 uncertainties>=3.0.1

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -4,7 +4,6 @@ import inspect
 
 import numpy as np
 from numpy.testing import assert_allclose
-import pytest
 from scipy.optimize import fsolve
 
 from lmfit import lineshapes, models
@@ -285,12 +284,3 @@ def test_guess_from_peak2d():
 
     for param, value in zip(['centerx', 'centery'], [centerx, centery]):
         assert np.abs((guess_increasing_x[param].value - value)/value) < 0.5
-
-
-def test_DonaichModel_emits_futurewarning():
-    """Assert that using the wrong spelling emits a FutureWarning."""
-    msg = ('Please correct the name of your built-in model: DonaichModel --> '
-           'DoniachModel. The incorrect spelling will be removed in a later '
-           'release.')
-    with pytest.warns(FutureWarning, match=msg):
-        models.DonaichModel()

--- a/tests/test_lineshapes.py
+++ b/tests/test_lineshapes.py
@@ -137,14 +137,3 @@ def test_form_argument_thermal_distribution(form):
     else:
         fnc_output = func(*fnc_args)
         assert len(fnc_output) == len(xvals)
-
-
-def test_donaich_emits_futurewarning():
-    """Assert that using the wrong spelling emits a FutureWarning."""
-    xvals = np.linspace(0, 10, 100)
-
-    msg = ('Please correct the name of your lineshape function: donaich --> '
-           'doniach. The incorrect spelling will be removed in a later '
-           'release.')
-    with pytest.warns(FutureWarning, match=msg):
-        lmfit.lineshapes.donaich(xvals)

--- a/tests/test_model_saveload.py
+++ b/tests/test_model_saveload.py
@@ -1,4 +1,5 @@
 """Tests for saving/loading Models and ModelResults."""
+
 import os
 import time
 
@@ -186,11 +187,11 @@ def test_saveload_modelresult_exception():
 
 
 @pytest.mark.parametrize("method", ['leastsq', 'nelder', 'powell', 'cobyla',
-                                    'bfgs', 'lbfgsb', 'differential_evolution', 'brute',
-                                    'basinhopping', 'ampgo', 'shgo',
+                                    'bfgs', 'lbfgsb', 'differential_evolution',
+                                    'brute', 'basinhopping', 'ampgo', 'shgo',
                                     'dual_annealing'])
 def test_saveload_modelresult_roundtrip(method):
-    """Test for modelresult.loads()/dumps() and repeating that"""
+    """Test for modelresult.loads()/dumps() and repeating that."""
     def mfunc(x, a, b):
         return a * (x-b)
 
@@ -201,7 +202,7 @@ def test_saveload_modelresult_roundtrip(method):
 
     np.random.seed(2020)
     xx = np.linspace(-5, 5, 201)
-    yy = 0.5 * (xx - 0.22) + np.random.normal(scale=0.01, size=len(xx))
+    yy = 0.5 * (xx - 0.22) + np.random.normal(scale=0.01, size=xx.size)
 
     result1 = model.fit(yy, params=params, x=xx, method=method)
 
@@ -246,9 +247,12 @@ def test_saveload_modelresult_expression_model():
 
 
 def test_saveload_usersyms():
-    """Test save/load of modelresult with non-trivial user symbols,
-    this example uses a VoigtModel, wheree `wofz()` is used in a
-    constraint expression"""
+    """Test save/load of ModelResult with non-trivial user symbols.
+
+    This example uses a VoigtModel, where `wofz()` is used in a constraint
+    expression.
+
+    """
     x = np.linspace(0, 20, 501)
     y = gaussian(x, 1.1, 8.5, 2) + lorentzian(x, 1.7, 8.5, 1.5)
     np.random.seed(20)


### PR DESCRIPTION
#### Description
A slightly random selection of changes... sorry about that, but opening a PR for each of them seems silly.

- update `pyupgrade` pre-commit hook
- bump `asteval` requirement to >=0.9.22  to avoid DeprecationWarnings from NumPy that make certain tests in our test-suite fail. Install again fro PyPI on Azure Pipelines instead of upstream's GitHub repository.
- some additional tests for the Model class that I still had around; there is still more to do though, just don't know when
- remove the already earlier deprecated incorrect spelling of the `DonaichModel` and `donaich` lineshape 

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [X] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.9.1 (default, Dec  8 2020, 20:10:16)
[Clang 12.0.0 (clang-1200.0.32.27)]

lmfit: 1.0.2+5.g955dbe9, scipy: 1.6.0, numpy: 1.20.1, asteval: 0.9.22, uncertainties: 3.1.5


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
