### PR TITLE
 FIX: do not override user-specified figure title in Model.plot() functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
         additional_dependencies: [rstcheck, sphinx]
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.7.1
+    rev: v1.8.0
     hooks:
     -   id: rst-backticks
     -   id: rst-directive-colons

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -166,16 +166,18 @@ stages:
           displayName: 'Install pip, setuptools, wheel, pybind11 cython'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            wget https://github.com/numpy/numpy/releases/download/v1.20.0/numpy-1.20.0.tar.gz
-            tar xzvf numpy-1.20.0.tar.gz
-            cd numpy-1.20.0
+            export numpy_version=1.20.1
+            wget https://github.com/numpy/numpy/releases/download/v${numpy_version}/numpy-${numpy_version}.tar.gz
+            tar xzvf numpy-${numpy_version}.tar.gz
+            cd numpy-${numpy_version}
             python3.10 setup.py install --user
           displayName: 'Install latest available version of NumPy'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            wget https://github.com/scipy/scipy/releases/download/v1.6.0/scipy-1.6.0.tar.gz
-            tar xzvf scipy-1.6.0.tar.gz
-            cd scipy-1.6.0
+            export scipy_version=1.6.1
+            wget https://github.com/scipy/scipy/releases/download/v${scipy_version}/scipy-${scipy_version}.tar.gz
+            tar xzvf scipy-${scipy_version}.tar.gz
+            cd scipy-${scipy_version}
             # force Cythonizing code in attempt to avoid "undefined symbol: _PyGen_Send" error
             rm -f PKG-INFO cythonize.dat
             python3.10 setup.py install --user

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,10 +160,8 @@ stages:
             export PATH=/home/vsts/.local/bin:$PATH
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             python3.10 get-pip.py --user
-            pip3.10 install -U pip setuptools wheel pybind11
-            # install Cython from GitHub to fix "undefined symbol: _PyGen_Send" error
-            pip3.10 install git+https://github.com/cython/cython@0.29.x
-          displayName: 'Install pip, setuptools, wheel, pybind11 cython'
+            pip3.10 install -U pip setuptools wheel pybind11 cython
+          displayName: 'Install pip, setuptools, wheel, pybind11, and cython'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
             export numpy_version=1.20.1

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -19,8 +19,8 @@ Version 1.0.3 Release Notes (unreleased)
 
 New features:
 
-Bug fixes:
-- do not overwrite user-specified figure titles in Model.plot() functions (PR #711)
+Bug fixes/enhancements:
+- do not overwrite user-specified figure titles in Model.plot() functions and allow setting with 'title' keyword argument (PR #711)
 
 Various:
 - update asteval dependency to >=0.9.22 to avoid DeprecationWarnings from NumPy v1.20.0 (PR #707)

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -20,6 +20,7 @@ Version 1.0.3 Release Notes (unreleased)
 New features:
 
 Bug fixes:
+- do not overwrite user-specified figure titles in Model.plot() functions (PR #711)
 
 Various:
 - update asteval dependency to >=0.9.22 to avoid DeprecationWarnings from NumPy v1.20.0 (PR #707)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1771,7 +1771,7 @@ class ModelResult(Minimizer):
     def plot_fit(self, ax=None, datafmt='o', fitfmt='-', initfmt='--',
                  xlabel=None, ylabel=None, yerr=None, numpoints=None,
                  data_kws=None, fit_kws=None, init_kws=None, ax_kws=None,
-                 show_init=False, parse_complex='abs'):
+                 show_init=False, parse_complex='abs', title=None):
         """Plot the fit results using matplotlib, if available.
 
         The plot will include the data points, the initial fit curve
@@ -1816,6 +1816,8 @@ class ModelResult(Minimizer):
             How to reduce complex data for plotting. Options are one of:
             `'abs'` (default), `'real'`, `'imag'`, or `'angle'`, which
             correspond to the NumPy functions with the same name.
+        title : str, optional
+            Matplotlib format string for figure title.
 
         Returns
         -------
@@ -1897,7 +1899,9 @@ class ModelResult(Minimizer):
                                            **{independent_var: x_array_dense})),
             fitfmt, label='best-fit', **fit_kws)
 
-        if ax.get_title() == '':
+        if title:
+            ax.set_title(title)
+        elif ax.get_title() == '':
             ax.set_title(self.model.name)
         if xlabel is None:
             ax.set_xlabel(independent_var)
@@ -1912,7 +1916,8 @@ class ModelResult(Minimizer):
 
     @_ensureMatplotlib
     def plot_residuals(self, ax=None, datafmt='o', yerr=None, data_kws=None,
-                       fit_kws=None, ax_kws=None, parse_complex='abs'):
+                       fit_kws=None, ax_kws=None, parse_complex='abs',
+                       title=None):
         """Plot the fit residuals using matplotlib, if available.
 
         If `yerr` is supplied or if the model included weights, errorbars
@@ -1937,6 +1942,8 @@ class ModelResult(Minimizer):
             How to reduce complex data for plotting. Options are one of:
             `'abs'` (default), `'real'`, `'imag'`, or `'angle'`, which
             correspond to the NumPy functions with the same name.
+        title : str, optional
+            Matplotlib format string for figure title.
 
         Returns
         -------
@@ -1998,7 +2005,9 @@ class ModelResult(Minimizer):
             ax.plot(x_array, reduce_complex(self.eval()) - reduce_complex(self.data), datafmt,
                     label='residuals', **data_kws)
 
-        if ax.get_title() == '':
+        if title:
+            ax.set_title(title)
+        elif ax.get_title() == '':
             ax.set_title(self.model.name)
         ax.set_ylabel('residuals')
         ax.legend(loc='best')
@@ -2008,7 +2017,7 @@ class ModelResult(Minimizer):
     def plot(self, datafmt='o', fitfmt='-', initfmt='--', xlabel=None,
              ylabel=None, yerr=None, numpoints=None, fig=None, data_kws=None,
              fit_kws=None, init_kws=None, ax_res_kws=None, ax_fit_kws=None,
-             fig_kws=None, show_init=False, parse_complex='abs'):
+             fig_kws=None, show_init=False, parse_complex='abs', title=None):
         """Plot the fit results and residuals using matplotlib.
 
         The method will produce a matplotlib figure (if package available)
@@ -2058,6 +2067,8 @@ class ModelResult(Minimizer):
             How to reduce complex data for plotting. Options are one of:
             `'abs'` (default), `'real'`, `'imag'`, or `'angle'`, which
             correspond to the NumPy functions with the same name.
+        title : str, optional
+            Matplotlib format string for figure title.
 
         Returns
         -------
@@ -2119,10 +2130,12 @@ class ModelResult(Minimizer):
                       initfmt=initfmt, xlabel=xlabel, ylabel=ylabel,
                       numpoints=numpoints, data_kws=data_kws,
                       fit_kws=fit_kws, init_kws=init_kws, ax_kws=ax_fit_kws,
-                      show_init=show_init, parse_complex=parse_complex)
+                      show_init=show_init, parse_complex=parse_complex,
+                      title=title)
         self.plot_residuals(ax=ax_res, datafmt=datafmt, yerr=yerr,
                             data_kws=data_kws, fit_kws=fit_kws,
-                            ax_kws=ax_res_kws, parse_complex=parse_complex)
+                            ax_kws=ax_res_kws, parse_complex=parse_complex,
+                            title=title)
         plt.setp(ax_res.get_xticklabels(), visible=False)
         ax_fit.set_title('')
         return fig, gs

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1897,7 +1897,8 @@ class ModelResult(Minimizer):
                                            **{independent_var: x_array_dense})),
             fitfmt, label='best-fit', **fit_kws)
 
-        ax.set_title(self.model.name)
+        if ax.get_title() == '':
+            ax.set_title(self.model.name)
         if xlabel is None:
             ax.set_xlabel(independent_var)
         else:
@@ -1997,7 +1998,8 @@ class ModelResult(Minimizer):
             ax.plot(x_array, reduce_complex(self.eval()) - reduce_complex(self.data), datafmt,
                     label='residuals', **data_kws)
 
-        ax.set_title(self.model.name)
+        if ax.get_title() == '':
+            ax.set_title(self.model.name)
         ax.set_ylabel('residuals')
         ax.legend(loc='best')
         return ax

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -191,7 +191,6 @@ def test_confidence_exceptions(data, pars):
         lmfit.conf_interval(minimizer, out_lsq)
 
 
-@pytest.mark.xfail("np.__version__ == '1.20.0'")  # FIXME
 def test_confidence_warnings(data, pars):
     """Make sure the proper warnings are emitted when needed."""
     minimizer = lmfit.Minimizer(residual, pars, fcn_args=data)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -357,6 +357,94 @@ def test__parse_params_forbidden_variable_names():
         Model(func_invalid_par)
 
 
+@pytest.mark.skipif(not lmfit.model._HAS_MATPLOTLIB,
+                    reason="requires matplotlib.pyplot")
+def test_figure_default_title(peakdata):
+    """Test default figure title."""
+    x, y = peakdata
+    pvmodel = PseudoVoigtModel()
+    params = pvmodel.guess(y, x=x)
+    result = pvmodel.fit(y, params, x=x)
+
+    ax = result.plot_fit()
+    assert ax.axes.get_title() == 'Model(pvoigt)'
+
+    ax = result.plot_residuals()
+    assert ax.axes.get_title() == 'Model(pvoigt)'
+
+    fig, _ = result.plot()
+    assert fig.axes[0].get_title() == 'Model(pvoigt)'  # default model.name
+    assert fig.axes[1].get_title() == ''  # no title for fit subplot
+
+
+@pytest.mark.skipif(not lmfit.model._HAS_MATPLOTLIB,
+                    reason="requires matplotlib.pyplot")
+def test_figure_title_using_title_keyword_argument(peakdata):
+    """Test setting figure title using title keyword argument."""
+    x, y = peakdata
+    pvmodel = PseudoVoigtModel()
+    params = pvmodel.guess(y, x=x)
+    result = pvmodel.fit(y, params, x=x)
+
+    ax = result.plot_fit(title='test')
+    assert ax.axes.get_title() == 'test'
+
+    ax = result.plot_residuals(title='test')
+    assert ax.axes.get_title() == 'test'
+
+    fig, _ = result.plot(title='test')
+    assert fig.axes[0].get_title() == 'test'
+    assert fig.axes[1].get_title() == ''  # no title for fit subplot
+
+
+@pytest.mark.skipif(not lmfit.model._HAS_MATPLOTLIB,
+                    reason="requires matplotlib.pyplot")
+def test_figure_title_using_title_to_ax_kws(peakdata):
+    """Test setting figure title by supplying ax_{fit,res}_kws."""
+    x, y = peakdata
+    pvmodel = PseudoVoigtModel()
+    params = pvmodel.guess(y, x=x)
+    result = pvmodel.fit(y, params, x=x)
+
+    ax = result.plot_fit(ax_kws={'title': 'ax_kws'})
+    assert ax.axes.get_title() == 'ax_kws'
+
+    ax = result.plot_residuals(ax_kws={'title': 'ax_kws'})
+    assert ax.axes.get_title() == 'ax_kws'
+
+    fig, _ = result.plot(ax_res_kws={'title': 'ax_res_kws'})
+    assert fig.axes[0].get_title() == 'ax_res_kws'
+    assert fig.axes[1].get_title() == ''
+
+    fig, _ = result.plot(ax_fit_kws={'title': 'ax_fit_kws'})
+    assert fig.axes[0].get_title() == 'Model(pvoigt)'  # default model.name
+    assert fig.axes[1].get_title() == ''  # no title for fit subplot
+
+
+@pytest.mark.skipif(not lmfit.model._HAS_MATPLOTLIB,
+                    reason="requires matplotlib.pyplot")
+def test_priority_setting_figure_title(peakdata):
+    """Test for setting figure title: title keyword argument has priority."""
+    x, y = peakdata
+    pvmodel = PseudoVoigtModel()
+    params = pvmodel.guess(y, x=x)
+    result = pvmodel.fit(y, params, x=x)
+
+    ax = result.plot_fit(ax_kws={'title': 'ax_kws'}, title='test')
+    assert ax.axes.get_title() == 'test'
+
+    ax = result.plot_residuals(ax_kws={'title': 'ax_kws'}, title='test')
+    assert ax.axes.get_title() == 'test'
+
+    fig, _ = result.plot(ax_res_kws={'title': 'ax_res_kws'}, title='test')
+    assert fig.axes[0].get_title() == 'test'
+    assert fig.axes[1].get_title() == ''
+
+    fig, _ = result.plot(ax_fit_kws={'title': 'ax_fit_kws'}, title='test')
+    assert fig.axes[0].get_title() == 'test'
+    assert fig.axes[1].get_title() == ''
+
+
 # Below is the content of the original test_model.py file. These tests still
 # need to be checked and possibly updated to the pytest-style. They work fine
 # though so leave them in for now.
@@ -844,10 +932,10 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         for _, par in pars.items():
             assert len(repr(par)) > 5
 
-    @pytest.mark.skipif(not lmfit.model._HAS_MATPLOTLIB, reason="requires matplotlib.pyplot")
+    @pytest.mark.skipif(not lmfit.model._HAS_MATPLOTLIB,
+                        reason="requires matplotlib.pyplot")
     def test_composite_plotting(self):
         # test that a composite model has non-empty best_values
-        pytest.importorskip("matplotlib")
         import matplotlib
         matplotlib.use('Agg')
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -705,7 +705,6 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
             params[param_name].value = value
         self.model.fit(self.data, params, x=self.x)
 
-    @pytest.mark.xfail("np.__version__ == '1.20.0'")  # FIXME
     def test_extra_param_issues_warning(self):
         # The function accepts extra params, Model will warn but not raise.
         def flexible_func(x, amplitude, center, sigma, **kwargs):


### PR DESCRIPTION
#### Description
As discussed on the mailing-list (see: https://groups.google.com/g/lmfit-py/c/3kxu8OYCAW4/m/61dhxzJkAgAJ) the automatically generate Model names are often not very suitable as figure titles for the Model.plot() functions. It should be possible to pass a `title` to `ax_kws` (or `ax_fit_kws`/`ax_res_kws`) depending on the plot function used; however, after the initialization of the `axes` it is overwritten with `ax.set_title` later.

Added a `title` keyword argument as well that allows for setting the figure title. If used, it will take priority over supplying a `title` to `ax_kws` (or `ax_fit_kws`/`ax_res_kws`).

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.9.1 (default, Dec  8 2020, 20:10:16)
[Clang 12.0.0 (clang-1200.0.32.27)]

lmfit: 1.0.2+8.g5016da7, scipy: 1.6.0, numpy: 1.20.1, asteval: 0.9.22, uncertainties: 3.1.5

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?