### PR TITLE
remove use of OrderedDict

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -24,6 +24,7 @@ Bug fixes:
 Various:
 - update asteval dependency to >=0.9.22 to avoid DeprecationWarnings from NumPy v1.20.0 (PR #707)
 - remove incorrectly spelled ``DonaichModel`` and ``donaich`` lineshape, deprecated in version 1.0.1 (PR #707)
+- remove occurrences of OrderedDict throughout the code; dict is order-preserving since Python 3.6 (PR #713)
 
 
 .. _whatsnew_102_label:

--- a/lmfit/confidence.py
+++ b/lmfit/confidence.py
@@ -1,6 +1,5 @@
 """Contains functions to calculate confidence intervals."""
 
-from collections import OrderedDict
 from warnings import warn
 
 import numpy as np
@@ -213,7 +212,7 @@ class ConfidenceInterval:
 
     def calc_all_ci(self):
         """Calculate all confidence intervals."""
-        out = OrderedDict()
+        out = {}
 
         for p in self.p_names:
             out[p] = (self.calc_ci(p, -1)[::-1] +

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1,6 +1,5 @@
 """Implementation of the Model interface."""
 
-from collections import OrderedDict
 from copy import deepcopy
 from functools import wraps
 import inspect
@@ -270,8 +269,8 @@ class Model:
         self.nan_policy = nan_policy
 
         self.opts = kws
-        self.param_hints = OrderedDict()
         # the following has been changed from OrderedSet for the time being
+        self.param_hints = {}
         self._param_names = []
         self._parse_params()
         if self.independent_vars is None:
@@ -589,7 +588,7 @@ class Model:
             name = name[npref:]
 
         if name not in self.param_hints:
-            self.param_hints[name] = OrderedDict()
+            self.param_hints[name] = {}
 
         for key, val in kwargs.items():
             if key in self._hint_names:
@@ -862,7 +861,7 @@ class Model:
 
         Returns
         -------
-        OrderedDict
+        dict
             Keys are prefixes for component model, values are value of
             each component.
 
@@ -1132,8 +1131,8 @@ class CompositeModel(Model):
                        self.right.eval(params=params, **kwargs))
 
     def eval_components(self, **kwargs):
-        """Return OrderedDict of name, results for each component."""
-        out = OrderedDict(self.left.eval_components(**kwargs))
+        """Return dictionary of name, results for each component."""
+        out = dict(self.left.eval_components(**kwargs))
         out.update(self.right.eval_components(**kwargs))
         return out
 
@@ -1425,7 +1424,7 @@ class ModelResult(Minimizer):
 
         Returns
         -------
-        OrderedDict
+        dict
             Keys are prefixes of component models, and values are the
             estimated model value for each component of the model.
 

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -202,6 +202,12 @@ class Parameters(dict):
         # then add all the parameters
         self.add_many(*state['params'])
 
+    def __repr__(self):
+        """__repr__ from OrderedDict."""
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, list(self.items()))
+
     def eval(self, expr):
         """Evaluate a statement using the `asteval` Interpreter.
 
@@ -265,7 +271,7 @@ class Parameters(dict):
 
         """
         if oneline:
-            return super().__repr__()
+            return self.__repr__()
         s = "Parameters({\n"
         for key in self.keys():
             s += "    '%s': %s, \n" % (key, self[key])

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -1,6 +1,5 @@
 """Parameter class."""
 
-from collections import OrderedDict
 from copy import deepcopy
 import json
 import warnings
@@ -24,8 +23,8 @@ def check_ast_errors(expr_eval):
         expr_eval.raise_exception(None)
 
 
-class Parameters(OrderedDict):
-    """An ordered dictionary of Parameter objects.
+class Parameters(dict):
+    """A dictionary of Parameter objects.
 
     It should contain all Parameter objects that are required to specify
     a fit model. All minimization and Model fitting routines in lmfit will
@@ -137,7 +136,7 @@ class Parameters(OrderedDict):
                 raise KeyError("'%s' is not a valid Parameters name" % key)
         if par is not None and not isinstance(par, Parameter):
             raise ValueError("'%s' is not a Parameter" % par)
-        OrderedDict.__setitem__(self, key, par)
+        dict.__setitem__(self, key, par)
         par.name = key
         par._expr_eval = self._asteval
         self._asteval.symtable[key] = par.value
@@ -415,12 +414,12 @@ class Parameters(OrderedDict):
 
         Returns
         -------
-        OrderedDict
-            An ordered dictionary of :attr:`name`::attr:`value` pairs for
-            each Parameter.
+        dict
+            A dictionary of :attr:`name`::attr:`value` pairs for each
+            Parameter.
 
         """
-        return OrderedDict((p.name, p.value) for p in self.values())
+        return {p.name: p.value for p in self.values()}
 
     def dumps(self, **kws):
         """Represent Parameters as a JSON string.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,5 @@
 """Tests for the Model, CompositeModel, and ModelResult classes."""
 
-from collections import OrderedDict
 import functools
 import sys
 import unittest
@@ -207,8 +206,7 @@ def test_Model_get_state(gmodel):
 
     assert out[0][0] == 'gaussian'
     assert out[0][2:] == ('gaussian', '', ['x'],
-                          ['amplitude', 'center', 'sigma'], OrderedDict(),
-                          'raise', {})
+                          ['amplitude', 'center', 'sigma'], {}, 'raise', {})
 
 
 def test_Model_set_state(gmodel):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -274,7 +274,7 @@ def test_pickle_parameters():
     # check that unpickling of Parameters is not affected by expr that
     # refer to Parameter that are added later on. In the following
     # example var_0.expr refers to var_1, which is a Parameter later
-    # on in the Parameters OrderedDict.
+    # on in the Parameters dictionary.
     p = lmfit.Parameters()
     p.add('var_0', value=1)
     p.add('var_1', value=2)


### PR DESCRIPTION
#### Description
Since Python 3.6 dictionaries are order-preserving so there is no reason anymore to use `OrderedDict`. This PR removes the use of it, and now the `Parameters` class will inherit from `dict` instead. To keep the output the same we override the `__repr__` method with the one used in `OrderedDict`.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [X] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.9.1 (default, Dec  8 2020, 20:10:16)
[Clang 12.0.0 (clang-1200.0.32.27)]

lmfit: 1.0.2+9.gf60d332, scipy: 1.6.0, numpy: 1.20.1, asteval: 0.9.22, uncertainties: 3.1.5


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?