### PR TITLE
Skipping a plotting test in case `import matplotlib.pyplot` raises OSError

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -764,6 +764,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         for _, par in pars.items():
             assert len(repr(par)) > 5
 
+    @pytest.mark.skipif(not lmfit.model._HAS_MATPLOTLIB, reason="requires matplotlib.pyplot")
     def test_composite_plotting(self):
         # test that a composite model has non-empty best_values
         pytest.importorskip("matplotlib")


### PR DESCRIPTION
Introducing a conditional skip on `TestUserDefiniedModel.test_composite_plotting` in case something's wrong with matplotlib. 

Fixes #712 

<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
The plotting test: `TestUserDefiniedModel.test_composite_plotting` fails when `pip` is used to install `cairosvg` and `matplotlib` on windows. Does not occur when using `conda`. This PR simply causes this test to be skipped in this case.
<!--- If it fixes an open issue, please link to the issue here. -->
See: https://github.com/lmfit/lmfit-py/issues/712 and https://github.com/matplotlib/matplotlib/issues/19547

Following the discussion, I decided to simply skip the test, as it is already the intent of the code, using `pytest.importorskip`. However, this weird dependency error causes the call to `import matplotlib.pyplot` to raise `OSError` instead of `ImportError`, so `pytest.importorskip` doesn't catch it. Instead, the current `pytest.mark.skipif` uses the same flag (`lmfit.model._HAS_MATPLOTLIB`) which leads to the failing test.

This is using a private module attribute. I think it's probably fine in that case. If it raises concerns, I can think of another way to get the same behavior.

The detailed breakdown of the bug:
1. `lmfit.model.py` tries  to import `pyplot`, since it fails, it sets `_HAS_MATPLOTLIB` to false.
2. This then causes the `_ensureMatplotlib` decorator to replace plotting functions such as `Model.plot` with `no_op`, which returns `None`.
https://github.com/lmfit/lmfit-py/blob/500ee04da487d11573e73b63f7990cd97cac81a1/lmfit/model.py#L38-L55
3. `TestUserDefiniedModel.test_composite_plotting` does not catch the problem with `matplotlib`, so it tries to run the test about plotting. At line 872, the executed function is actually `no_op`. It's return value is `None`, which causes the test to fail.
https://github.com/lmfit/lmfit-py/blob/500ee04da487d11573e73b63f7990cd97cac81a1/tests/test_model.py#L847-L880

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.9.1 | packaged by conda-forge | (default, Jan 26 2021, 01:29:07) [MSC v.1916 64 bit (AMD64)]

lmfit: 1.0.2+1.g4283774, scipy: 1.6.1, numpy: 1.20.1, asteval: 0.9.22, uncertainties: 3.1.5


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
