### PR TITLE
Preserve Parameters subclass in deepcopy

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -101,7 +101,7 @@ class Parameters(dict):
         all individual Parameter objects are copied.
 
         """
-        _pars = Parameters(asteval=None)
+        _pars = self.__class__(asteval=None)
 
         # find the symbols that were added by users, not during construction
         unique_symbols = {key: self._asteval.symtable[key]

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -111,6 +111,18 @@ def test_parameters_deepcopy(parameters):
                     deepcopy_pars._asteval.symtable[unique_symbol])
 
 
+def test_parameters_deepcopy_subclass():
+    """Test that a subclass of parameters is preserved when performing a deepcopy"""
+    class ParametersSubclass(lmfit.Parameters):
+        pass
+
+    parameters = ParametersSubclass()
+    assert isinstance(parameters, ParametersSubclass)
+
+    parameterscopy = deepcopy(parameters)
+    assert isinstance(parameterscopy, ParametersSubclass)
+
+
 def test_parameters_update(parameters):
     """Tests for updating a Parameters class."""
     pars, exp_attr_values_A, exp_attr_values_B = parameters


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
This is a small fix to allow the end users to subclass Parameters. We have found this handy to add 
a few specific convenience methods to our Parameters. Currently a Parameters subclass is lost when a fit is performed
as the parameter is copied into a new instance of the Parameters class. Here we fix that by creating an instance of the 
same class as the original object when doing a deepcopy.


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
```
lmfit: 1.0.2+21.g8a0cd5c, scipy: 1.6.1, numpy: 1.20.1, asteval: 0.9.23, uncertainties: 3.1.5
```

###### Verification <!-- (delete not applicable items) -->

- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?

