### PR TITLE
Defer import of pyplot

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -36,7 +36,7 @@ def _align(var, mask, data):
 
 
 try:
-    from matplotlib import pyplot as plt
+    import matplotlib  # noqa: F401
     _HAS_MATPLOTLIB = True
 except Exception:
     _HAS_MATPLOTLIB = False
@@ -2097,6 +2097,7 @@ class ModelResult(Minimizer):
         called, otherwise `fig_kws` is ignored.
 
         """
+        from matplotlib import pyplot as plt
         if data_kws is None:
             data_kws = {}
         if fit_kws is None:


### PR DESCRIPTION
#### Description
[Issue 528](https://github.com/lmfit/lmfit-py/issues/528) was raised to address why pyplot should be deferred to import only in the functions that need them. However, this behavior regressed in commit d865ddf122b67dfe705a3c1a1e514860a926555d. This pull request restores the correct behavior.

This was discussed in the [mailing list](https://groups.google.com/g/lmfit-py/c/KFrXkubVxsg).

A test might be nice to ensure this doesn't happen again, but I'm not sure how to do that.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.8.8 | packaged by conda-forge | (default, Feb 20 2021, 16:12:38) 
[Clang 11.0.1 ]
lmfit: 1.0.2+26.g03daaf8.dirty, scipy: 1.6.2, numpy: 1.20.2, asteval: 0.9.23, uncertainties: 3.1.5

###### Verification
- [ ] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
