### PR TITLE
[WIP] assert input data for least squares is of correct type

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -27,7 +27,7 @@ Various:
 - remove incorrectly spelled ``DonaichModel`` and ``donaich`` lineshape, deprecated in version 1.0.1 (PR #707)
 - remove occurrences of OrderedDict throughout the code; dict is order-preserving since Python 3.6 (PR #713)
 - update the contributing instructions (PR #718; @martin-majlis)
-
+- add warning if independent data of incorrect type is used in least squares fitting (PR #722)
 
 .. _whatsnew_102_label:
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1574,6 +1574,9 @@ class Minimizer:
 
         result.call_kws = kws
         try:
+            if 'x' in self.userkws:
+                if np.asarray(self.userkws['x']).dtype is np.dtype(np.float32):
+                    warnings.warn('input argument x has inccorect type np.float32')
             ret = least_squares(self.__residual, start_vals,
                                 bounds=(lower_bounds, upper_bounds),
                                 kwargs=dict(apply_bounds_transformation=False),


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

For least squares fitting some odd behaviour happens when the type of the independent data is not float64. Also see the discussion in https://github.com/lmfit/lmfit-py/issues/617. The documentation states that the input data should be float64, but that is easy to miss for new users. Also, adding explicit conversions to float64 around all calls to `lmfit` adds unnecessary additional code.

This PR add a warning if data with incorrect type is supplied to the `least_squares` method.

A minimal example that shows how a simple sine fit can go wrong, without warnings or errors from `lmfit`:
```
import numpy as np

from lmfit import Model
from typing import Union
import matplotlib.pyplot as plt


def sine(x: Union[float, np.ndarray], amplitude: float, frequency: float,
         phase: float, offset: float) -> Union[float, np.ndarray]:
    """ Model for sine function with offset

        y = offset + amplitude * np.sin(2 * np.pi * frequency * x + phase)

    Args:
        x : Independent data points
        amplitude, frequency, phase, offset: Arguments for the sine model
    Returns:
        Calculated data points

    """
    y = amplitude * np.sin(2 * np.pi * frequency * x + phase) + offset
    return y


x_data=np.array([0.        , 0.39130434, 0.7826087 , 1.173913  , 1.5652174 ,
       1.9565217 , 2.347826  , 2.7391305 , 3.1304348 , 3.5217392 ,
       3.9130435 , 4.304348  , 4.695652  , 5.0869565 , 5.478261  ,
       5.869565  , 6.2608695 , 6.652174  , 7.0434785 , 7.4347825 ,
       7.826087  , 8.217391  , 8.608696  , 9.        ], dtype=np.float32)

y_data=np.array([ 5.14749191,  4.73160261,  3.56180872,  2.07035031,  0.08382382,
       -1.81577806, -3.51661368, -4.5393273 , -4.99211742, -4.47738279,
       -3.61221642, -2.08006958, -0.11406613,  1.74609116,  3.46597728,
        4.70999518,  5.09628533,  4.58258861,  3.56415328,  2.0660223 ,
        0.02111145, -1.77618434, -3.27206256, -4.66309001], dtype=np.float64)

initial_parameters=np.array([ 5.06980466,  0.16300641,  1.9141469658, -0.17445164])


lmfit_model = Model(sine)
lmfit_model.set_param_hint('amplitude', min=0)
lmfit_result = lmfit_model.fit(y_data, x=x_data, method='least_squares',
                               **dict(zip(lmfit_model.param_names, initial_parameters)) )

lmfit_result.plot(show_init=True)
plt.title('different dtype: bad fit')
```
For users who the results can be hard to interpret.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples

The PR add a check on the type of the independent variable for least squares fitting. The goal is to make the PR backwards compatible, except when the user is supplying data that is invalid and make sure the added overhead is minimal.

###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
```
Python: 3.8.6 (tags/v3.8.6:db45529, Sep 23 2020, 15:52:53) [MSC v.1927 64 bit (AMD64)]

lmfit: 1.0.2+26.g03daaf8.dirty, scipy: 1.6.1, numpy: 1.20.1, asteval: 0.9.23, uncertainties: 3.1.5
```

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257? No new methods written
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally? Partly build with `make html`. Fails with error unrelated to this PR
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example? Not required
