### PR TITLE
add checks on input data type for Model

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -28,7 +28,7 @@ Various:
 - remove incorrectly spelled ``DonaichModel`` and ``donaich`` lineshape, deprecated in version 1.0.1 (PR #707)
 - remove occurrences of OrderedDict throughout the code; dict is order-preserving since Python 3.6 (PR #713)
 - update the contributing instructions (PR #718; @martin-majlis)
-
+- add check on input type of Model data and independent data. If the type is float32 a warning is generated (PR #723)
 
 .. _whatsnew_102_label:
 

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -185,6 +185,15 @@ def propagate_err(z, dz, option):
     return err
 
 
+class DataPrecisionWarning(UserWarning):
+    """ Warning generated when input data for the fitting methods is of incorrect type
+
+    Data in lmfit is expected to be of double-precision. When data is supplied in single-precision
+    this warning is emitted.
+    """
+    pass
+
+
 class Model:
     """Create a model from a user-supplied model function."""
 
@@ -1008,9 +1017,16 @@ class Model:
         # and apply the mask from above if there is one.
 
         for var in self.independent_vars:
+            independent_dtype = np.asarray(kwargs[var]).dtype
+            if independent_dtype is np.dtype(np.float32):
+                warnings.warn(f'independent data {var} has type {independent_dtype}', DataPrecisionWarning)
+
             if not np.isscalar(kwargs[var]):
-                # print("Model fit align ind dep ", var, mask.sum())
                 kwargs[var] = _align(kwargs[var], mask, data)
+
+        data_dtype = np.asarray(data).dtype
+        if data_dtype is np.dtype(np.float32):
+            warnings.warn(f'input data has type {data_dtype}', DataPrecisionWarning)
 
         if fit_kws is None:
             fit_kws = {}


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

`lmfit` excepts input data to be in double-precision format. However, users can be unaware of this or pre-processing methods could accidentally cast to single-precision. This PR adds warnings to all model input data that is of type float32.

Notes:

* Also see #617, #722 , https://github.com/scipy/scipy/issues/7117
* The warning is generated as a `DataPrecisionWarning` so users can filter out the warning if they choose to. No error is generated so that the change is backwards compatible with current behaviour.
* The current check is only on `float32`, which seems to be the most common type of mistake. Integer types are converted automatically to float type. Adding `np.float16` to the check would be an option.



###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

```
Python: 3.8.6 (tags/v3.8.6:db45529, Sep 23 2020, 15:52:53) [MSC v.1927 64 bit (AMD64)]

lmfit: 1.0.2+32.gc448ced.dirty, scipy: 1.6.1, numpy: 1.20.1, asteval: 0.9.23, uncertainties: 3.1.5
```

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally? Partial build
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example? Not required
