### PR TITLE
Coerce `data` and `independent_vars` in Model class to `float64`/`complex128`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'versioneer.py|lmfit/_version|doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.18.1
+    rev: v2.19.0
     hooks:
     -   id: pyupgrade
         # for now don't force to change from %-operator to {}

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -22,6 +22,7 @@ New features:
 Bug fixes/enhancements:
 - do not overwrite user-specified figure titles in Model.plot() functions and allow setting with 'title' keyword argument (PR #711)
 - preserve Parameters subclass in deepcopy (@jenshnielsen; PR #719)
+- coerce ``data`` and ``indepdent_vars`` to NumPy array with ``dtype=float64`` or ``dtype=complex128`` where  applicable (Issues #723 and #727)
 
 Various:
 - update asteval dependency to >=0.9.22 to avoid DeprecationWarnings from NumPy v1.20.0 (PR #707)

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -20,7 +20,7 @@ Version 1.0.3 Release Notes (unreleased)
 New features:
 
 Bug fixes/enhancements:
-- do not overwrite user-specified figure titles in Model.plot() functions and allow setting with 'title' keyword argument (PR #711)
+- do not overwrite user-specified figure titles in Model.plot() functions and allow setting with ``title`` keyword argument (PR #711)
 - preserve Parameters subclass in deepcopy (@jenshnielsen; PR #719)
 - coerce ``data`` and ``indepdent_vars`` to NumPy array with ``dtype=float64`` or ``dtype=complex128`` where  applicable (Issues #723 and #727)
 
@@ -29,6 +29,9 @@ Various:
 - remove incorrectly spelled ``DonaichModel`` and ``donaich`` lineshape, deprecated in version 1.0.1 (PR #707)
 - remove occurrences of OrderedDict throughout the code; dict is order-preserving since Python 3.6 (PR #713)
 - update the contributing instructions (PR #718; @martin-majlis)
+- (again) defer import of matplotlib to when it is needed (@zobristnicholas; PR #721)
+- fix description of ``name`` argument in ``Parameters.add`` (@kristianmeyerr; PR #725)
+- update dependencies, make sure a functional development environment is installed on Windows (Issue #712))
 
 
 .. _whatsnew_102_label:

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -982,15 +982,6 @@ class Model:
             msg += 'Non initialized parameters: %s' % str(blank)
             raise ValueError(msg)
 
-        # Do not alter anything that implements the array interface (np.array, pd.Series)
-        # but convert other iterables (e.g., Python lists) to NumPy arrays.
-        if not hasattr(data, '__array__'):
-            data = np.asfarray(data)
-        for var in self.independent_vars:
-            var_data = kwargs[var]
-            if isinstance(var_data, (list, tuple)):
-                kwargs[var] = np.asfarray(var_data)
-
         # Handle null/missing values.
         if nan_policy is not None:
             self.nan_policy = nan_policy
@@ -1005,11 +996,26 @@ class Model:
 
         # If independent_vars and data are alignable (pandas), align them,
         # and apply the mask from above if there is one.
-
         for var in self.independent_vars:
             if not np.isscalar(kwargs[var]):
-                # print("Model fit align ind dep ", var, mask.sum())
                 kwargs[var] = _align(kwargs[var], mask, data)
+
+        # Make sure `dtype` for data is always `float64` or `complex128`
+        if np.isrealobj(data):
+            data = np.asfarray(data)
+        elif np.iscomplexobj(data):
+            data = np.asarray(data, dtype='complex128')
+
+        # Coerce `dtype` for independent variable(s) to `float64` or
+        # `complex128` when the variable has one of the following types: list,
+        # tuple, numpy.ndarray, or pandas.Series
+        for var in self.independent_vars:
+            var_data = kwargs[var]
+            if isinstance(var_data, (list, tuple, np.ndarray, Series)):
+                if np.isrealobj(var_data):
+                    kwargs[var] = np.asfarray(var_data)
+                elif np.iscomplexobj(var_data):
+                    kwargs[var] = np.asarray(var_data, dtype='complex128')
 
         if fit_kws is None:
             fit_kws = {}

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -22,3 +22,14 @@ def test_pandas_guess_from_peak():
     guess = model.guess(ydat, x=xdat)
 
     assert guess_pd == guess
+
+
+def test_pandas_Voigt_model():
+    """Regression test for Series.real reported in GH Issues 727."""
+    data = pandas.read_csv(os.path.join(os.path.dirname(__file__), '..',
+                                        'examples', 'peak.csv'))
+    model = lmfit.models.VoigtModel()
+    params = model.make_params()
+    fit = model.fit(data['y'], params, x=data['x'])
+
+    assert fit.success


### PR DESCRIPTION
#### Description
This PR coerces the datatypes for `data` (i.e., y-values) and `independent_var` (i.e., x-values) to `float64` or `complex128` where applicable. I think this covers what was discussed before in a recent issue/PR and does change the dtype now as well for `pandas.Series` and `numpy.ndarray`s. It will still allow for the `independent_var` to be a more complex, user-defined object and all the current tests still pass so I don't think it will have any unintended side-effects but please take a look. 

I know that @newville suggested to add a `"check_independent_vars()` function, but given that some of this already happened in the Model class anyway, I decided against that apporach and just extended the code that was already present.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.9.5 (default, May  7 2021, 19:09:51)
[Clang 12.0.0 (clang-1200.0.32.29)]

lmfit: 1.0.2+50.g350965d, scipy: 1.6.3, numpy: 1.20.3, asteval: 0.9.23, uncertainties: 3.1.5


###### Verification <!-- (delete not applicable items) -->
Have you
- [ ] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
