### PR TITLE
MAINT: transition to f-strings

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -28,7 +28,7 @@ of the sections does not apply to your Issue, state that explicitly.
 <!-- Provide a short description of the issue, describe the expected outcome, and give the actual result -->
 
 ###### A Minimal, Complete, and Verifiable example
-<!-- see, for example, https://stackoverflow.com/help/mcve on how to do this. -->
+<!-- see, for example, https://stackoverflow.com/help/mcve on how to do this -->
 
 ###### Error message:
 <!-- If any, paste the *full* error message inside a code block (starting from line Traceback) -->
@@ -42,12 +42,9 @@ Traceback (most recent call last):
 ###### Version information
 <!-- Generate version information with this command in the Python shell and copy the output here:
 import sys, lmfit, numpy, scipy, asteval, uncertainties
-print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
-      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
-      asteval.__version__, uncertainties.__version__))
- -->
+print(f"Python: {sys.version}\n\nlmfit: {lmfit.__version__}, scipy: {scipy.__version__}, numpy: {numpy.__version__}"
+      f", asteval: {asteval.__version__}, uncertainties: {uncertainties.__version__}")
+-->
 
 ###### Link(s)
-<!--If you started a discussion on the lmfit mailing list or Stack Overflow, please provide
-        the relevant link(s).
--->
+<!-- If you started a discussion on the lmfit mailing list or Stack Overflow, please provide the relevant link(s) -->

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,10 @@ exclude: 'doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.24.0
+    rev: v2.25.1
     hooks:
     -   id: pyupgrade
-        # for now don't force to change from %-operator to {}
-        args: [--keep-percent-format, --py36-plus]
+        args: [--py36-plus]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,8 @@ stages:
             swig libmpc-dev
           displayName: 'Install dependencies'
         - script: |
-            python -m pip install --upgrade pip setuptools wheel
+            python -m pip install --upgrade pip wheel
+            pip install setuptools==57.5.0
             pip install asteval==0.9.22 numpy==1.18 scipy==1.3.2 uncertainties==3.0.1 pytest coverage codecov
           displayName: 'Install minimum required version of dependencies'
         - script: |

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,7 +65,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'lmfit'
-copyright = u'{}, Matthew Newville, Till Stensitzki, Renee Otten, and others'.format(date.today().year)
+copyright = f'{date.today().year}, Matthew Newville, Till Stensitzki, Renee Otten, and others'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/doc_examples_to_gallery.py
+++ b/doc/doc_examples_to_gallery.py
@@ -51,11 +51,8 @@ for fn in files:
 
     gallery_file = examples_documentation_dir / fn.name[4:]
     msg = ""  # add optional message f
-    gallery_file.write_text(
-        '"""\n{}\n{}\n\n{}\n"""\n{}'.format(
-            fn.name, "=" * len(fn.name), msg, script_text
-        )
-    )
+    gallery_file.write_text(f'"""\n{fn.name}\n{"=" * len(fn.name)}\n\n'
+                            f'{msg}\n"""\n{script_text}')
 
     # make sure the saved Models and ModelResult are available
     if "save" in fn.name:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -36,6 +36,7 @@ Various:
 - fix description of ``name`` argument in ``Parameters.add`` (@kristianmeyerr; PR #725)
 - update dependencies, make sure a functional development environment is installed on Windows (Issue #712))
 - use ``setuptools_scm`` for version info instead of ``versioneer`` (PR #729)
+- transition to using ``f-strings`` (PR #730)
 
 
 .. _whatsnew_102_label:

--- a/examples/doc_model_with_iter_callback.py
+++ b/examples/doc_model_with_iter_callback.py
@@ -7,7 +7,7 @@ from lmfit.models import GaussianModel, LinearModel
 
 
 def per_iteration(pars, iteration, resid, *args, **kws):
-    print(" ITER ", iteration, ["%.5f" % p for p in pars.values()])
+    print(" ITER ", iteration, [f"{p.name} = {p.value:.5f}" for p in pars.values()])
 
 
 x = linspace(0., 20, 401)
@@ -28,7 +28,7 @@ out = mod.fit(y, pars, x=x, iter_cb=per_iteration)
 
 plt.plot(x, y, 'b--')
 
-print('Nfev = ', out.nfev)
+print(f'Nfev = {out.nfev}')
 print(out.fit_report())
 
 plt.plot(x, out.best_fit, 'k-', label='best fit')

--- a/examples/example_brute.py
+++ b/examples/example_brute.py
@@ -186,9 +186,7 @@ result_brute = fitter.minimize(method='brute', Ns=25, keep=25)
 par_name = 'shift'
 indx_shift = result_brute.var_names.index(par_name)
 grid_shift = np.unique(result_brute.brute_grid[indx_shift].ravel())
-print("parameter = {}\nnumber of steps = {}\ngrid = {}".format(par_name,
-                                                               len(grid_shift),
-                                                               grid_shift))
+print(f"parameter = {par_name}\nnumber of steps = {len(grid_shift)}\ngrid = {grid_shift}")
 
 ###############################################################################
 # If finite bounds are not set for a certain parameter then the user **must**

--- a/examples/example_complex_resonator_model.py
+++ b/examples/example_complex_resonator_model.py
@@ -62,11 +62,11 @@ class ResonatorModel(lmfit.model.Model):
         Q_guess = np.sqrt(Q_min*Q_max)  # geometric mean, why not?
         Q_e_real_guess = Q_guess/(1-np.abs(data[argmin_s21]))
         if verbose:
-            print("fmin=", fmin, "fmax=", fmax, "f_0_guess=", f_0_guess)
-            print("Qmin=", Q_min, "Q_max=", Q_max, "Q_guess=", Q_guess, "Q_e_real_guess=", Q_e_real_guess)
+            print(f"fmin={fmin}, fmax={fmax}, f_0_guess={f_0_guess}")
+            print(f"Qmin={Q_min}, Q_max={Q_max}, Q_guess={Q_guess}, Q_e_real_guess={Q_e_real_guess}")
         params = self.make_params(Q=Q_guess, Q_e_real=Q_e_real_guess, Q_e_imag=0, f_0=f_0_guess)
-        params['%sQ' % self.prefix].set(min=Q_min, max=Q_max)
-        params['%sf_0' % self.prefix].set(min=fmin, max=fmax)
+        params[f'{self.prefix}Q'].set(min=Q_min, max=Q_max)
+        params[f'{self.prefix}f_0'].set(min=fmin, max=fmax)
         return lmfit.models.update_param_vals(params, self.prefix, **kwargs)
 
 

--- a/examples/example_fit_multi_datasets.py
+++ b/examples/example_fit_multi_datasets.py
@@ -23,9 +23,9 @@ def gauss(x, amp, cen, sigma):
 
 def gauss_dataset(params, i, x):
     """Calculate Gaussian lineshape from parameters for data set."""
-    amp = params['amp_%i' % (i+1)]
-    cen = params['cen_%i' % (i+1)]
-    sig = params['sig_%i' % (i+1)]
+    amp = params[f'amp_{i+1}']
+    cen = params[f'cen_{i+1}']
+    sig = params[f'sig_{i+1}']
     return gauss(x, amp, cen, sig)
 
 
@@ -62,16 +62,16 @@ data = np.array(data)
 
 fit_params = Parameters()
 for iy, y in enumerate(data):
-    fit_params.add('amp_%i' % (iy+1), value=0.5, min=0.0, max=200)
-    fit_params.add('cen_%i' % (iy+1), value=0.4, min=-2.0, max=2.0)
-    fit_params.add('sig_%i' % (iy+1), value=0.3, min=0.01, max=3.0)
+    fit_params.add(f'amp_{iy+1}', value=0.5, min=0.0, max=200)
+    fit_params.add(f'cen_{iy+1}', value=0.4, min=-2.0, max=2.0)
+    fit_params.add(f'sig_{iy+1}', value=0.3, min=0.01, max=3.0)
 
 ###############################################################################
 # Constrain the values of sigma to be the same for all peaks by assigning
 # sig_2, ..., sig_5 to be equal to sig_1.
 
 for iy in (2, 3, 4, 5):
-    fit_params['sig_%i' % iy].expr = 'sig_1'
+    fit_params[f'sig_{iy}'].expr = 'sig_1'
 
 ###############################################################################
 # Run the global fit and show the fitting result

--- a/examples/lmfit_emcee_model_selection.py
+++ b/examples/lmfit_emcee_model_selection.py
@@ -43,8 +43,8 @@ def residual(p, just_generative=False):
     v = p.valuesdict()
     generative = v['a'] + v['b'] * x
     M = 0
-    while 'a_max%d' % M in v:
-        generative += gauss(x, v['a_max%d' % M], v['loc%d' % M], v['sd%d' % M])
+    while f'a_max{M}' in v:
+        generative += gauss(x, v[f'a_max{M}'], v[f'loc{M}'], v[f'sd{M}'])
         M += 1
 
     if just_generative:
@@ -70,9 +70,9 @@ def initial_peak_params(M):
     p.add_many(('a', a, True, 0, 10), ('b', b, True, 1, 15))
 
     for i in range(M):
-        p.add_many(('a_max%d' % i, 0.5 * a_max, True, 10, a_max),
-                   ('loc%d' % i, loc, True, np.min(x), np.max(x)),
-                   ('sd%d' % i, sd, True, 0.1, np.max(x) - np.min(x)))
+        p.add_many((f'a_max{i}', 0.5 * a_max, True, 10, a_max),
+                   (f'loc{i}', loc, True, np.min(x), np.max(x)),
+                   (f'sd{i}', sd, True, 0.1, np.max(x) - np.min(x)))
     return p
 
 

--- a/lmfit/_ampgo.py
+++ b/lmfit/_ampgo.py
@@ -118,11 +118,11 @@ def ampgo(objfun, x0, args=(), local='L-BFGS-B', local_opts=None, bounds=None,
         maxfunevals = np.inf
 
     if tabulistsize < 1:
-        raise Exception('Invalid tabulistsize specified: {:d}. It should be '
-                        'an integer greater than zero.'.format(tabulistsize))
+        raise Exception(f'Invalid tabulistsize specified: {tabulistsize}. '
+                        'It should be an integer greater than zero.')
     if tabustrategy not in ['oldest', 'farthest']:
-        raise Exception('Invalid tabustrategy specified: {:s}. It must be one '
-                        'of "oldest" or "farthest".'.format(tabustrategy))
+        raise Exception(f'Invalid tabustrategy specified: {tabustrategy}. '
+                        'It must be one of "oldest" or "farthest".')
 
     tabulist = []
     best_f = np.inf
@@ -225,7 +225,7 @@ def ampgo(objfun, x0, args=(), local='L-BFGS-B', local_opts=None, bounds=None,
 
                 if disp:
                     print('\n\n ==> Successful tunnelling phase. Reached new '
-                          'local minimum: {:.5g} < {:.5g}\n'.format(yf, oldf))
+                          f'local minimum: {yf:.5g} < {oldf:.5g}\n')
 
             i += 1
 

--- a/lmfit/confidence.py
+++ b/lmfit/confidence.py
@@ -10,8 +10,8 @@ from scipy.stats import f
 from .minimizer import MinimizerException
 
 CONF_ERR_GEN = 'Cannot determine Confidence Intervals'
-CONF_ERR_STDERR = '%s without sensible uncertainty estimates' % CONF_ERR_GEN
-CONF_ERR_NVARS = '%s with < 2 variables' % CONF_ERR_GEN
+CONF_ERR_STDERR = f'{CONF_ERR_GEN} without sensible uncertainty estimates'
+CONF_ERR_NVARS = f'{CONF_ERR_GEN} with < 2 variables'
 
 
 def f_compare(best_fit, new_fit):
@@ -275,7 +275,7 @@ class ConfidenceInterval:
     def find_limit(self, para, direction):
         """Find a value for given parameter so that prob(val) > sigmas."""
         if self.verbose:
-            print('Calculating CI for ' + para.name)
+            print(f'Calculating CI for {para.name}')
         self.reset_vals()
 
         # determine starting step
@@ -306,30 +306,27 @@ class ConfidenceInterval:
             rel_change = (new_prob - old_prob) / max(new_prob, old_prob, 1e-12)
             old_prob = new_prob
             if self.verbose:
-                msg = "P({}={}) = {}, max. prob={}"
-                print(msg.format(para.name, limit, new_prob, max_prob))
+                print(f'P({para.name}={limit}) = {new_prob}, '
+                      f'max. prob={max_prob}')
 
             # check for convergence
             if bound_reached:
                 if new_prob < max(self.probs):
-                    errmsg = ("Bound reached with "
-                              "prob({}={}) = {} < max(sigmas)"
-                              ).format(para.name, limit, new_prob)
+                    errmsg = (f'Bound reached with prob({para.name}={limit}) '
+                              f'= {new_prob} < max(sigmas)')
                     warn(errmsg)
                     break
 
             if i > self.maxiter:
-                errmsg = f"maxiter={self.maxiter} reached "
-                errmsg += ("and prob({}={}) = {} < "
-                           "max(sigmas).".format(para.name, limit, new_prob))
+                errmsg = (f'maxiter={self.maxiter} reached and prob('
+                          f'{para.name}={limit}) = {new_prob} < max(sigmas)')
                 warn(errmsg)
                 break
 
             if rel_change < self.min_rel_change:
-                errmsg = "rel_change={} < {} ".format(rel_change,
-                                                      self.min_rel_change)
-                errmsg += ("at iteration {} and prob({}={}) = {} < max"
-                           "(sigmas).".format(i, para.name, limit, new_prob))
+                errmsg = (f'rel_change={rel_change} < {self.min_rel_change} '
+                          f'at iteration {i} and prob({para.name}={limit}) = '
+                          f'{new_prob} < max(sigmas)')
                 warn(errmsg)
                 break
 

--- a/lmfit/jsonutils.py
+++ b/lmfit/jsonutils.py
@@ -18,6 +18,9 @@ except ImportError:
     read_json = None
 
 
+pyvers = f'{sys.version_info.major}.{sys.version_info.minor}'
+
+
 def find_importer(obj):
     """Find importer of an object."""
     oname = obj.__name__
@@ -86,8 +89,6 @@ def encode4js(obj):
         return out
     if callable(obj):
         val, importer = None, None
-        pyvers = "%d.%d" % (sys.version_info.major,
-                            sys.version_info.minor)
         if HAS_DILL:
             val = str(b64encode(dill.dumps(obj)), 'utf-8')
         else:
@@ -132,8 +133,6 @@ def decode4js(obj):
         out = read_json(obj['value'], typ='series')
     elif classname == 'Callable':
         out = val = obj['__name__']
-        pyvers = "%d.%d" % (sys.version_info.major,
-                            sys.version_info.minor)
         if pyvers == obj['pyversion'] and HAS_DILL:
             out = dill.loads(b64decode(obj['value']))
         elif obj['importer'] is not None:

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -380,8 +380,8 @@ def thermal_distribution(x, amplitude=1.0, center=0.0, kt=1.0, form='bose'):
     elif form.startswith('fermi'):
         offset = 1
     else:
-        msg = "Invalid value ('%s') for argument 'form'; should be one of %s."\
-              % (form, "'maxwell', 'fermi', or 'bose'")
+        msg = (f"Invalid value ('{form}') for argument 'form'; should be one "
+               "of 'maxwell', 'fermi', or 'bose'.")
         raise ValueError(msg)
 
     return real(1/(amplitude*exp((x - center)/not_zero(kt)) + offset + tiny*1j))
@@ -413,8 +413,8 @@ def step(x, amplitude=1.0, center=0.0, sigma=1.0, form='linear'):
         out[where(out < 0)] = 0.0
         out[where(out > 1)] = 1.0
     else:
-        msg = "Invalid value ('%s') for argument 'form'; should be one of %s."\
-               % (form, "'erf', 'logistic', 'atan', 'arctan', or 'linear'")
+        msg = (f"Invalid value ('{form}') for argument 'form'; should be one "
+               "of 'erf', 'logistic', 'atan', 'arctan', or 'linear'.")
         raise ValueError(msg)
 
     return amplitude*out
@@ -455,8 +455,8 @@ def rectangle(x, amplitude=1.0, center1=0.0, sigma1=1.0,
         arg2[where(arg2 < -1)] = -1.0
         out = arg1 + arg2
     else:
-        msg = "Invalid value ('%s') for argument 'form'; should be one of %s."\
-               % (form, "'erf', 'logistic', 'atan', 'arctan', or 'linear'")
+        msg = (f"Invalid value ('{form}') for argument 'form'; should be one "
+               "of 'erf', 'logistic', 'atan', 'arctan', or 'linear'.")
         raise ValueError(msg)
 
     return amplitude*out

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -76,7 +76,7 @@ except ImportError:
 # define the namedtuple here so pickle will work with the MinimizerResult
 Candidate = namedtuple('Candidate', ['params', 'score'])
 
-MAXEVAL_Warning = "ignoring `%s` argument to `%s()`. Use `max_nfev` instead."
+maxeval_warning = "ignoring `{}` argument to `{}()`. Use `max_nfev` instead."
 
 
 def thisfuncname():
@@ -347,16 +347,13 @@ class MinimizerResult:
         if hasattr(self, 'candidates'):
             if candidate_nmb == 'all':
                 for i, candidate in enumerate(self.candidates):
-                    print("\nCandidate #{}, chisqr = "
-                          "{:.3f}".format(i+1, candidate.score))
+                    print(f"\nCandidate #{i + 1}, chisqr = {candidate.score:.3f}")
                     candidate.params.pretty_print()
             elif (candidate_nmb < 1 or candidate_nmb > len(self.candidates)):
-                raise ValueError("'candidate_nmb' should be between 1 and {}."
-                                 .format(len(self.candidates)))
+                raise ValueError(f"'candidate_nmb' should be between 1 and {len(self.candidates)}.")
             else:
                 candidate = self.candidates[candidate_nmb-1]
-                print("\nCandidate #{}, chisqr = "
-                      "{:.3f}".format(candidate_nmb, candidate.score))
+                print(f"\nCandidate #{candidate_nmb}, chisqr = {candidate.score:.3f}")
                 candidate.params.pretty_print()
 
     def _calculate_statistics(self):
@@ -390,7 +387,7 @@ class Minimizer:
 
     _err_nonparam = ("params must be a minimizer.Parameters() instance or"
                      " list of Parameters()")
-    _err_max_evals = ("Too many function calls (max set to %i)! Use:"
+    _err_max_evals = ("Too many function calls (max set to {:i})! Use:"
                       " minimize(func, params, ..., max_nfev=NNN)"
                       " to increase this maximum.")
 
@@ -493,7 +490,7 @@ class Minimizer:
             self.userkws = {}
         for maxnfev_alias in ('maxfev', 'maxiter'):
             if maxnfev_alias in kws:
-                warnings.warn(MAXEVAL_Warning % (maxnfev_alias, 'Minimizer'),
+                warnings.warn(maxeval_warning.format(maxnfev_alias, 'Minimizer'),
                               RuntimeWarning)
                 kws.pop(maxnfev_alias)
 
@@ -582,10 +579,10 @@ class Minimizer:
         self.result.last_internal_values = fvars
         if self.result.nfev > self.max_nfev:
             self.result.aborted = True
-            m = "number of function evaluations > %d" % self.max_nfev
-            self.result.message = "Fit aborted: %s" % m
+            m = f"number of function evaluations > {self.max_nfev}"
+            self.result.message = f"Fit aborted: {m}"
             self.result.success = False
-            raise AbortFitException("fit aborted: too many function evaluations (%d)." % self.max_nfev)
+            raise AbortFitException(f"fit aborted: too many function evaluations {self.max_nfev}")
 
         out = self.userfcn(params, *self.userargs, **self.userkws)
 
@@ -959,7 +956,7 @@ class Minimizer:
         fmin_kws.update(self.kws)
 
         if 'maxiter' in kws:
-            warnings.warn(MAXEVAL_Warning % ('maxiter', thisfuncname()),
+            warnings.warn(maxeval_warning.format('maxiter', thisfuncname()),
                           RuntimeWarning)
             kws.pop('maxiter')
         fmin_kws.update(kws)
@@ -1680,7 +1677,7 @@ class Minimizer:
         lskws = dict(full_output=1, xtol=1.e-7, ftol=1.e-7, col_deriv=False,
                      gtol=1.e-7, maxfev=2*self.max_nfev, Dfun=None)
         if 'maxfev' in kws:
-            warnings.warn(MAXEVAL_Warning % ('maxfev', thisfuncname()),
+            warnings.warn(maxeval_warning.format('maxfev', thisfuncname()),
                           RuntimeWarning)
             kws.pop('maxfev')
 
@@ -1731,7 +1728,7 @@ class Minimizer:
         elif ier == 4:
             result.message = 'One or more variable did not affect the fit.'
         elif ier == 5:
-            result.message = self._err_max_evals % lskws['maxfev']
+            result.message = self._err_max_evals.format(lskws['maxfev'])
         else:
             result.message = 'Tolerance seems to be too small.'
 
@@ -1743,7 +1740,7 @@ class Minimizer:
             # calculate parameter uncertainties and correlations
             self._calculate_uncertainties_correlations()
         else:
-            result.message = '%s Could not estimate error-bars.' % result.message
+            result.message = f'{result.message} Could not estimate error-bars.'
 
         np.seterr(**orig_warn_settings)
 
@@ -2083,7 +2080,7 @@ class Minimizer:
         ampgo_kws.update(kws)
 
         values = result.init_vals
-        result.method = "ampgo, with {} as local solver".format(ampgo_kws['local'])
+        result.method = f"ampgo, with {ampgo_kws['local']} as local solver"
         result.call_kws = ampgo_kws
         try:
             ret = ampgo(self.penalty, values, **ampgo_kws)
@@ -2331,7 +2328,7 @@ class Minimizer:
         kwargs.update(self.kws)
         for maxnfev_alias in ('maxfev', 'maxiter'):
             if maxnfev_alias in kws:
-                warnings.warn(MAXEVAL_Warning % (maxnfev_alias, thisfuncname()),
+                warnings.warn(maxeval_warning.format(maxnfev_alias, thisfuncname()),
                               RuntimeWarning)
                 kws.pop(maxnfev_alias)
 
@@ -2378,8 +2375,8 @@ def _make_random_gen(seed):
         return np.random.RandomState(seed)
     if isinstance(seed, np.random.RandomState):
         return seed
-    raise ValueError('%r cannot be used to seed a numpy.random.RandomState'
-                     ' instance' % seed)
+    raise ValueError(f'{seed:r} cannot be used to seed a numpy.random.RandomState'
+                     ' instance')
 
 
 def _nan_policy(arr, nan_policy='raise', handle_inf=True):

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -69,7 +69,7 @@ def get_reducer(option):
 
     """
     if option not in ['real', 'imag', 'abs', 'angle']:
-        raise ValueError("Invalid option ('%s') for function 'propagate_err'." % option)
+        raise ValueError(f"Invalid option ('{option}') for function 'propagate_err'.")
 
     def reducer(array):
         """Convert a complex array to a real array.
@@ -138,10 +138,10 @@ def propagate_err(z, dz, option):
 
     """
     if option not in ['real', 'imag', 'abs', 'angle']:
-        raise ValueError("Invalid option ('%s') for function 'propagate_err'." % option)
+        raise ValueError(f"Invalid option ('{option}') for function 'propagate_err'.")
 
     if not z.shape == dz.shape:
-        raise ValueError("shape of z: %s != shape of dz: %s" % (z.shape, dz.shape))
+        raise ValueError(f"shape of z: {z.shape} != shape of dz: {dz.shape}")
 
     # Check the main vector for complex. Do nothing if real.
     if any(np.iscomplex(z)):
@@ -283,13 +283,13 @@ class Model:
         out = self._name
         opts = []
         if len(self._prefix) > 0:
-            opts.append("prefix='%s'" % (self._prefix))
+            opts.append(f"prefix='{self._prefix}'")
         if long:
             for k, v in self.opts.items():
-                opts.append("%s='%s'" % (k, v))
+                opts.append(f"{k}='{v}'")
         if len(opts) > 0:
-            out = "%s, %s" % (out, ', '.join(opts))
-        return "Model(%s)" % out
+            out = f"{out}, {', '.join(opts)}"
+        return f"Model({out})"
 
     def _get_state(self):
         """Save a Model for serialization.
@@ -448,7 +448,7 @@ class Model:
 
     def __repr__(self):
         """Return representation of Model."""
-        return "<lmfit.Model: %s>" % (self.name)
+        return f"<lmfit.Model: {self.name}>"
 
     def copy(self, **kwargs):
         """DOES NOT WORK."""
@@ -484,7 +484,7 @@ class Model:
                     else:
                         kw_args[fnam] = fpar.default
                 elif fpar.kind == fpar.VAR_POSITIONAL:
-                    raise ValueError("varargs '*%s' is not supported" % fnam)
+                    raise ValueError(f"varargs '*{fnam}' is not supported")
         # inspection done
 
         self._func_haskeywords = keywords_ is not None
@@ -529,7 +529,7 @@ class Model:
         if self._prefix is None:
             self._prefix = ''
         for pname in self._param_root_names:
-            names.append("%s%s" % (self._prefix, pname))
+            names.append(f"{self._prefix}{pname}")
 
         # check variables names for validity
         # The implicit magic in fit() requires us to disallow some
@@ -673,20 +673,20 @@ class Model:
                 par.value = kwargs[name]
             params.add(par)
             if verbose:
-                print(' - Adding parameter "%s"' % name)
+                print(f' - Adding parameter "{name}"')
 
         # next build parameters defined in param_hints
         # note that composites may define their own additional
         # convenience parameters here
         for basename, hint in self.param_hints.items():
-            name = "%s%s" % (self._prefix, basename)
+            name = f"{self._prefix}{basename}"
             if name in params:
                 par = params[name]
             else:
                 par = Parameter(name=name)
                 params.add(par)
                 if verbose:
-                    print(' - Adding parameter for hint "%s"' % name)
+                    print(f' - Adding parameter for hint "{name}"')
             par._delay_asteval = True
             for item in self._hint_names:
                 if item in hint:
@@ -732,7 +732,7 @@ class Model:
 
         """
         cname = self.__class__.__name__
-        msg = 'guess() not implemented for %s' % cname
+        msg = f'guess() not implemented for {cname}'
         raise NotImplementedError(msg)
 
     def _residual(self, params, data, weights, **kwargs):
@@ -823,7 +823,7 @@ class Model:
         """Generate **all** function args for all functions."""
         args = {}
         for key, val in self.make_funcargs(params, kwargs).items():
-            args["%s%s" % (self._prefix, key)] = val
+            args[f"{self._prefix}{key}"] = val
         return args
 
     def eval(self, params=None, **kwargs):
@@ -975,7 +975,7 @@ class Model:
         # All remaining kwargs should correspond to independent variables.
         for name in kwargs:
             if name not in self.independent_vars:
-                warnings.warn("The keyword argument %s does not " % name +
+                warnings.warn(f"The keyword argument {name} does not " +
                               "match any arguments of the model function. " +
                               "It will be ignored.", UserWarning)
 
@@ -989,8 +989,8 @@ class Model:
             missing = [p for p in self.param_names if p not in params.keys()]
             blank = [name for name, p in params.items()
                      if p.value is None and p.expr is None]
-            msg += 'Missing parameters: %s\n' % str(missing)
-            msg += 'Non initialized parameters: %s' % str(blank)
+            msg += f'Missing parameters: {str(missing)}\n'
+            msg += f'Non initialized parameters: {str(blank)}'
             raise ValueError(msg)
 
         # Handle null/missing values.
@@ -1067,10 +1067,6 @@ class CompositeModel(Model):
 
     """
 
-    _names_collide = ("\nTwo models have parameters named '{clash}'. "
-                      "Use distinct names.")
-    _bad_arg = "CompositeModel: argument {arg} is not a Model"
-    _bad_op = "CompositeModel: operator {op} is not callable"
     _known_ops = {operator.add: '+', operator.sub: '-',
                   operator.mul: '*', operator.truediv: '/'}
 
@@ -1094,11 +1090,11 @@ class CompositeModel(Model):
 
         """
         if not isinstance(left, Model):
-            raise ValueError(self._bad_arg.format(arg=left))
+            raise ValueError(f'CompositeModel: argument {left} is not a Model')
         if not isinstance(right, Model):
-            raise ValueError(self._bad_arg.format(arg=right))
+            raise ValueError(f'CompositeModel: argument {right} is not a Model')
         if not callable(op):
-            raise ValueError(self._bad_op.format(op=op))
+            raise ValueError(f'CompositeModel: operator {op} is not callable')
 
         self.left = left
         self.right = right
@@ -1108,7 +1104,8 @@ class CompositeModel(Model):
         if len(name_collisions) > 0:
             msg = ''
             for collision in name_collisions:
-                msg += self._names_collide.format(clash=collision)
+                msg += (f"\nTwo models have parameters named '{collision}'; "
+                        "use distinct names.")
             raise NameError(msg)
 
         # we assume that all the sub-models have the same independent vars
@@ -1124,7 +1121,7 @@ class CompositeModel(Model):
         for side in (left, right):
             prefix = side.prefix
             for basename, hint in side.param_hints.items():
-                self.param_hints["%s%s" % (prefix, basename)] = hint
+                self.param_hints[f"{prefix}{basename}"] = hint
 
     def _parse_params(self):
         self._func_haskeywords = (self.left._func_haskeywords or
@@ -1137,9 +1134,9 @@ class CompositeModel(Model):
         self.opts.update(self.left.opts)
 
     def _reprstring(self, long=False):
-        return "(%s %s %s)" % (self.left._reprstring(long=long),
-                               self._known_ops.get(self.op, self.op),
-                               self.right._reprstring(long=long))
+        return (f"({self.left._reprstring(long=long)} "
+                f"{self._known_ops.get(self.op, self.op)} "
+                f"{self.right._reprstring(long=long)})")
 
     def eval(self, params=None, **kwargs):
         """Evaluate model function for composite model."""
@@ -1605,14 +1602,14 @@ class ModelResult(Minimizer):
                             show_correl=show_correl,
                             min_correl=min_correl, sort_pars=sort_pars)
         modname = self.model._reprstring(long=True)
-        return '[[Model]]\n    %s\n%s' % (modname, report)
+        return f'[[Model]]\n    {modname}\n{report}'
 
     def _repr_html_(self, show_correl=True, min_correl=0.1):
         """Return a HTML representation of parameters data."""
         report = fitreport_html_table(self, show_correl=show_correl,
                                       min_correl=min_correl)
         modname = self.model._reprstring(long=True)
-        return "<h2> Model</h2> %s %s" % (modname, report)
+        return f"<h2> Model</h2> {modname} {report}"
 
     def dumps(self, **kws):
         """Represent ModelResult as a JSON string.

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -84,7 +84,7 @@ class Parameters(dict):
     def update(self, other):
         """Update values and symbols with another Parameters object."""
         if not isinstance(other, Parameters):
-            raise ValueError("'%s' is not a Parameters object" % other)
+            raise ValueError(f"'{other}' is not a Parameters object")
         self.add_many(*other.values())
         for sym in other._asteval.user_defined_symbols():
             self._asteval.symtable[sym] = other._asteval.symtable[sym]
@@ -133,9 +133,9 @@ class Parameters(dict):
         """Set items of Parameters object."""
         if key not in self:
             if not valid_symbol_name(key):
-                raise KeyError("'%s' is not a valid Parameters name" % key)
+                raise KeyError(f"'{key}' is not a valid Parameters name")
         if par is not None and not isinstance(par, Parameter):
-            raise ValueError("'%s' is not a Parameter" % par)
+            raise ValueError(f"'{par}' is not a Parameter")
         dict.__setitem__(self, key, par)
         par.name = key
         par._expr_eval = self._asteval
@@ -144,7 +144,7 @@ class Parameters(dict):
     def __add__(self, other):
         """Add Parameters objects."""
         if not isinstance(other, Parameters):
-            raise ValueError("'%s' is not a Parameters object" % other)
+            raise ValueError(f"'{other}' is not a Parameters object")
         out = deepcopy(self)
         out.add_many(*other.values())
         for sym in other._asteval.user_defined_symbols():
@@ -205,8 +205,8 @@ class Parameters(dict):
     def __repr__(self):
         """__repr__ from OrderedDict."""
         if not self:
-            return '%s()' % (self.__class__.__name__,)
-        return '%s(%r)' % (self.__class__.__name__, list(self.items()))
+            return f'{self.__class__.__name__}()'
+        return f'{self.__class__.__name__}({list(self.items())!r})'
 
     def eval(self, expr):
         """Evaluate a statement using the `asteval` Interpreter.
@@ -274,7 +274,7 @@ class Parameters(dict):
             return self.__repr__()
         s = "Parameters({\n"
         for key in self.keys():
-            s += "    '%s': %s, \n" % (key, self[key])
+            s += f"    '{key}': {self[key]}, \n"
         s += "    })\n"
         return s
 
@@ -702,7 +702,7 @@ class Parameter:
         if self.min > self.max:
             self.min, self.max = self.max, self.min
         if isclose(self.min, self.max, atol=1e-13, rtol=1e-13):
-            raise ValueError("Parameter '%s' has min == max" % self.name)
+            raise ValueError(f"Parameter '{self.name}' has min == max")
         if self._val > self.max:
             self._val = self.max
         if self._val < self.min:
@@ -731,18 +731,18 @@ class Parameter:
     def __repr__(self):
         """Return printable representation of a Parameter object."""
         s = []
-        sval = "value=%s" % repr(self._getval())
+        sval = f"value={repr(self._getval())}"
         if not self.vary and self._expr is None:
             sval += " (fixed)"
         elif self.stderr is not None:
-            sval += " +/- %.3g" % self.stderr
+            sval += f" +/- {self.stderr:.3g}"
         s.append(sval)
-        s.append("bounds=[%s:%s]" % (repr(self.min), repr(self.max)))
+        s.append(f"bounds=[{repr(self.min)}:{repr(self.max)}]")
         if self._expr is not None:
-            s.append("expr='%s'" % self.expr)
+            s.append(f"expr='{self.expr}'")
         if self.brute_step is not None:
-            s.append("brute_step=%s" % (self.brute_step))
-        return "<Parameter '%s', %s>" % (self.name, ', '.join(s))
+            s.append(f"brute_step={self.brute_step}")
+        return f"<Parameter '{self.name}', {', '.join(s)}>"
 
     def setup_bounds(self):
         """Set up Minuit-style internal/external parameter transformation

--- a/tests/NISTModels.py
+++ b/tests/NISTModels.py
@@ -188,7 +188,7 @@ def ReadNistData(dataset):
     """NIST STRD data is in a simple, fixed format with
     line numbers being significant!
     """
-    finp = open(os.path.join(NIST_DIR, "%s.dat" % dataset))
+    finp = open(os.path.join(NIST_DIR, f"{dataset}.dat"))
     lines = [line[:-1] for line in finp.readlines()]
     finp.close()
     ModelLines = lines[30:39]

--- a/tests/test_NIST_Strd.py
+++ b/tests/test_NIST_Strd.py
@@ -18,7 +18,7 @@ ABAR = ' |----------------+----------------+------------------+-----------------
 
 def Compare_NIST_Results(DataSet, myfit, params, NISTdata):
     buff = [' ======================================',
-            ' %s: ' % DataSet,
+            f' {DataSet}: ',
             ' | Parameter Name |  Value Found   |  Certified Value | # Matching Digits |']
     buff.append(ABAR)
 
@@ -26,7 +26,7 @@ def Compare_NIST_Results(DataSet, myfit, params, NISTdata):
     err_dig_min = 200
     fmt = ' | %s | % -.7e | % -.7e   | %2i                |'
     for i in range(NISTdata['nparams']):
-        parname = 'b%i' % (i+1)
+        parname = f'b{i+1}'
         par = params[parname]
         thisval = par.value
         certval = NISTdata['cert_values'][i]
@@ -56,10 +56,10 @@ def Compare_NIST_Results(DataSet, myfit, params, NISTdata):
         buff.append(' |          * * * * COULD NOT ESTIMATE UNCERTAINTIES * * * *              |')
         err_dig_min = 0
     if err_dig_min < 199:
-        buff.append(' Worst agreement: %i digits for value, %i digits for error '
-                    % (val_dig_min, err_dig_min))
+        buff.append(f' Worst agreement: {val_dig_min} digits for value, '
+                    f'{err_dig_min} digits for error ')
     else:
-        buff.append(' Worst agreement: %i digits' % (val_dig_min))
+        buff.append(f' Worst agreement: {val_dig_min} digits')
     return val_dig_min, '\n'.join(buff)
 
 
@@ -73,7 +73,7 @@ def NIST_Dataset(DataSet, method='leastsq', start='start2',
 
     params = Parameters()
     for i in range(npar):
-        pname = 'b%i' % (i+1)
+        pname = f'b{i+1}'
         pval1 = NISTdata[start][i]
         params.add(pname, value=pval1)
     try:
@@ -93,14 +93,14 @@ def build_usage():
     modelnames = []
     ms = ''
     for d in sorted(Models.keys()):
-        ms = ms + ' %s ' % d
+        ms = ms + f' {d} '
         if len(ms) > 55:
             modelnames.append(ms)
             ms = '    '
     modelnames.append(ms)
     modelnames = '\n'.join(modelnames)
 
-    usage = """
+    usage = f"""
  === Test Fit to NIST StRD Models ===
 
 usage:
@@ -110,7 +110,7 @@ usage:
 where Start is one of 'start1','start2' or 'cert', for different
 starting values, and Model is one of
 
-    %s
+    {modelnames}
 
 if Model = 'all', all models and starting values will be run.
 
@@ -120,7 +120,7 @@ options:
           leastsq, nelder, powell, lbfgsb, bfgs,
           tnc, cobyla, slsqp, cg, newto-cg
       leastsq (Levenberg-Marquardt) is the default
-""" % modelnames
+"""
     return usage
 ############################
 
@@ -154,10 +154,10 @@ def run_interactive():
                     tpass += 1
                 else:
                     tfail += 1
-                    failures.append("   %s (starting at '%s')" % (dset, start))
+                    failures.append(f"   {dset} (starting at '{start}')")
         print('--------------------------------------')
-        print(' Fit Method: %s ' % opts.method)
-        print(' Final Results: %i pass, %i fail.' % (tpass, tfail))
+        print(f' Fit Method: {opts.method} ')
+        print(f' Final Results: {tpass} pass, {tfail} fail.')
         print(' Tests Failed for:\n %s' % '\n '.join(failures))
         print('--------------------------------------')
     elif dset not in Models:

--- a/tests/test_manypeaks_speed.py
+++ b/tests/test_manypeaks_speed.py
@@ -17,7 +17,7 @@ def test_manypeaks_speed():
     model = None
     t0 = time.time()
     for i in np.arange(500):
-        g = Model(gaussian, prefix='g%i_' % i)
+        g = Model(gaussian, prefix=f'g{i}')
         if model is None:
             model = g
         else:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1047,7 +1047,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
             m.set_param_hint('amp', value=1)
             m.set_param_hint('amp', value=25)
 
-            models[i] = Model(func, prefix='mod%i_' % i)
+            models[i] = Model(func, prefix=f'mod{i}')
             models[i].param_hints['amp'] = m.param_hints['amp']
 
         self.assertEqual(models[0].param_hints['amp'],

--- a/tests/test_multidatasets.py
+++ b/tests/test_multidatasets.py
@@ -9,9 +9,9 @@ from lmfit.lineshapes import gaussian
 def gauss_dataset(params, i, x):
     """calc gaussian from params for data set i
     using simple, hardwired naming convention"""
-    amp = params['amp_%i' % (i+1)]
-    cen = params['cen_%i' % (i+1)]
-    sig = params['sig_%i' % (i+1)]
+    amp = params[f'amp_{i+1}']
+    cen = params[f'cen_{i+1}']
+    sig = params[f'sig_{i+1}']
     return gaussian(x, amp, cen, sig)
 
 
@@ -46,14 +46,14 @@ def test_multidatasets():
     # create 5 sets of parameters, one per data set
     pars = Parameters()
     for iy, _ in enumerate(data):
-        pars.add('amp_%i' % (iy+1), value=0.5, min=0.0, max=200)
-        pars.add('cen_%i' % (iy+1), value=0.4, min=-2.0, max=2.0)
-        pars.add('sig_%i' % (iy+1), value=0.3, min=0.01, max=3.0)
+        pars.add(f'amp_{iy+1}', value=0.5, min=0.0, max=200)
+        pars.add(f'cen_{iy+1}', value=0.4, min=-2.0, max=2.0)
+        pars.add(f'sig_{iy+1}', value=0.3, min=0.01, max=3.0)
 
     # but now constrain all values of sigma to have the same value
     # by assigning sig_2, sig_3, .. sig_5 to be equal to sig_1
     for iy in (2, 3, 4, 5):
-        pars['sig_%i' % iy].expr = 'sig_1'
+        pars[f'sig_{iy}'].expr = 'sig_1'
 
     # run the global fit to all the data sets
     out = minimize(objective, pars, args=(x, data))


### PR DESCRIPTION
#### Description
This PR transitions to code base to use `f-strings`:
- update to `pre-commit` hooks:(i) remove `--keep-percent-format` argument for `pyupgrade` and (ii) add `flynt` pre-commit hook to make sure that formatting-strings are used (`pyupgrade` isn't all that actively changing things...)
- use these tools in addition to manually going through the code to update the "old" style to f-strings.

In places where changing this would make the code less readable or more complicated I left the original.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.9.6 (default, Jul  3 2021, 08:35:53)
[Clang 11.0.3 (clang-1103.0.32.62)]

lmfit: 1.0.2.post65+gd614cd5, scipy: 1.7.0, numpy: 1.21.0, asteval: 0.9.25, uncertainties: 3.1.5

###### Verification <!-- (delete not applicable items) -->
Have you
- [ ] included docstrings that follow PEP 257?
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?