### PR TITLE
Fix model name collisions

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -792,13 +792,24 @@ class Model:
             kwargs = {}
         out = {}
         out.update(self.opts)
+
+        # 1. fill in in all parameter values
         for name, par in params.items():
             if strip:
                 name = self._strip_prefix(name)
             if name in self._func_allargs or self._func_haskeywords:
                 out[name] = par.value
 
-        # kwargs handled slightly differently -- may set param value too!
+        # 2. for each function argument, use 'prefx+varname' in params,
+        # avoiding possible name collisions with unprefixed params
+        if len(self._prefix) > 0:
+            for fullname in self._param_names:
+                if fullname in params:
+                    name = self._strip_prefix(fullname)
+                    if name in self._func_allargs or self._func_haskeywords:
+                        out[name]  = params[fullname].value
+
+        # 3. kwargs handled slightly differently -- may set param value too!
         for name, val in kwargs.items():
             if strip:
                 name = self._strip_prefix(name)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -807,7 +807,7 @@ class Model:
                 if fullname in params:
                     name = self._strip_prefix(fullname)
                     if name in self._func_allargs or self._func_haskeywords:
-                        out[name]  = params[fullname].value
+                        out[name] = params[fullname].value
 
         # 3. kwargs handled slightly differently -- may set param value too!
         for name, val in kwargs.items():

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1082,7 +1082,6 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         self.assertTrue(result.params['sigma'].stderr > 0.02)
         self.assertTrue(result.params['sigma'].stderr < 0.50)
 
-
     def test_unprefixed_name_collisions(self):
         # tests Github Issue 710
         np.random.seed(0)
@@ -1112,7 +1111,6 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         self.assertTrue(result.params['line_b'].value < 0.75)
         self.assertTrue(result.params['a'].value > 10)
         self.assertTrue(result.params['a'].value < 11)
-
 
     def test_composite_model_with_expr_constrains(self):
         """Smoke test for composite model fitting with expr constraints."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1088,10 +1088,10 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         np.random.seed(0)
         x = np.linspace(0, 20, 201)
         y = 6 + x * 0.55 + gaussian(x, 4.5, 8.5, 2.1) + np.random.normal(size=len(x), scale=0.03)
-        
+
         def myline(x, a, b):
             return a + b * x
-        
+
         def mygauss(x, a, b, c):
             return gaussian(x, a, b, c)
 
@@ -1112,7 +1112,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         self.assertTrue(result.params['line_b'].value < 0.75)
         self.assertTrue(result.params['a'].value > 10)
         self.assertTrue(result.params['a'].value < 11)
-        
+
 
     def test_composite_model_with_expr_constrains(self):
         """Smoke test for composite model fitting with expr constraints."""


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

This addresses #710 by adding an explicit step to Model.make_funcargs that says "for each function argument, get the parameter value from the fully-prefixed name".


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

Python: 3.8.10 | packaged by conda-forge | (default, May 10 2021, 22:58:09)
[Clang 11.1.0 ]

lmfit: 1.0.2.post64+g65f5a4d.d20210705, scipy: 1.7.0, numpy: 1.21.0, asteval: 0.9.25, uncertainties: 3.1.5




###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
