### PR TITLE
fix error message of models.PolynomialModel

### DIFF
--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -302,7 +302,7 @@ class PolynomialModel(Model):
         if 'form' in kwargs:
             degree = int(kwargs.pop('form'))
         if not isinstance(degree, int) or degree > self.MAX_DEGREE:
-            raise TypeError(self.DEGREE_ERR % self.MAX_DEGREE)
+            raise TypeError(self.DEGREE_ERR % (self.MAX_DEGREE+1))
 
         self.poly_degree = degree
         pnames = ['c%i' % (i) for i in range(degree + 1)]

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -291,7 +291,7 @@ class PolynomialModel(Model):
     """
 
     MAX_DEGREE = 7
-    DEGREE_ERR = "degree must be an integer less than %d."
+    DEGREE_ERR = "degree must be an integer equal to or smaller than %d."
 
     valid_forms = (0, 1, 2, 3, 4, 5, 6, 7)
 
@@ -302,7 +302,7 @@ class PolynomialModel(Model):
         if 'form' in kwargs:
             degree = int(kwargs.pop('form'))
         if not isinstance(degree, int) or degree > self.MAX_DEGREE:
-            raise TypeError(self.DEGREE_ERR % (self.MAX_DEGREE+1))
+            raise TypeError(self.DEGREE_ERR % self.MAX_DEGREE)
 
         self.poly_degree = degree
         pnames = ['c%i' % (i) for i in range(degree + 1)]


### PR DESCRIPTION
fix error message

<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
When creating a lmfit.models.PolynomialModel() with a higher degree than the allowed maximum, the error `TypeError: degree must be an integer less than 7.` is raised. However 7 is an allowed degree and thus it should be `TypeError: degree must be an integer less than 8.`
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.7.5 (tags/v3.7.5:5c02a39a0b, Oct 15 2019, 00:11:34) [MSC v.1916 64 bit (AMD64)]
lmfit: 1.0.2, scipy: 1.3.1, numpy: 1.17.3, asteval: 0.9.16, uncertainties: 3.1.2

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] squashed/minimized your commits and written descriptive commit messages?
