### PR TITLE
CI: switch to new codecov uploader

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  token: 11c28e95-6e64-4829-9887-04e4cd661bf6
+
 coverage:
   notify:
     after_n_builds: 8

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,7 @@ codecov:
 coverage:
   notify:
     after_n_builds: 8
+  informational: true
   status:
     project:
       default:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,16 @@ stages:
             pytest
           displayName: 'Run test-suite and collect coverage'
         - script: |
-            bash <(curl -s https://codecov.io/bash)
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+          displayName: 'Download and verify codecov uploader'
+        - script: |
+            ./codecov -v -f "coverage.xml"
           displayName: 'Upload to codecov.io'
 
 - stage: tests_latest_dependencies
@@ -140,7 +149,16 @@ stages:
             pytest
           displayName: 'Run test-suite and collect coverage'
         - script: |
-            bash <(curl -s https://codecov.io/bash)
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x codecov
+          displayName: 'Download and verify codecov uploader'
+        - script: |
+            ./codecov -v -f "coverage.xml"
           displayName: 'Upload to codecov.io'
 
 - stage: test_Windows_latest


### PR DESCRIPTION
#### Description
The bash uploader for `codecov` will be deprecated soon-ish after the security incident earlier this year. This PR attempts to implement the new approach, including the verification of the signatures/checksums. I cannot really do this locally or on my fork as `codecov` doesn't work there... this might need a few attempts to get it right.

###### Type of Changes
- [x] Refactoring / maintenance