### PR TITLE
Handle altered json parameters

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -25,6 +25,7 @@ Bug fixes/enhancements:
 - coerce ``data`` and ``indepdent_vars`` to NumPy array with ``dtype=float64`` or ``dtype=complex128`` where  applicable (Issues #723 and #727)
 - fix collision between parameter names in built-in models and user-specified parameters (Issue #710 and PR #732)
 - correct error message in PolynomialModel (@kremeyer; PR #737)
+- improved handling of altered JSON data (Issue #739; PR #740, reported by Matthew Giammar)
 
 Various:
 - update asteval dependency to >=0.9.22 to avoid DeprecationWarnings from NumPy v1.20.0 (PR #707)

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -724,8 +724,9 @@ class Parameter:
         self._expr_eval = None
         self._expr_deps = []
         self._delay_asteval = False
-        self.value = _value
+        self._val = _value
         self._init_bounds()
+        self.value = _value
 
     def __repr__(self):
         """Return printable representation of a Parameter object."""


### PR DESCRIPTION

#### Description

Addresses #739 by making sure that bounds are set up before setting the parameter value when loading a json or other "stateful" representation of a `Parameter`.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

Python: 3.8.10 | packaged by conda-forge | (default, May 10 2021, 22:58:09)
[Clang 11.1.0 ]

lmfit: 1.0.2.post78+g15a952b, scipy: 1.7.0, numpy: 1.21.0, asteval: 0.9.25, uncertainties: 3.1.5

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
