### PR TITLE
CI/TST: mark test as flaky to avoid intermittent CI failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,7 +81,7 @@ stages:
         - script: |
             python -m pip install --upgrade pip wheel
             pip install setuptools==57.5.0
-            pip install asteval==0.9.22 numpy==1.18 scipy==1.3.2 uncertainties==3.0.1 pytest coverage codecov
+            pip install asteval==0.9.22 numpy==1.18 scipy==1.3.2 uncertainties==3.0.1 pytest coverage codecov flaky
           displayName: 'Install minimum required version of dependencies'
         - script: |
             python setup.py install
@@ -221,7 +221,7 @@ stages:
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
             # remove numdifftools for now as it pulls in statsmodels, that wants to build with NumPy 1.14.5
-            pip3.10 install asteval uncertainties dill emcee
+            pip3.10 install asteval uncertainties dill emcee flaky
           displayName: 'Install latest available version of Python dependencies'
         - script: |
             python3.10 setup.py install --user

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -22,6 +22,7 @@ Downloading and Installation
 .. _sphinxcontrib-svg2pdfconverter: https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter
 .. _cairosvg: https://cairosvg.org/
 .. _Pillow: https://python-pillow.org/
+.. _flaky: https://github.com/box/flaky
 
 
 Prerequisites
@@ -39,7 +40,7 @@ Lmfit requires the following Python packages, with versions given:
 All of these are readily available on PyPI, and should be installed
 automatically if installing with ``pip install lmfit``.
 
-In order to run the test suite, the `pytest`_ package is required. Some
+In order to run the test suite, the `pytest`_ and `flaky`_ packages are required. Some
 functionality requires the `emcee`_ (version 3+), `corner`_, `pandas`_, `Jupyter`_,
 `matplotlib`_, `dill`_, or `numdifftools`_ packages. These are not installed
 automatically, but we highly recommend each of these packages.

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -34,9 +34,10 @@ Various:
 - update the contributing instructions (PR #718; @martin-majlis)
 - (again) defer import of matplotlib to when it is needed (@zobristnicholas; PR #721)
 - fix description of ``name`` argument in ``Parameters.add`` (@kristianmeyerr; PR #725)
-- update dependencies, make sure a functional development environment is installed on Windows (Issue #712))
+- update dependencies, make sure a functional development environment is installed on Windows (Issue #712)
 - use ``setuptools_scm`` for version info instead of ``versioneer`` (PR #729)
 - transition to using ``f-strings`` (PR #730)
+- mark ``test_manypeaks_speed.py`` as flaky to avoid intermittent test failures (repeat up to 5 times; PR #745)
 
 
 .. _whatsnew_102_label:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ corner
 coverage
 dill
 emcee>=3.0.0
+flaky
 jupyter_sphinx>=0.2.4
 matplotlib
 numdifftools

--- a/tests/test_manypeaks_speed.py
+++ b/tests/test_manypeaks_speed.py
@@ -1,11 +1,10 @@
-#
-# test speed of building complex model
-#
+"""Test speed of building complex model."""
 from copy import deepcopy
 import sys
 import time
 
 import numpy as np
+import pytest
 
 from lmfit import Model
 from lmfit.lineshapes import gaussian
@@ -13,6 +12,7 @@ from lmfit.lineshapes import gaussian
 sys.setrecursionlimit(2000)
 
 
+@pytest.mark.flaky(max_runs=5)
 def test_manypeaks_speed():
     model = None
     t0 = time.time()


### PR DESCRIPTION
#### Description
The (flaky) test `test_manypeaks_speed.py` fails intermittently for random reasons causing the build to fail while it's not really the case. Label this test as flaky (and install the required package) so that `pytest` will repeat it up to 5 times; it it still fails then, something is probably wrong indeed ;)
 
###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.9.6 (default, Jul  3 2021, 08:35:53)
[Clang 11.0.3 (clang-1103.0.32.62)]

lmfit: 1.0.2.post73+g1925ecd, scipy: 1.7.1, numpy: 1.21.2, asteval: 0.9.25, uncertainties: 3.1.6


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
