### PR TITLE
ENH: make ``x`` required argument in guess method

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -19,6 +19,13 @@ Version 1.0.3 Release Notes (unreleased)
 
 New features:
 
+Potentially breaking change:
+- argument ``x`` is now required for the ``guess`` method of Models (Issue #747; PR #748)
+
+To get reasonable estimates for starting values one should always supply both ``x`` and ``y`` values; in some cases it would work
+when only providing ``data`` (i.e., y-values). With the change above, ``x`` is now required in the ``guess`` method call, so scripts might
+need to be updated to explicitly supply ``x``.
+
 Bug fixes/enhancements:
 - do not overwrite user-specified figure titles in Model.plot() functions and allow setting with ``title`` keyword argument (PR #711)
 - preserve Parameters subclass in deepcopy (@jenshnielsen; PR #719)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -701,7 +701,7 @@ class Model:
             p._delay_asteval = False
         return params
 
-    def guess(self, data, **kws):
+    def guess(self, data, x, **kws):
         """Guess starting values for the parameters of a Model.
 
         This is not implemented for all models, but is available for many
@@ -710,7 +710,9 @@ class Model:
         Parameters
         ----------
         data : array_like
-            Array of data to use to guess parameter values.
+            Array of data (i.e., y-values) to use to guess parameter values.
+        x : array_like
+            Array of values for the independent variable (i.e., x-values).
         **kws : optional
             Additional keyword arguments, passed to model function.
 
@@ -729,6 +731,9 @@ class Model:
         Should be implemented for each model subclass to run
         `self.make_params()`, update starting values and return a
         Parameters object.
+
+        .. versionchanged:: 1.0.3
+           Argument ``x`` is now explicitly required to estimate starting values.
 
         """
         cname = self.__class__.__name__

--- a/tests/test_builtin_models.py
+++ b/tests/test_builtin_models.py
@@ -4,9 +4,11 @@ import inspect
 
 import numpy as np
 from numpy.testing import assert_allclose
+import pytest
 from scipy.optimize import fsolve
 
 from lmfit import lineshapes, models
+from lmfit.models import GaussianModel
 
 
 def check_height_fwhm(x, y, lineshape, model):
@@ -284,3 +286,14 @@ def test_guess_from_peak2d():
 
     for param, value in zip(['centerx', 'centery'], [centerx, centery]):
         assert np.abs((guess_increasing_x[param].value - value)/value) < 0.5
+
+
+def test_guess_requires_x():
+    """Regression test for GH #747."""
+    x = np.arange(100)
+    y = np.exp(-(x-50)**2/(2*10**2))
+
+    mod = GaussianModel()
+    msg = r"guess\(\) missing 1 required positional argument: 'x'"
+    with pytest.raises(TypeError, match=msg):
+        mod.guess(y)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -486,6 +486,21 @@ def test_priority_setting_figure_title(peakdata):
     assert fig.axes[1].get_title() == ''
 
 
+def test_guess_requires_x():
+    """Test to make sure that ``guess()`` method requires the argument ``x``.
+
+    The ``guess`` method needs ``x`` values (i.e., the independent variable)
+    to estimate initial parameters, but this was not a required argument.
+    See GH #747.
+
+    """
+    mod = lmfit.model.Model(gaussian)
+
+    msg = r"guess\(\) missing 2 required positional arguments: 'data' and 'x'"
+    with pytest.raises(TypeError, match=msg):
+        mod.guess()
+
+
 # Below is the content of the original test_model.py file. These tests still
 # need to be checked and possibly updated to the pytest-style. They work fine
 # though so leave them in for now.


### PR DESCRIPTION
#### Description
This PR makes `x` an required argument of the `guess` method that is implemented in the Model class and many (all?) of the built-in models. 

Closes: #747

###### Type of Changes
- [x] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples

###### Tested on
Python: 3.9.7 (default, Sep  6 2021, 12:38:33)
[Clang 12.0.0 (clang-1200.0.32.29)]

lmfit: 1.0.2.post91+g62c0528, scipy: 1.7.1, numpy: 1.21.2, asteval: 0.9.25, uncertainties: 3.1.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
