### PR TITLE
docs: Fix a few typos

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -102,7 +102,7 @@ require 3.6+ so that we can use formatting-strings and rely on dictionaries bein
 New features:
 
 - added thermal distribution model and lineshape (PR #620; @mpmdean)
-- introduced a new argument ``max_nfev`` to uniformly specify the maximum number of function evalutions (PR #610)
+- introduced a new argument ``max_nfev`` to uniformly specify the maximum number of function evaluations (PR #610)
   **Please note: all other arguments (e.g., ``maxfev``, ``maxiter``, ...) will no longer be passed to the underlying
   solver. A warning will be emitted stating that one should use ``max_nfev``.**
 - the attribute ``call_kws`` was added to the ``MinimizerResult`` class and contains the keyword arguments that are

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -484,7 +484,7 @@ def powerlaw(x, amplitude=1, exponent=1.0):
 def linear(x, slope=1.0, intercept=0.0):
     """Return a linear function.
 
-    linear(x, slope, interceps) = slope * x + intercept
+    linear(x, slope, intercept) = slope * x + intercept
 
     """
     return slope * x + intercept

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1078,7 +1078,7 @@ class Minimizer:
             Extra keyword arguments required for user objective function.
         float_behavior : {'posterior', 'chi2'}, optional
             Specifies meaning of objective when it returns a float. Use
-            `'posterior'` if objective function returnins a log-posterior
+            `'posterior'` if objective function returning a log-posterior
             probability (default) or `'chi2'` if it returns a chi2 value.
         is_weighted : bool, optional
             If `userfcn` returns a vector of residuals then `is_weighted`

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1078,7 +1078,7 @@ class Minimizer:
             Extra keyword arguments required for user objective function.
         float_behavior : {'posterior', 'chi2'}, optional
             Specifies meaning of objective when it returns a float. Use
-            `'posterior'` if objective function returning a log-posterior
+            `'posterior'` if objective function returns a log-posterior
             probability (default) or `'chi2'` if it returns a chi2 value.
         is_weighted : bool, optional
             If `userfcn` returns a vector of residuals then `is_weighted`

--- a/tests/test_covariance_matrix.py
+++ b/tests/test_covariance_matrix.py
@@ -131,7 +131,7 @@ def test_numdifftools_no_bounds(fit_method):
     assert_allclose(vals_ndt, vals, rtol=0.1)
     assert_allclose(result_ndt.chisqr, result.chisqr, rtol=1e-5)
 
-    # assert that parameter uncertaintes from leastsq and calculated from
+    # assert that parameter uncertainties from leastsq and calculated from
     # the covariance matrix using numdifftools are very similar
     stderr = [result.params[p].stderr for p in result.params.valuesdict()]
     stderr_ndt = [result_ndt.params[p].stderr for p in result_ndt.params.valuesdict()]
@@ -179,7 +179,7 @@ def test_numdifftools_with_bounds(fit_method):
     assert_allclose(vals_ndt, vals, rtol=0.1)
     assert_allclose(result_ndt.chisqr, result.chisqr, rtol=1e-5)
 
-    # assert that parameter uncertaintes from leastsq and calculated from
+    # assert that parameter uncertainties from leastsq and calculated from
     # the covariance matrix using numdifftools are very similar
     stderr = [result.params[p].stderr for p in result.params.valuesdict()]
     stderr_ndt = [result_ndt.params[p].stderr for p in result_ndt.params.valuesdict()]

--- a/tests/test_least_squares.py
+++ b/tests/test_least_squares.py
@@ -87,7 +87,7 @@ def test_least_squares_cov_x(peakdata, bounds):
     assert_allclose(vals, vals_lsq, rtol=1e-5)
     assert_allclose(result.chisqr, result_lsq.chisqr)
 
-    # assert that parameter uncertaintes obtained from the leastsq method and
+    # assert that parameter uncertainties obtained from the leastsq method and
     # those from the covariance matrix estimated from the Jacbian matrix in
     # least_squares are similar
     stderr = [result.params[p].stderr for p in result.params.valuesdict()]


### PR DESCRIPTION
There are small typos in:
- doc/whatsnew.rst
- lmfit/lineshapes.py
- lmfit/minimizer.py
- tests/test_covariance_matrix.py
- tests/test_least_squares.py

Fixes:
- Should read `uncertainties` rather than `uncertaintes`.
- Should read `returns` rather than `returnins`.
- Should read `intercept` rather than `interceps`.
- Should read `evaluations` rather than `evalutions`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md