### PR TITLE
DOC: fix use of noise/uncertainty in intro

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -34,6 +34,7 @@ Bug fixes/enhancements:
 - correct error message in PolynomialModel (@kremeyer; PR #737)
 - improved handling of altered JSON data (Issue #739; PR #740, reported by Matthew Giammar)
 - map ``max_nfev`` to ``maxiter`` when using ``differential_evolution`` (PR #749, reported by Olivier B.)
+- correct use of noise versus experimental uncertainty in the documentation (PR #751, reported by Andrés Zelcer)
 
 Various:
 


### PR DESCRIPTION
#### Description
Correct use of noise versus experimental uncertainty in the documentation (`intro.rst`) reported on the [mailinglist](https://groups.google.com/g/lmfit-py/c/8PyyP93sUvU/m/GYvi8XbBAwAJ) by Andrés Zelcer.

- experimental uncertainties cannot be negative
- add noise to the data and provide synthetic experimental uncertainties


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
Python: 3.9.7 (default, Sep  6 2021, 12:38:33)
[Clang 12.0.0 (clang-1200.0.32.29)]

lmfit: 1.0.2.post103+g429e247, scipy: 1.7.1, numpy: 1.21.2, asteval: 0.9.25, uncertainties: 3.1.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?