### PR TITLE
updates to examples gallery

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,13 +29,13 @@ you intend to contribute to the lmfit repository:
 
 If you need any additional help, please send a message to the
 [mailing list](https://groups.google.com/group/lmfit-py) or use the
-[github discussion page](https://github.com/lmfit/lmfit-py/discussions).
+[GitHub discussions page](https://github.com/lmfit/lmfit-py/discussions).
 
 ## Using the Mailing List versus GitHub Issues
 
 If you have ***questions, comments, or suggestions*** for lmfit, please use
 the [mailing list](https://groups.google.com/group/lmfit-py) or
-[github discussion page](https://github.com/lmfit/lmfit-py/discussions).
+[GitHub discussions page](https://github.com/lmfit/lmfit-py/discussions).
 These provide online conversations that are archived and can be searched
 easily.
 
@@ -77,12 +77,10 @@ version and installed dependencies. You can paste the code below in your
 Python shell to get this information:
 
 ```python
-import sys, lmfit, numpy, scipy, asteval, uncertainties, six
-print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}, six: {}'\
-	  .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
-	  asteval.__version__, uncertainties.__version__, six.__version__))
+import sys, lmfit, numpy, scipy, asteval, uncertainties
+print(f"Python: {sys.version}\n\nlmfit: {lmfit.__version__}, scipy: {scipy.__version__}, numpy: {numpy.__version__},"
+	  f"asteval: {asteval.__version__}, uncertainties: {uncertainties.__version__}")
 ```
-
 
 ## Using IPython Notebooks to Show Examples
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,10 +12,10 @@ Getting a "bad fit" definitely does NOT qualify as an Issue! Issues here
 are concerned with errors or problems in the lmfit code.
 
 Use the [mailing list](https://groups.google.com/group/lmfit-py) or
-[github discussion page](https://github.com/lmfit/lmfit-py/discussions) for
+[GitHub discussions page](https://github.com/lmfit/lmfit-py/discussions) for
 questions about lmfit or things you think might be problems. We don't feel
 obligated to spend our free time helping people who do not respect our
-chosen work processes, so If you ignore this advice and post a question as
+chosen work processes, so if you ignore this advice and post a question as
 a GitHub Issue anyway, it is quite likely that your Issue will be closed
 and not answered. If you have any doubt, start with a discussion either on
 the mailing list or discussions page.
@@ -45,8 +45,8 @@ Traceback (most recent call last):
 ###### Version information
 <!-- Generate version information with this command in the Python shell and copy the output here:
 import sys, lmfit, numpy, scipy, asteval, uncertainties
-print(f"Python: {sys.version}\n\nlmfit: {lmfit.__version__}, scipy: {scipy.__version__}, numpy: {numpy.__version__}"
-	  f", asteval: {asteval.__version__}, uncertainties: {uncertainties.__version__}")
+print(f"Python: {sys.version}\n\nlmfit: {lmfit.__version__}, scipy: {scipy.__version__}, numpy: {numpy.__version__},"
+	  f"asteval: {asteval.__version__}, uncertainties: {uncertainties.__version__}")
 -->
 
 ###### Link(s)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.27.0
+    rev: v2.29.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]

--- a/README.rst
+++ b/README.rst
@@ -72,9 +72,9 @@ positional and keyword arguments as desired::
         ...
         return residual_array
 
-For each call of this function, the values for the params may have changed,
+For each call of this function, the values for the ``params`` may have changed,
 subject to the bounds and constraint settings for each Parameter. The function
-should return the residual (i.e., data-model) array to be minimized.
+should return the residual (i.e., ``data-model``) array to be minimized.
 
 The advantage here is that the function to be minimized does not have to be
 changed if different bounds or constraints are placed on the fitting Parameters.
@@ -94,7 +94,7 @@ the fit (e.g., fitting statistics and optimized parameters). The dictionary
 ``result.params`` contains the best-fit values, estimated standard deviations,
 and correlations with other variables in the fit.
 
-By default, the underlying fit algorithm is the Levenberg-Marquart algorithm
+By default, the underlying fit algorithm is the Levenberg-Marquardt algorithm
 with numerically-calculated derivatives from MINPACK's lmdif function, as used
 by ``scipy.optimize.leastsq``. Most other solvers that are present in ``scipy``
 (e.g., Nelder-Mead, differential_evolution, basinhopping, etctera) are also

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -1,6 +1,6 @@
-Many people have contributed to lmfit.  The attribution of credit in a
+Many people have contributed to lmfit. The attribution of credit in a
 project such as this is difficult to get perfect, and there are no doubt
-important contributions that are missing or under-represented here.  Please
+important contributions that are missing or under-represented here. Please
 consider this file as part of the code and documentation that may have bugs
 that need fixing.
 
@@ -34,7 +34,7 @@ of size of the contribution to the existing code) are from:
 
   The method used for placing bounds on parameters was derived from the
   clear description in the MINUIT documentation, and adapted from
-  J. J. Helmus's python implementation in leastsqbounds.py.
+  J. J. Helmus's Python implementation in leastsqbounds.py.
 
   E. O. Le Bigot wrote the uncertainties package, a version of which was
   used by lmfit for many years, and is now an external dependency.
@@ -58,5 +58,5 @@ Michael Hudson-Doyle, Ruben Verweij, @jedzill4, @spalato, Jens Hedegaard Nielsen
 Martin Majli, Kristian Meyer, and many others.
 
 The lmfit code obviously depends on, and owes a very large debt to the code
-in scipy.optimize.  Several discussions on the SciPy-user and lmfit mailing
+in scipy.optimize. Several discussions on the SciPy-user and lmfit mailing
 lists have also led to improvements in this code.

--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -380,7 +380,7 @@ are pretty good. A plot of the fit:
     import matplotlib.pyplot as plt
     plt.plot(x, y, '-')
     plt.plot(x, out.best_fit, '-', label='Gaussian Model')
-    plt.legend(loc='best')
+    plt.legend()
     plt.show()
 
 shows a decent match to the data -- the fit worked with no explicit setting
@@ -412,7 +412,7 @@ and also by visual inspection of the fit to the data (figure below).
 
      plt.plot(x, y, '-')
      plt.plot(x, out.best_fit, '-', label='Lorentzian Model')
-     plt.legend(loc='best')
+     plt.legend()
      plt.show()
 
 The tails are now too big, and the value for :math:`\chi^2` almost doubled.
@@ -442,13 +442,13 @@ in the figure below (left).
     fig, axes = plt.subplots(1, 2, figsize=(12.8, 4.8))
     axes[0].plot(x, y, '-')
     axes[0].plot(x, out.best_fit, '-', label='Voigt Model\ngamma constrained')
-    axes[0].legend(loc='best')
+    axes[0].legend()
     # free gamma parameter
     pars['gamma'].set(value=0.7, vary=True, expr='')
     out_gamma = mod.fit(y, pars, x=x)
     axes[1].plot(x, y, '-')
     axes[1].plot(x, out_gamma.best_fit, '-', label='Voigt Model\ngamma unconstrained')
-    axes[1].legend(loc='best')
+    axes[1].legend()
     plt.show()
 
 Fit to peak with Voigt model (left) and Voigt model with ``gamma``
@@ -528,7 +528,7 @@ with a plot of
     plt.plot(x, y)
     plt.plot(x, out.init_fit, '--', label='initial fit')
     plt.plot(x, out.best_fit, '-', label='best fit')
-    plt.legend(loc='best')
+    plt.legend()
     plt.show()
 
 
@@ -579,14 +579,14 @@ components displayed on the right:
     axes[0].plot(x, y)
     axes[0].plot(x, init, '--', label='initial fit')
     axes[0].plot(x, out.best_fit, '-', label='best fit')
-    axes[0].legend(loc='best')
+    axes[0].legend()
 
     comps = out.eval_components(x=x)
     axes[1].plot(x, y)
     axes[1].plot(x, comps['g1_'], '--', label='Gaussian component 1')
     axes[1].plot(x, comps['g2_'], '--', label='Gaussian component 2')
     axes[1].plot(x, comps['exp_'], '--', label='Exponential component')
-    axes[1].legend(loc='best')
+    axes[1].legend()
 
     plt.show()
 
@@ -625,7 +625,7 @@ we can get a better initial estimate (see below).
     plt.plot(x, y)
     plt.plot(x, out.init_fit, '--', label='initial fit')
     plt.plot(x, out.best_fit, '-', label='best fit')
-    plt.legend(loc='best')
+    plt.legend()
 
     plt.show()
 

--- a/doc/builtin_models.rst
+++ b/doc/builtin_models.rst
@@ -331,7 +331,7 @@ and ``wid``, and build a model that can be used to fit data.
 Example 1: Fit Peak data to Gaussian, Lorentzian, and Voigt profiles
 --------------------------------------------------------------------
 
-Here, we will fit data to three similar line shapes, in order to decide which
+Here, we will fit data to three similar lineshapes, in order to decide which
 might be the better model. We will start with a Gaussian profile, as in
 the previous chapter, but use the built-in :class:`GaussianModel` instead
 of writing one ourselves. This is a slightly different version from the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -169,6 +169,7 @@ sphinx_gallery_conf = {
     'filename_pattern': r'(\\|/)documentation|(\\|/)example_',
     'ignore_pattern': r'(\\|/)doc_',
     'ignore_repr_types': r'matplotlib',
+    'image_srcset': ["3x"],
 }
 
 # remove certain RuntimeWarnings from examples

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -449,7 +449,7 @@ and standard errors could be done as
     print('-------------------------------')
     print('Parameter    Value       Stderr')
     for name, param in out.params.items():
-        print('{:7s} {:11.5f} {:11.5f}'.format(name, param.value, param.stderr))
+        print(f'{name:7s} {param.value:11.5f} {param.stderr:11.5f}')
 
 
 ..  _fit-itercb-label:

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -575,8 +575,6 @@ parameters, which is a similar goal to the one here.
     x = np.linspace(1, 10, 250)
     np.random.seed(0)
     y = 3.0 * np.exp(-x / 2) - 5.0 * np.exp(-(x - 0.1) / 10.) + 0.1 * np.random.randn(x.size)
-    plt.plot(x, y)
-    plt.show()
 
 Create a Parameter set for the initial guesses:
 
@@ -603,9 +601,9 @@ and plotting the fit using the Maximum Likelihood solution gives the graph below
 
 .. jupyter-execute::
 
-    plt.plot(x, y)
+    plt.plot(x, y, 'o')
     plt.plot(x, residual(mi.params) + y, label='best fit')
-    plt.legend(loc='best')
+    plt.legend()
     plt.show()
 
 Note that the fit here (for which the ``numdifftools`` package is installed)
@@ -659,6 +657,7 @@ worked as intended (as a rule of thumb the value should be between 0.2 and
     plt.plot(res.acceptance_fraction, 'o')
     plt.xlabel('walker')
     plt.ylabel('acceptance fraction')
+    plt.show()
 
 With the results from ``emcee``, we can visualize the posterior distributions
 for the parameters using the ``corner`` package:

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -22,6 +22,7 @@ Downloading and Installation
 .. _sphinxcontrib-svg2pdfconverter: https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter
 .. _cairosvg: https://cairosvg.org/
 .. _Pillow: https://python-pillow.org/
+.. _sphinx-gallery: https://sphinx-gallery.github.io/stable/index.html
 .. _flaky: https://github.com/box/flaky
 
 
@@ -46,7 +47,7 @@ functionality requires the `emcee`_ (version 3+), `corner`_, `pandas`_, `Jupyter
 automatically, but we highly recommend each of these packages.
 
 For building the documentation and generating the examples gallery,
-`matplotlib`_, `emcee`_ (version 3+), `corner`_, `Sphinx`_,
+`matplotlib`_, `emcee`_ (version 3+), `corner`_, `Sphinx`_, `sphinx-gallery`_,
 `jupyter_sphinx`_, `Pillow`_, `sphinxcontrib-svg2pdfconverter`_, and `cairosvg`_
 are required (the latter two only when generating the PDF document).
 

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -169,7 +169,7 @@ created:
     params['decay'].min = 0.10
 
 Importantly, our objective function remains unchanged. This means the
-objective function can simply express the parameterized phenomenon to be
+objective function can simply express the parametrized phenomenon to be
 modeled, and is separate from the choice of parameters to be varied in the
 fit.
 

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -189,7 +189,7 @@ plot:
     plt.plot(x, y, 'o')
     plt.plot(x, result.init_fit, '--', label='initial fit')
     plt.plot(x, result.best_fit, '-', label='best fit')
-    plt.legend(loc='best')
+    plt.legend()
     plt.show()
 
 which shows the data in blue dots, the best fit as a solid green line, and
@@ -839,7 +839,7 @@ figure below.
     plt.plot(x, result.best_fit, '-', label='best fit')
     plt.fill_between(x, result.best_fit-dely, result.best_fit+dely, color="#ABABAB",
                      label='3-$\sigma$ uncertainty band')
-    plt.legend(loc='best')
+    plt.legend()
     plt.show()
 
 
@@ -952,13 +952,13 @@ and shows the plot on the left.
     axes[0].plot(x, y, 'o')
     axes[0].plot(x, result.init_fit, '--', label='initial fit')
     axes[0].plot(x, result.best_fit, '-', label='best fit')
-    axes[0].legend(loc='best')
+    axes[0].legend()
 
     comps = result.eval_components()
     axes[1].plot(x, y, 'o')
     axes[1].plot(x, comps['gaussian'], '--', label='Gaussian component')
     axes[1].plot(x, comps['line'], '--', label='Line component')
-    axes[1].legend(loc='best')
+    axes[1].legend()
     plt.show()
 
 On the left, data is shown in blue dots, the total fit is shown in solid
@@ -1069,11 +1069,11 @@ and shows the plots:
     axes[0].plot(x, y, 'o')
     axes[0].plot(x, result.init_fit, '--', label='initial fit')
     axes[0].plot(x, result.best_fit, '-', label='best fit')
-    axes[0].legend(loc='best')
+    axes[0].legend()
     axes[1].plot(x, y, 'o')
     axes[1].plot(x, 10*comps['jump'], '--', label='Jump component')
     axes[1].plot(x, 10*comps['gaussian'], '-', label='Gaussian component')
-    axes[1].legend(loc='best')
+    axes[1].legend()
     plt.show()
 
 Using composite models with built-in or custom operators allows you to

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -28,7 +28,7 @@ different from :scipydoc:`optimize.curve_fit`, for example in that it uses
 important advantages.
 
 In addition to allowing you to turn any model function into a curve-fitting
-method, lmfit also provides canonical definitions for many known line shapes
+method, lmfit also provides canonical definitions for many known lineshapes
 such as Gaussian or Lorentzian peaks and Exponential decays that are widely
 used in many scientific domains. These are available in the :mod:`models`
 module that will be discussed in more detail in the next chapter
@@ -91,8 +91,8 @@ signature itself:
     from lmfit import Model
 
     gmodel = Model(gaussian)
-    print('parameter names: {}'.format(gmodel.param_names))
-    print('independent variables: {}'.format(gmodel.independent_vars))
+    print(f'parameter names: {gmodel.param_names}')
+    print(f'independent variables: {gmodel.independent_vars}')
 
 As you can see, the Model ``gmodel`` determined the names of the parameters
 and the independent variables. By default, the first argument of the
@@ -329,7 +329,7 @@ function is fairly easy. Let's try another one:
 
 
     decay_model = Model(decay)
-    print('independent variables: {}'.format(decay_model.independent_vars))
+    print(f'independent variables: {decay_model.independent_vars}')
 
     params = decay_model.make_params()
     print('\nParameters:')
@@ -346,7 +346,7 @@ you can say so:
 .. jupyter-execute::
 
     decay_model = Model(decay, independent_vars=['tau'])
-    print('independent variables: {}'.format(decay_model.independent_vars))
+    print(f'independent variables: {decay_model.independent_vars}')
 
     params = decay_model.make_params()
     print('\nParameters:')

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -37,6 +37,7 @@ Bug fixes/enhancements:
 - correct use of noise versus experimental uncertainty in the documentation (PR #751, reported by Andrés Zelcer)
 - specify return type of ``eval`` method more precisely and allow for plotting of (Complex)ConstantModel by coercing their
   ``float``, ``int``, or ``complex`` return value to a ``numpy.ndarray`` (Issue #684 and PR #754)
+- fix ``dho`` (Damped Harmonic Oscillator) lineshape (PR #755; @rayosborn)
 
 Various:
 

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -51,6 +51,7 @@ Various:
 - transition to using ``f-strings`` (PR #730)
 - mark ``test_manypeaks_speed.py`` as flaky to avoid intermittent test failures (repeat up to 5 times; PR #745)
 - update scipy dependency to >= 1.14.0 (PR #751)
+- improvement to output of examples in sphinx-gallery and use higher resolution figures (PR #753)
 
 
 .. _whatsnew_102_label:

--- a/examples/doc_builtinmodels_nistgauss.py
+++ b/examples/doc_builtinmodels_nistgauss.py
@@ -36,14 +36,14 @@ fig, axes = plt.subplots(1, 2, figsize=(12.8, 4.8))
 axes[0].plot(x, y)
 axes[0].plot(x, init, '--', label='initial fit')
 axes[0].plot(x, out.best_fit, '-', label='best fit')
-axes[0].legend(loc='best')
+axes[0].legend()
 
 comps = out.eval_components(x=x)
 axes[1].plot(x, y)
 axes[1].plot(x, comps['g1_'], '--', label='Gaussian component 1')
 axes[1].plot(x, comps['g2_'], '--', label='Gaussian component 2')
 axes[1].plot(x, comps['exp_'], '--', label='Exponential component')
-axes[1].legend(loc='best')
+axes[1].legend()
 
 plt.show()
 # <end examples/doc_builtinmodels_nistgauss.py>

--- a/examples/doc_builtinmodels_nistgauss2.py
+++ b/examples/doc_builtinmodels_nistgauss2.py
@@ -38,6 +38,6 @@ print(out.fit_report(min_correl=0.5))
 plt.plot(x, y)
 plt.plot(x, out.init_fit, '--', label='initial fit')
 plt.plot(x, out.best_fit, '-', label='best fit')
-plt.legend(loc='best')
+plt.legend()
 plt.show()
 # <end examples/doc_nistgauss2.py>

--- a/examples/doc_builtinmodels_peakmodels.py
+++ b/examples/doc_builtinmodels_peakmodels.py
@@ -18,7 +18,7 @@ print(out.fit_report(min_correl=0.25))
 
 plt.plot(x, y)
 plt.plot(x, out.best_fit, '-', label='Gaussian Model')
-plt.legend(loc='best')
+plt.legend()
 plt.show()
 
 
@@ -32,7 +32,7 @@ print(out.fit_report(min_correl=0.25))
 plt.figure()
 plt.plot(x, y, '-')
 plt.plot(x, out.best_fit, '-', label='Lorentzian Model')
-plt.legend(loc='best')
+plt.legend()
 plt.show()
 
 
@@ -47,14 +47,14 @@ fig, axes = plt.subplots(1, 2, figsize=(12.8, 4.8))
 
 axes[0].plot(x, y, '-')
 axes[0].plot(x, out.best_fit, '-', label='Voigt Model\ngamma constrained')
-axes[0].legend(loc='best')
+axes[0].legend()
 
 # free gamma parameter
 pars['gamma'].set(value=0.7, vary=True, expr='')
 out_gamma = mod.fit(y, pars, x=x)
 axes[1].plot(x, y, '-')
 axes[1].plot(x, out_gamma.best_fit, '-', label='Voigt Model\ngamma unconstrained')
-axes[1].legend(loc='best')
+axes[1].legend()
 
 plt.show()
 # <end examples/doc_builtinmodels_peakmodels.py>

--- a/examples/doc_builtinmodels_stepmodel.py
+++ b/examples/doc_builtinmodels_stepmodel.py
@@ -25,6 +25,6 @@ print(out.fit_report())
 plt.plot(x, y)
 plt.plot(x, out.init_fit, '--', label='initial fit')
 plt.plot(x, out.best_fit, '-', label='best fit')
-plt.legend(loc='best')
+plt.legend()
 plt.show()
 # <end examples/doc_builtinmodels_stepmodel.py>

--- a/examples/doc_confidence_advanced.py
+++ b/examples/doc_confidence_advanced.py
@@ -35,6 +35,7 @@ lmfit.printfuncs.report_ci(ci)
 plt.figure()
 plt.plot(x, y)
 plt.plot(x, residual(out2.params) + y, '-')
+plt.show()
 
 # plot confidence intervals (a1 vs t2 and a2 vs t2)
 fig, axes = plt.subplots(1, 2, figsize=(12.8, 4.8))
@@ -49,6 +50,7 @@ ctp = axes[1].contourf(cx, cy, grid, np.linspace(0, 1, 11))
 fig.colorbar(ctp, ax=axes[1])
 axes[1].set_xlabel('a2')
 axes[1].set_ylabel('t2')
+plt.show()
 
 # plot dependence between two parameters
 fig, axes = plt.subplots(1, 2, figsize=(12.8, 4.8))
@@ -62,6 +64,5 @@ axes[0].set_ylabel('t2')
 axes[1].scatter(cx2, cy2, c=prob2, s=30)
 axes[1].set_xlabel('t2')
 axes[1].set_ylabel('a1')
-
 plt.show()
 # <end examples/doc_confidence_advanced.py>

--- a/examples/doc_fitting_emcee.py
+++ b/examples/doc_fitting_emcee.py
@@ -19,9 +19,6 @@ x = np.linspace(1, 10, 250)
 np.random.seed(0)
 y = (3.0*np.exp(-x/2) - 5.0*np.exp(-(x-0.1) / 10.) +
      0.1*np.random.randn(x.size))
-if HASPYLAB:
-    plt.plot(x, y)
-    plt.show()
 
 p = lmfit.Parameters()
 p.add_many(('a1', 4), ('a2', 4), ('t1', 3), ('t2', 3., True))
@@ -36,9 +33,9 @@ mi = lmfit.minimize(residual, p, method='nelder', nan_policy='omit')
 lmfit.printfuncs.report_fit(mi.params, min_correl=0.5)
 if HASPYLAB:
     plt.figure()
-    plt.plot(x, y)
+    plt.plot(x, y, 'o')
     plt.plot(x, residual(mi.params) + y, label='best fit')
-    plt.legend(loc='best')
+    plt.legend()
     plt.show()
 
 # Place bounds on the ln(sigma) parameter that emcee will automatically add
@@ -88,7 +85,7 @@ for name, param in p.items():
 
 if HASPYLAB:
     plt.figure()
-    plt.plot(x, y)
+    plt.plot(x, y, 'o')
     plt.plot(x, residual(mi.params) + y, label='Nelder-Mead')
     plt.plot(x, residual(res.params) + y, '--', label='emcee')
     plt.legend()

--- a/examples/doc_model_composite.py
+++ b/examples/doc_model_composite.py
@@ -52,12 +52,12 @@ fig, axes = plt.subplots(1, 2, figsize=(12.8, 4.8))
 axes[0].plot(x, y, 'bo')
 axes[0].plot(x, result.init_fit, 'k--', label='initial fit')
 axes[0].plot(x, result.best_fit, 'r-', label='best fit')
-axes[0].legend(loc='best')
+axes[0].legend()
 
 axes[1].plot(x, y, 'bo')
 axes[1].plot(x, 10*comps['jump'], 'k--', label='Jump component')
 axes[1].plot(x, 10*comps['gaussian'], 'r-', label='Gaussian component')
-axes[1].legend(loc='best')
+axes[1].legend()
 
 plt.show()
 # <end examples/doc_model_composite.py>

--- a/examples/doc_model_gaussian.py
+++ b/examples/doc_model_gaussian.py
@@ -22,6 +22,6 @@ print(result.fit_report())
 plt.plot(x, y, 'o')
 plt.plot(x, result.init_fit, '--', label='initial fit')
 plt.plot(x, result.best_fit, '-', label='best fit')
-plt.legend(loc='best')
+plt.legend()
 plt.show()
 # <end examples/doc_model_gaussian.py>

--- a/examples/doc_model_two_components.py
+++ b/examples/doc_model_two_components.py
@@ -29,6 +29,6 @@ print(result.fit_report())
 plt.plot(x, y, 'o')
 plt.plot(x, result.init_fit, '--', label='initial fit')
 plt.plot(x, result.best_fit, '-', label='best fit')
-plt.legend(loc='best')
+plt.legend()
 plt.show()
 # <end examples/doc_model_two_components.py>

--- a/examples/doc_model_uncertainty.py
+++ b/examples/doc_model_uncertainty.py
@@ -26,6 +26,6 @@ plt.plot(x, result.init_fit, '--', label='initial fit')
 plt.plot(x, result.best_fit, '-', label='best fit')
 plt.fill_between(x, result.best_fit-dely, result.best_fit+dely,
                  color="#ABABAB", label=r'3-$\sigma$ uncertainty band')
-plt.legend(loc='best')
+plt.legend()
 plt.show()
 # <end examples/doc_model_uncertainty.py>

--- a/examples/doc_model_with_iter_callback.py
+++ b/examples/doc_model_with_iter_callback.py
@@ -32,6 +32,6 @@ print(f'Nfev = {out.nfev}')
 print(out.fit_report())
 
 plt.plot(x, out.best_fit, '-', label='best fit')
-plt.legend(loc='best')
+plt.legend()
 plt.show()
 # <end examples/doc_with_itercb.py>

--- a/examples/doc_model_with_nan_policy.py
+++ b/examples/doc_model_with_nan_policy.py
@@ -28,6 +28,6 @@ y_ = y[np.where(np.isfinite(y))]
 plt.plot(x_, y_, 'o')
 plt.plot(x_, result.init_fit, '--', label='initial fit')
 plt.plot(x_, result.best_fit, '-', label='best fit')
-plt.legend(loc='best')
+plt.legend()
 plt.show()
 # <end examples/doc_model_with_nan_policy.py>

--- a/examples/example_brute.py
+++ b/examples/example_brute.py
@@ -26,7 +26,7 @@ from lmfit import Minimizer, Parameters, fit_report
 # "We illustrate the use of brute to seek the global minimum of a function of
 # two variables that is given as the sum of a positive-definite quadratic and
 # two deep “Gaussian-shaped” craters. Specifically, define the objective
-# function f as the sum of three other functions, ``f = f1 + f2 + f3``. We
+# function ``f`` as the sum of three other functions, ``f = f1 + f2 + f3``. We
 # suppose each of these has a signature ``(z, *params), where z = (x, y)``,
 # and params and the functions are as defined below."
 #
@@ -106,17 +106,17 @@ print(grid_x)
 print(result.brute_x0)
 
 ###############################################################################
-# ``result.brute_fval`` -- Function value at the point x0.
+# ``result.brute_fval`` -- Function value at the point ``x0``.
 print(result.brute_fval)
 
 ###############################################################################
 # ``result.brute_grid`` -- Representation of the evaluation grid. It has the
-# same length as x0.
+# same length as ``x0``.
 print(result.brute_grid)
 
 ###############################################################################
 # ``result.brute_Jout`` -- Function values at each point of the evaluation
-# grid, i.e., Jout = func(\*grid).
+# grid, i.e., ``Jout = func(*grid)``.
 print(result.brute_Jout)
 
 ###############################################################################
@@ -128,13 +128,14 @@ print(result.brute_Jout)
 #
 # In this example, we will explain some of the options of the algorithm.
 #
-# We start off by generating some synthetic data with noise for a decaying
-# sine wave, define an objective function and create a Parameter set.
+# We start off by generating some synthetic data with noise for a decaying sine
+# wave, define an objective function, and create/initialize a Parameter set.
 x = np.linspace(0, 15, 301)
 np.random.seed(7)
 noise = np.random.normal(size=x.size, scale=0.2)
 data = (5. * np.sin(2*x - 0.1) * np.exp(-x*x*0.025) + noise)
-plt.plot(x, data)
+plt.plot(x, data, 'o')
+plt.show()
 
 
 def fcn2min(params, x, data):
@@ -169,7 +170,7 @@ params['omega'].set(brute_step=0.25)
 params.pretty_print()
 
 ###############################################################################
-# First, we initialize a Minimizer and perform the grid search:
+# First, we initialize a ``Minimizer`` and perform the grid search:
 fitter = Minimizer(fcn2min, params, fcn_args=(x, data))
 result_brute = fitter.minimize(method='brute', Ns=25, keep=25)
 
@@ -192,24 +193,24 @@ print(f"parameter = {par_name}\nnumber of steps = {len(grid_shift)}\ngrid = {gri
 # If finite bounds are not set for a certain parameter then the user **must**
 # specify ``brute_step`` - three more scenarios are considered here:
 #
-# **(2)** lower bound (min) and brute_step are specified:
-# range = (min, min + Ns * brute_step, brute_step)
+# **(2)** lower bound ``(min``) and ``brute_step`` are specified:
+# ``range = (min, min + Ns * brute_step, brute_step)``
 par_name = 'amp'
 indx_shift = result_brute.var_names.index(par_name)
 grid_shift = np.unique(result_brute.brute_grid[indx_shift].ravel())
 print(f"parameter = {par_name}\nnumber of steps = {len(grid_shift)}\ngrid = {grid_shift}")
 
 ###############################################################################
-# **(3)** upper bound (max) and brute_step are specified:
-# range = (max - Ns * brute_step, max, brute_step)
+# **(3)** upper bound (``max``) and ``brute_step`` are specified:
+# ``range = (max - Ns * brute_step, max, brute_step)``
 par_name = 'omega'
 indx_shift = result_brute.var_names.index(par_name)
 grid_shift = np.unique(result_brute.brute_grid[indx_shift].ravel())
 print(f"parameter = {par_name}\nnumber of steps = {len(grid_shift)}\ngrid = {grid_shift}")
 
 ###############################################################################
-# **(4)** numerical value (value) and brute_step are specified:
-# range = (value - (Ns//2) * brute_step, value + (Ns//2) * brute_step, brute_step)
+# **(4)** numerical value (``value``) and ``brute_step`` are specified:
+# ``range = (value - (Ns//2) * brute_step, value + (Ns//2) * brute_step, brute_step)``
 par_name = 'decay'
 indx_shift = result_brute.var_names.index(par_name)
 grid_shift = np.unique(result_brute.brute_grid[indx_shift].ravel())
@@ -220,8 +221,11 @@ print(f"parameter = {par_name}\nnumber of steps = {len(grid_shift)}\ngrid = {gri
 # fitting statistics. For example, the optimal solution from the grid search
 # is given below together with a plot:
 print(fit_report(result_brute))
-plt.plot(x, data)
+
+###############################################################################
+plt.plot(x, data, 'o')
 plt.plot(x, data + fcn2min(result_brute.params, x, data), '--')
+plt.show()
 
 ###############################################################################
 # We can see that this fit is already very good, which is what we should expect
@@ -231,12 +235,12 @@ plt.plot(x, data + fcn2min(result_brute.params, x, data), '--')
 # In a more realistic, complicated example the ``brute`` method will be used
 # to get reasonable values for the parameters and perform another minimization
 # (e.g., using ``leastsq``) using those as starting values. That is where the
-# `keep`` parameter comes into play: it determines the "number of best
+# ``keep`` parameter comes into play: it determines the "number of best
 # candidates from the brute force method that are stored in the ``candidates``
 # attribute". In the example above we store the best-ranking 25 solutions (the
 # default value is ``50`` and storing all the grid points can be accomplished
 # by choosing ``all``). The ``candidates`` attribute contains the parameters
-# and ``chisqr`` from the brute force method as a namedtuple,
+# and ``chisqr`` from the brute force method as a ``namedtuple``,
 # ``(‘Candidate’, [‘params’, ‘score’])``, sorted on the (lowest) ``chisqr``
 # value. To access the values for a particular candidate one can use
 # ``result.candidate[#].params`` or ``result.candidate[#].score``, where a
@@ -276,8 +280,8 @@ print(fit_report(best_result))
 # As expected the parameters have not changed significantly as they were
 # already very close to the "real" values, which can also be appreciated from
 # the plots below.
-plt.plot(x, data)
-plt.plot(x, data + fcn2min(result_brute.params, x, data), '--',
+plt.plot(x, data, 'o')
+plt.plot(x, data + fcn2min(result_brute.params, x, data), '-',
          label='brute')
 plt.plot(x, data + fcn2min(best_result.params, x, data), '--',
          label='brute followed by leastsq')

--- a/examples/example_complex_resonator_model.py
+++ b/examples/example_complex_resonator_model.py
@@ -36,16 +36,15 @@ def linear_resonator(f, f_0, Q, Q_e_real, Q_e_imag):
 
 
 ###############################################################################
-# The standard practice of defining an ``lmfit`` model is as follows:
-
+# The standard practice of defining a ``lmfit`` model is as follows:
 class ResonatorModel(lmfit.model.Model):
     __doc__ = "resonator model" + lmfit.models.COMMON_INIT_DOC
 
     def __init__(self, *args, **kwargs):
-        # pass in the defining equation so the user doesn't have to later.
+        # pass in the defining equation so the user doesn't have to later
         super().__init__(linear_resonator, *args, **kwargs)
 
-        self.set_param_hint('Q', min=0)  # Enforce Q is positive
+        self.set_param_hint('Q', min=0)  # enforce Q is positive
 
     def guess(self, data, f=None, **kwargs):
         verbose = kwargs.pop('verbose', None)
@@ -55,7 +54,7 @@ class ResonatorModel(lmfit.model.Model):
         fmin = f.min()
         fmax = f.max()
         f_0_guess = f[argmin_s21]  # guess that the resonance is the lowest point
-        Q_min = 0.1 * (f_0_guess/(fmax-fmin))  # assume the user isn't trying to fit just a small part of a resonance curve.
+        Q_min = 0.1 * (f_0_guess/(fmax-fmin))  # assume the user isn't trying to fit just a small part of a resonance curve
         delta_f = np.diff(f)  # assume f is sorted
         min_delta_f = delta_f[delta_f > 0].min()
         Q_max = f_0_guess/min_delta_f  # assume data actually samples the resonance reasonably
@@ -72,7 +71,6 @@ class ResonatorModel(lmfit.model.Model):
 
 ###############################################################################
 # Now let's use the model to generate some fake data:
-
 resonator = ResonatorModel()
 true_params = resonator.make_params(f_0=100, Q=10000, Q_e_real=9000, Q_e_imag=-9000)
 
@@ -82,20 +80,17 @@ noise_scale = 0.02
 np.random.seed(123)
 measured_s21 = true_s21 + noise_scale*(np.random.randn(100) + 1j*np.random.randn(100))
 
-plt.figure()
 plt.plot(f, 20*np.log10(np.abs(measured_s21)))
 plt.ylabel('|S21| (dB)')
 plt.xlabel('MHz')
 plt.title('simulated measurement')
 
 ###############################################################################
-# Try out the guess method we added:
-
+# Try out the ``guess`` method we added:
 guess = resonator.guess(measured_s21, f=f, verbose=True)
 
 ##############################################################################
-# And now fit the data using the guess as a starting point:
-
+# And now fit the data using the ``guess``-ed values as a starting point:
 result = resonator.fit(measured_s21, params=guess, f=f, verbose=True)
 
 print(result.fit_report() + '\n')
@@ -116,8 +111,8 @@ guess_s21 = resonator.eval(params=guess, f=f)
 plt.figure()
 plot_ri(measured_s21, '.')
 plot_ri(fit_s21, '.-', label='best fit')
-plot_ri(guess_s21, '--', label='inital fit')
-plt.legend(loc='best')
+plot_ri(guess_s21, '--', label='initial fit')
+plt.legend()
 plt.xlabel('Re(S21)')
 plt.ylabel('Im(S21)')
 
@@ -125,6 +120,6 @@ plt.figure()
 plt.plot(f, 20*np.log10(np.abs(measured_s21)), '.')
 plt.plot(f, 20*np.log10(np.abs(fit_s21)), '.-', label='best fit')
 plt.plot(f, 20*np.log10(np.abs(guess_s21)), '--', label='initial fit')
-plt.legend(loc='best')
+plt.legend()
 plt.ylabel('|S21| (dB)')
 plt.xlabel('MHz')

--- a/examples/example_confidence_interval.py
+++ b/examples/example_confidence_interval.py
@@ -46,8 +46,8 @@ fit_params.add('shift', value=0.0)
 fit_params.add('decay', value=0.02)
 
 ###############################################################################
-# Set-up the minimizer and perform the fit using leastsq algorithm, and show
-# the report:
+# Set-up the minimizer and perform the fit using ``leastsq`` algorithm, and
+# show the report:
 mini = Minimizer(residual, fit_params, fcn_args=(x,), fcn_kws={'data': data})
 out = mini.leastsq()
 
@@ -95,7 +95,7 @@ for fixed in names:
         f = prob < 0.96
 
         x, y = res[free], res[fixed]
-        ax.scatter(x[f], y[f], c=1-prob[f], s=200*(1-prob[f]+0.5))
+        ax.scatter(x[f], y[f], c=1-prob[f], s=25*(1-prob[f]+0.5))
         ax.autoscale(1, 1)
         j += 1
     i += 1
@@ -107,21 +107,34 @@ for fixed in names:
 names = list(out.params.keys())
 
 plt.figure()
-cm = plt.cm.coolwarm
 for i in range(4):
     for j in range(4):
-        plt.subplot(4, 4, 16-j*4-i)
+        indx = 16-j*4-i
+        ax = plt.subplot(4, 4, indx)
+        ax.ticklabel_format(style='sci', scilimits=(-2, 2), axis='y')
+
+        # set-up labels and tick marks
+        ax.tick_params(labelleft=False, labelbottom=False)
+        if indx in (2, 5, 9, 13):
+            plt.ylabel(names[j])
+            ax.tick_params(labelleft=True)
+        if indx == 1:
+            ax.tick_params(labelleft=True)
+        if indx in (13, 14, 15, 16):
+            plt.xlabel(names[i])
+            ax.tick_params(labelbottom=True)
+            [label.set_rotation(45) for label in ax.get_xticklabels()]
+
         if i != j:
             x, y, m = conf_interval2d(mini, out, names[i], names[j], 20, 20)
-            plt.contourf(x, y, m, linspace(0, 1, 10), cmap=cm)
-            plt.xlabel(names[i])
-            plt.ylabel(names[j])
+            plt.contourf(x, y, m, linspace(0, 1, 10))
 
             x = tr[names[i]][names[i]]
             y = tr[names[i]][names[j]]
             pr = tr[names[i]]['prob']
             s = argsort(x)
-            plt.scatter(x[s], y[s], c=pr[s], s=30, lw=1, cmap=cm)
+            plt.scatter(x[s], y[s], c=pr[s], s=30, lw=1)
+
         else:
             x = tr[names[i]][names[i]]
             y = tr[names[i]]['prob']
@@ -130,7 +143,8 @@ for i in range(4):
             f = interp1d(t, y[s], 'slinear')
             xn = linspace(x.min(), x.max(), 50)
             plt.plot(xn, f(xn), lw=1)
-            plt.xlabel(names[i])
             plt.ylabel('prob')
+            ax.tick_params(labelleft=True)
 
+plt.tight_layout()
 plt.show()

--- a/examples/example_detect_outliers.py
+++ b/examples/example_detect_outliers.py
@@ -14,10 +14,8 @@ import numpy as np
 
 import lmfit
 
-plt.rcParams['figure.dpi'] = 130
-plt.rcParams['figure.autolayout'] = True
 ###############################################################################
-# Generate test data and model. Apply the model to the data
+# Generate test data and model:
 x = np.linspace(0.3, 10, 100)
 np.random.seed(1)
 y = 1.0 / (0.1 * x) + 2.0 + 3 * np.random.randn(x.size)
@@ -30,25 +28,27 @@ def func(x, a, b):
     return 1.0 / (a * x) + b
 
 
-# Make 5 points outliers
+###############################################################################
+# Make five points outliers:
 idx = np.random.randint(0, x.size, 5)
 y[idx] += 10 * np.random.randn(idx.size)
 
-# Fit the data
+###############################################################################
+# Fit the data:
 model = lmfit.Model(func, independent_vars=['x'])
 fit_result = model.fit(y, x=x, a=0.1, b=2)
 
 ###############################################################################
 # and gives the plot and fitting results below:
-
 fit_result.plot_fit()
 plt.plot(x[idx], y[idx], 'o', label='outliers')
 plt.show()
+
+###############################################################################
 print(fit_result.fit_report())
 
 ###############################################################################
-# Fit the dataset while omitting one data point
-
+# Fit the dataset while omitting one data point:
 best_vals = defaultdict(lambda: np.zeros(x.size))
 stderrs = defaultdict(lambda: np.zeros(x.size))
 chi_sq = np.zeros_like(x)
@@ -56,9 +56,7 @@ for i in range(x.size):
     idx2 = np.arange(0, x.size)
     idx2 = np.delete(idx2, i)
     tmp_x = x[idx2]
-    tmp = model.fit(y[idx2],
-                    x=tmp_x,
-                    a=fit_result.params['a'],
+    tmp = model.fit(y[idx2], x=tmp_x, a=fit_result.params['a'],
                     b=fit_result.params['b'])
     chi_sq[i] = tmp.chisqr
     for p in tmp.params:
@@ -67,21 +65,17 @@ for i in range(x.size):
         stderrs[p][i] = (tpar.stderr / fit_result.params[p].stderr)
 
 ###############################################################################
-# Plot the influence on the red. chisqr of each point
-
+# Plot the influence on the red. chisqr of each point:
 fig, ax = plt.subplots()
 ax.plot(x, (fit_result.chisqr - chi_sq) / chi_sq)
-ax.scatter(x[idx],
-           fit_result.chisqr / chi_sq[idx] - 1,
-           color='r',
+ax.scatter(x[idx], fit_result.chisqr / chi_sq[idx] - 1, color='r',
            label='outlier')
 ax.set_ylabel(r'Relative red. $\chi^2$ change')
 ax.set_xlabel('x')
 ax.legend()
 
 ###############################################################################
-# Plot the influence on the parameter value and error of each point
-
+# Plot the influence on the parameter value and error of each point:
 fig, axs = plt.subplots(4, figsize=(4, 7), sharex='col')
 axs[0].plot(x, best_vals['a'])
 axs[0].scatter(x[idx], best_vals['a'][idx], color='r', label='outlier')

--- a/examples/example_diffev.py
+++ b/examples/example_diffev.py
@@ -2,26 +2,14 @@
 Fit Using differential_evolution Algorithm
 ==========================================
 
-This example compares the "leastsq" and "differential_evolution" algorithms on
-a fairly simple problem.
+This example compares the ``leastsq`` and ``differential_evolution`` algorithms
+on a fairly simple problem.
 
 """
 import matplotlib.pyplot as plt
 import numpy as np
 
 import lmfit
-
-np.random.seed(2)
-x = np.linspace(0, 10, 101)
-
-# Setup example
-decay = 5
-offset = 1.0
-amp = 2.0
-omega = 4.0
-
-y = offset + amp*np.sin(omega*x) * np.exp(-x/decay)
-yn = y + np.random.normal(size=y.size, scale=0.450)
 
 
 def resid(params, x, ydata):
@@ -34,22 +22,37 @@ def resid(params, x, ydata):
     return y_model - ydata
 
 
+###############################################################################
+# Generate synthetic data and set-up Parameters with initial values/boundaries:
+decay = 5
+offset = 1.0
+amp = 2.0
+omega = 4.0
+
+np.random.seed(2)
+x = np.linspace(0, 10, 101)
+y = offset + amp*np.sin(omega*x) * np.exp(-x/decay)
+yn = y + np.random.normal(size=y.size, scale=0.450)
+
 params = lmfit.Parameters()
 params.add('offset', 2.0, min=0, max=10.0)
 params.add('omega', 3.3, min=0, max=10.0)
 params.add('amp', 2.5, min=0, max=10.0)
 params.add('decay', 1.0, min=0, max=10.0)
 
+###############################################################################
+# Perform the fits and show fitting results and plot:
 o1 = lmfit.minimize(resid, params, args=(x, yn), method='leastsq')
 print("# Fit using leastsq:")
 lmfit.report_fit(o1)
 
+###############################################################################
 o2 = lmfit.minimize(resid, params, args=(x, yn), method='differential_evolution')
 print("\n\n# Fit using differential_evolution:")
 lmfit.report_fit(o2)
 
-plt.plot(x, yn, 'o', lw=2)
-plt.plot(x, yn+o1.residual, '-', lw=2)
-plt.plot(x, yn+o2.residual, '--', lw=2)
-plt.legend(['data', 'leastsq', 'diffev'], loc='upper left')
-plt.show()
+###############################################################################
+plt.plot(x, yn, 'o', label='data')
+plt.plot(x, yn+o1.residual, '-', label='leastsq')
+plt.plot(x, yn+o2.residual, '--', label='diffev')
+plt.legend()

--- a/examples/example_emcee_Model_interface.py
+++ b/examples/example_emcee_Model_interface.py
@@ -11,7 +11,7 @@ import lmfit
 
 
 ###############################################################################
-# Set up a double-exponential function and create a Model
+# Set up a double-exponential function and create a Model:
 def double_exp(x, a1, t1, a2, t2):
     return a1*np.exp(-x/t1) + a2*np.exp(-(x-0.1) / t2)
 
@@ -19,14 +19,14 @@ def double_exp(x, a1, t1, a2, t2):
 model = lmfit.Model(double_exp)
 
 ###############################################################################
-# Generate some fake data from the model with added noise
+# Generate some fake data from the model with added noise:
 truths = (3.0, 2.0, -5.0, 10.0)
 x = np.linspace(1, 10, 250)
 np.random.seed(0)
 y = double_exp(x, *truths)+0.1*np.random.randn(x.size)
 
 ###############################################################################
-# Create model parameters and give them initial values
+# Create model parameters and give them initial values:
 p = model.make_params(a1=4, t1=3, a2=4, t2=3)
 
 ###############################################################################
@@ -37,12 +37,12 @@ lmfit.report_fit(result)
 result.plot()
 
 ###############################################################################
-# Calculate parameter covariance using emcee:
+# Calculate parameter covariance using ``emcee``:
 #
 #  - start the walkers out at the best-fit values
-#  - set is_weighted to False to estimate the noise weights
+#  - set ``is_weighted`` to ``False`` to estimate the noise weights
 #  - set some sensible priors on the uncertainty to keep the MCMC in check
-#
+
 emcee_kws = dict(steps=5000, burn=500, thin=20, is_weighted=False,
                  progress=False)
 emcee_params = result.params.copy()
@@ -53,49 +53,48 @@ emcee_params.add('__lnsigma', value=np.log(0.1), min=np.log(0.001), max=np.log(2
 result_emcee = model.fit(data=y, x=x, params=emcee_params, method='emcee',
                          nan_policy='omit', fit_kws=emcee_kws)
 
+###############################################################################
 lmfit.report_fit(result_emcee)
 
-result_emcee.plot_fit(data_kws=dict(color='gray', markersize=2))
-plt.plot(x, model.eval(params=result.params, x=x), label='Nelder', zorder=100)
+###############################################################################
+result_emcee.plot_fit()
+plt.plot(x, model.eval(params=result.params, x=x), '--', label='Nelder')
 plt.legend()
-plt.show()
 
 ###############################################################################
-# check the acceptance fraction to see whether emcee performed well
+# Check the acceptance fraction to see whether ``emcee`` performed well:
 plt.plot(result_emcee.acceptance_fraction, 'o')
 plt.xlabel('walker')
 plt.ylabel('acceptance fraction')
-plt.show()
 
 ###############################################################################
-# try to compute the autocorrelation time
+# Try to compute the autocorrelation time:
 if hasattr(result_emcee, "acor"):
     print("Autocorrelation time for the parameters:")
     print("----------------------------------------")
     for i, p in enumerate(result.params):
-        print(p, result_emcee.acor[i])
-
+        print(f'{p} = {result_emcee.acor[i]:.3f}')
 
 ###############################################################################
-# Plot the parameter covariances returned by emcee using corner
+# Plot the parameter covariances returned by ``emcee`` using ``corner``:
 emcee_corner = corner.corner(result_emcee.flatchain, labels=result_emcee.var_names,
                              truths=list(result_emcee.params.valuesdict().values()))
 
 ###############################################################################
-#
 print("\nmedian of posterior probability distribution")
 print('--------------------------------------------')
 lmfit.report_fit(result_emcee.params)
 
-# find the maximum likelihood solution
+###############################################################################
+# Find the maximum likelihood solution:
 highest_prob = np.argmax(result_emcee.lnprob)
 hp_loc = np.unravel_index(highest_prob, result_emcee.lnprob.shape)
 mle_soln = result_emcee.chain[hp_loc]
-print("\nMaximum likelihood Estimation")
-print('-----------------------------')
+print("\nMaximum Likelihood Estimation (MLE):")
+print('----------------------------------')
 for ix, param in enumerate(emcee_params):
-    print(param + ': ' + str(mle_soln[ix]))
+    print(f"{param}: {mle_soln[ix]:.3f}")
 
 quantiles = np.percentile(result_emcee.flatchain['t1'], [2.28, 15.9, 50, 84.2, 97.7])
-print("\n\n1 sigma spread", 0.5 * (quantiles[3] - quantiles[1]))
-print("2 sigma spread", 0.5 * (quantiles[4] - quantiles[0]))
+print(f"\n\n1 sigma spread = {0.5 * (quantiles[3] - quantiles[1]):.3f}")
+print(f"2 sigma spread = {0.5 * (quantiles[4] - quantiles[0]):.3f}")

--- a/examples/example_expression_model.py
+++ b/examples/example_expression_model.py
@@ -21,7 +21,7 @@ np.random.seed(2021)
 y = y + np.random.normal(size=x.size, scale=0.01)
 
 ###############################################################################
-# Define the ExpressionModel and perform the fit:
+# Define the ``ExpressionModel`` and perform the fit:
 gmod = ExpressionModel("amp * exp(-(x-cen)**2 /(2*wid**2))/(sqrt(2*pi)*wid)")
 result = gmod.fit(y, x=x, amp=5, cen=5, wid=1)
 
@@ -29,8 +29,8 @@ result = gmod.fit(y, x=x, amp=5, cen=5, wid=1)
 # this results in the following output:
 print(result.fit_report())
 
+###############################################################################
 plt.plot(x, y, 'o')
 plt.plot(x, result.init_fit, '--', label='initial fit')
 plt.plot(x, result.best_fit, '-', label='best fit')
-plt.legend(loc='best')
-plt.show()
+plt.legend()

--- a/examples/example_fit_multi_datasets.py
+++ b/examples/example_fit_multi_datasets.py
@@ -5,9 +5,9 @@ Fit Multiple Data Sets
 Fitting multiple (simulated) Gaussian data sets simultaneously.
 
 All minimizers require the residual array to be one-dimensional. Therefore, in
-the ``objective`` we need to ```flatten``` the array before returning it.
+the ``objective`` function we need to ``flatten`` the array before returning it.
 
-TODO: this should be using the Model interface / built-in models!
+TODO: this could/should be using the Model interface / built-in models!
 
 """
 import matplotlib.pyplot as plt
@@ -44,10 +44,9 @@ def objective(params, x, data):
 
 ###############################################################################
 # Create five simulated Gaussian data sets
-
+np.random.seed(2021)
 x = np.linspace(-1, 2, 151)
 data = []
-np.random.seed(2021)
 for _ in np.arange(5):
     params = Parameters()
     amp = 0.60 + 9.50*np.random.rand()
@@ -59,7 +58,6 @@ data = np.array(data)
 
 ###############################################################################
 # Create five sets of fitting parameters, one per data set
-
 fit_params = Parameters()
 for iy, y in enumerate(data):
     fit_params.add(f'amp_{iy+1}', value=0.5, min=0.0, max=200)
@@ -69,21 +67,17 @@ for iy, y in enumerate(data):
 ###############################################################################
 # Constrain the values of sigma to be the same for all peaks by assigning
 # sig_2, ..., sig_5 to be equal to sig_1.
-
 for iy in (2, 3, 4, 5):
     fit_params[f'sig_{iy}'].expr = 'sig_1'
 
 ###############################################################################
 # Run the global fit and show the fitting result
-
 out = minimize(objective, fit_params, args=(x, data))
 report_fit(out.params)
 
 ###############################################################################
 # Plot the data sets and fits
-
 plt.figure()
 for i in range(5):
     y_fit = gauss_dataset(out.params, i, x)
     plt.plot(x, data[i, :], 'o', x, y_fit, '-')
-plt.show()

--- a/examples/example_fit_with_algebraic_constraint.py
+++ b/examples/example_fit_with_algebraic_constraint.py
@@ -2,7 +2,6 @@
 Fit with Algebraic Constraint
 =============================
 
-
 """
 import matplotlib.pyplot as plt
 from numpy import linspace, random
@@ -32,9 +31,7 @@ x = linspace(0.0, 20.0, 601)
 
 data = (gaussian(x, 21, 8.1, 1.2) +
         lorentzian(x, 10, 9.6, 2.4) +
-        random.normal(scale=0.23, size=x.size) +
-        x*0.5)
-
+        random.normal(scale=0.23, size=x.size) + x*0.5)
 
 pfit = Parameters()
 pfit.add(name='amp_g', value=10)
@@ -49,9 +46,8 @@ pfit.add(name='line_off', value=0.0)
 
 sigma = 0.021  # estimate of data error (for all data points)
 
-myfit = Minimizer(residual, pfit,
-                  fcn_args=(x,), fcn_kws={'sigma': sigma, 'data': data},
-                  scale_covar=True)
+myfit = Minimizer(residual, pfit, fcn_args=(x,),
+                  fcn_kws={'sigma': sigma, 'data': data})
 
 result = myfit.leastsq()
 init = residual(pfit, x)
@@ -59,8 +55,8 @@ fit = residual(result.params, x)
 
 report_fit(result)
 
+###############################################################################
 plt.plot(x, data, '+')
 plt.plot(x, init, '--', label='initial fit')
 plt.plot(x, fit, '-', label='best fit')
-plt.legend(loc='best')
-plt.show()
+plt.legend()

--- a/examples/example_fit_with_bounds.py
+++ b/examples/example_fit_with_bounds.py
@@ -17,6 +17,8 @@ from numpy import exp, linspace, pi, random, sign, sin
 from lmfit import Parameters, minimize
 from lmfit.printfuncs import report_fit
 
+###############################################################################
+# Define the 'correct' Parameter values and residual function:
 p_true = Parameters()
 p_true.add('amp', value=14.0)
 p_true.add('period', value=5.4321)
@@ -35,28 +37,28 @@ def residual(pars, x, data=None):
     return model - data
 
 
+###############################################################################
+# Generate synthetic data and initialize fitting Parameters:
 random.seed(0)
 x = linspace(0, 250, 1500)
-noise = random.normal(scale=2.80, size=x.size)
+noise = random.normal(scale=2.8, size=x.size)
 data = residual(p_true, x) + noise
 
 fit_params = Parameters()
-fit_params.add('amp', value=13.0, max=20, min=0.0)
+fit_params.add('amp', value=13, max=20, min=0)
 fit_params.add('period', value=2, max=10)
-fit_params.add('shift', value=0.0, max=pi/2., min=-pi/2.)
-fit_params.add('decay', value=0.02, max=0.10, min=0.00)
+fit_params.add('shift', value=0, max=pi/2., min=-pi/2.)
+fit_params.add('decay', value=0.02, max=0.1, min=0)
 
+###############################################################################
+# Perform the fit and show the results:
 out = minimize(residual, fit_params, args=(x,), kws={'data': data})
 fit = residual(out.params, x)
 
 ###############################################################################
-# This gives the following fitting results:
-
-report_fit(out, show_correl=True, modelpars=p_true)
+report_fit(out, modelpars=p_true)
 
 ###############################################################################
-# and shows the plot below:
-#
-plt.plot(x, data, 'o')
-plt.plot(x, fit)
-plt.show()
+plt.plot(x, data, 'o', label='data')
+plt.plot(x, fit, label='best fit')
+plt.legend()

--- a/examples/example_fit_with_derivfunc.py
+++ b/examples/example_fit_with_derivfunc.py
@@ -41,42 +41,36 @@ y = f([a, b, c], x)
 np.random.seed(2021)
 data = y + 0.15*np.random.normal(size=x.size)
 
-# fit without analytic derivative
+###############################################################################
+# Fit without analytic derivative:
 min1 = Minimizer(func, params, fcn_args=(x,), fcn_kws={'data': data})
 out1 = min1.leastsq()
 fit1 = func(out1.params, x)
 
-# fit with analytic derivative
+###############################################################################
+# Fit with analytic derivative:
 min2 = Minimizer(func, params, fcn_args=(x,), fcn_kws={'data': data})
 out2 = min2.leastsq(Dfun=dfunc, col_deriv=1)
 fit2 = func(out2.params, x)
 
 ###############################################################################
 # Comparison of fit to exponential decay with/without analytical derivatives
-# to model = a*exp(-b*x) + c
-print('''
-"true" parameters are: a = %.3f, b = %.3f, c = %.3f
-
-==============================================
-Statistic/Parameter|   Without   | With      |
-----------------------------------------------
-N Function Calls   |   %3i       |   %3i     |
-Chi-square         |   %.4f    |   %.4f  |
-   a               |   %.4f    |   %.4f  |
-   b               |   %.4f    |   %.4f  |
-   c               |   %.4f    |   %.4f  |
-----------------------------------------------
-''' % (a, b, c,
-       out1.nfev, out2.nfev,
-       out1.chisqr, out2.chisqr,
-       out1.params['a'], out2.params['a'],
-       out1.params['b'], out2.params['b'],
-       out1.params['c'], out2.params['c']))
+# to model = a*exp(-b*x) + c:
+print(f'"true" parameters are: a = {a:.3f}, b = {b:.3f}, c = {c:.3f}\n\n'
+      '|=========================================\n'
+      '| Statistic/Parameter | Without | With   |\n'
+      '|-----------------------------------------\n'
+      f'|  N Function Calls   | {out1.nfev:d}      | {out2.nfev:d}     |\n'
+      f'|     Chi-square      | {out1.chisqr:.4f}  | {out2.chisqr:.4f} |\n'
+      f"|         a           | {out1.params['a'].value:.4f}  | {out2.params['a'].value:.4f} |\n"
+      f"|         b           | {out1.params['b'].value:.4f}  | {out2.params['b'].value:.4f} |\n"
+      f"|         c           | {out1.params['c'].value:.4f}  | {out2.params['c'].value:.4f} |\n"
+      '------------------------------------------')
 
 ###############################################################################
 # and the best-fit to the synthetic data (with added noise) is the same for
 # both methods:
-plt.plot(x, data, 'o')
-plt.plot(x, fit1)
-plt.plot(x, fit2)
-plt.show()
+plt.plot(x, data, 'o', label='data')
+plt.plot(x, fit1, label='with analytical derivative')
+plt.plot(x, fit2, '--', label='without analytical derivative')
+plt.legend()

--- a/examples/example_fit_with_inequality.py
+++ b/examples/example_fit_with_inequality.py
@@ -23,7 +23,7 @@ def residual(pars, x, data):
 
 
 ###############################################################################
-# Generate the simulated data using a Gaussian and Lorentzian line shape:
+# Generate the simulated data using a Gaussian and Lorentzian lineshape:
 np.random.seed(0)
 x = np.linspace(0, 20.0, 601)
 

--- a/examples/example_fit_with_inequality.py
+++ b/examples/example_fit_with_inequality.py
@@ -57,5 +57,4 @@ report_fit(out.params)
 # and figure:
 plt.plot(x, data, 'o')
 plt.plot(x, best_fit, '--', label='best fit')
-plt.legend(loc='best')
-plt.show()
+plt.legend()

--- a/examples/example_reduce_fcn.py
+++ b/examples/example_reduce_fcn.py
@@ -2,10 +2,10 @@
 Fit Specifying Different Reduce Function
 ========================================
 
-The reduce_fcn specifies how to convert a residual array to a scalar value for
-the scalar minimizers. The default value is None (i.e., "sum of squares of
-residual") - alternatives are: 'negentropy' and 'neglogcauchy' or a
-user-specified "callable". For more information please refer to:
+The ``reduce_fcn`` specifies how to convert a residual array to a scalar value
+for the scalar minimizers. The default value is None (i.e., "sum of squares of
+residual") - alternatives are: ``negentropy``, ``neglogcauchy``, or a
+user-specified ``callable``. For more information please refer to:
 https://lmfit.github.io/lmfit-py/fitting.html#using-the-minimizer-class
 
 Here, we use as an example the Student's t log-likelihood for robust fitting
@@ -16,21 +16,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import lmfit
-
-np.random.seed(2)
-x = np.linspace(0, 10, 101)
-
-# Setup example
-decay = 5
-offset = 1.0
-amp = 2.0
-omega = 4.0
-
-y = offset + amp * np.sin(omega*x) * np.exp(-x/decay)
-yn = y + np.random.normal(size=y.size, scale=0.250)
-
-outliers = np.random.randint(int(len(x)/3.0), len(x), int(len(x)/12))
-yn[outliers] += 5*np.random.random(len(outliers))
 
 
 def resid(params, x, ydata):
@@ -43,30 +28,43 @@ def resid(params, x, ydata):
     return y_model - ydata
 
 
-params = lmfit.Parameters()
+###############################################################################
+# Generate synthetic data with noise/outliers and initialize fitting Parameters:
+decay = 5
+offset = 1.0
+amp = 2.0
+omega = 4.0
 
+np.random.seed(2)
+x = np.linspace(0, 10, 101)
+y = offset + amp * np.sin(omega*x) * np.exp(-x/decay)
+yn = y + np.random.normal(size=y.size, scale=0.250)
+
+outliers = np.random.randint(int(len(x)/3.0), len(x), int(len(x)/12))
+yn[outliers] += 5*np.random.random(len(outliers))
+
+params = lmfit.Parameters()
 params.add('offset', 2.0)
 params.add('omega', 3.3)
 params.add('amp', 2.5)
 params.add('decay', 1.0, min=0)
 
+###############################################################################
+# Perform fits using the ``L-BFGS-B`` method with different ``reduce_fcn``:
 method = 'L-BFGS-B'
-
 o1 = lmfit.minimize(resid, params, args=(x, yn), method=method)
 print("# Fit using sum of squares:\n")
 lmfit.report_fit(o1)
 
+###############################################################################
 o2 = lmfit.minimize(resid, params, args=(x, yn), method=method,
                     reduce_fcn='neglogcauchy')
 print("\n\n# Robust Fit, using log-likelihood with Cauchy PDF:\n")
 lmfit.report_fit(o2)
 
-plt.plot(x, y, 'o', lw=2)
-plt.plot(x, yn, '--*', lw=1)
-plt.plot(x, yn+o1.residual, '-', lw=2)
-plt.plot(x, yn+o2.residual, '-', lw=2)
-plt.legend(['True function',
-            'with noise+outliers',
-            'sum of squares fit',
-            'robust fit'], loc='upper left')
-plt.show()
+###############################################################################
+plt.plot(x, y, 'o', label='true function')
+plt.plot(x, yn, '--*', label='with noise+outliers')
+plt.plot(x, yn+o1.residual, '-', label='sum of squares fit')
+plt.plot(x, yn+o2.residual, '-', label='robust fit')
+plt.legend()

--- a/examples/example_sympy.py
+++ b/examples/example_sympy.py
@@ -15,9 +15,7 @@ from sympy.parsing import sympy_parser
 
 import lmfit
 
-np.random.seed(1)
-
-# %%
+###############################################################################
 # Instead of creating the SymPy symbols explicitly and building an expression
 # with them, we will use the SymPy parser.
 
@@ -29,42 +27,42 @@ model_list = sympy.Array((gauss_peak1, gauss_peak2, exp_back))
 model = sum(model_list)
 print(model)
 
-# %%
+###############################################################################
 # We are using SymPy's lambdify function to make a function from the model
 # expressions. We then use these functions to generate some fake data.
 
 model_list_func = sympy.lambdify(list(model_list.free_symbols), model_list)
 model_func = sympy.lambdify(list(model.free_symbols), model)
 
+###############################################################################
+# Generate synthetic data with noise and plot the data.
+np.random.seed(1)
 x = np.linspace(0, 10, 40)
-param_values = dict(x=x, A1=2, sigma1=1, sigma2=1, A2=3,
-                    xc1=2, xc2=5, xw=4, B=5)
+param_values = dict(x=x, A1=2, sigma1=1, sigma2=1, A2=3, xc1=2, xc2=5, xw=4, B=5)
 y = model_func(**param_values)
 yi = model_list_func(**param_values)
 yn = y + np.random.randn(y.size)*0.4
 
-plt.plot(x, yn, 'o', zorder=1.9, ms=3)
-plt.plot(x, y, lw=3)
+plt.plot(x, yn, 'o')
+plt.plot(x, y)
 for c in yi:
-    plt.plot(x, c, lw=1, c='0.7')
+    plt.plot(x, c, color='0.7')
 
-
-# %%
+###############################################################################
 # Next, we will just create a lmfit model from the function and fit the data.
-
 lm_mod = lmfit.Model(model_func, independent_vars=('x'))
 res = lm_mod.fit(data=yn, **param_values)
+
+###############################################################################
 res.plot_fit()
 plt.plot(x, y, label='true')
 plt.legend()
-plt.show()
 
-# %%
+###############################################################################
 # The nice thing of using SymPy is that we can easily modify our fit function.
 # Let's assume we know that the width of both Gaussians are identical. Similarly,
 # we assume that the ratio between both Gaussians is fixed to 3:2 for some
 # reason. Both can be expressed by just substituting the variables.
-
 model2 = model.subs('sigma2', 'sigma1').subs('A2', '3/2*A1')
 model2_func = sympy.lambdify(list(model2.free_symbols), model2)
 lm_mod = lmfit.Model(model2_func, independent_vars=('x'))
@@ -73,4 +71,3 @@ res2 = lm_mod.fit(data=yn, **param2_values)
 res2.plot_fit()
 plt.plot(x, y, label='true')
 plt.legend()
-plt.show()

--- a/examples/example_use_pandas.py
+++ b/examples/example_use_pandas.py
@@ -2,17 +2,16 @@
 Fit with Data in a pandas DataFrame
 ===================================
 
-Simple example demonstrating how to read in the data using pandas and supply
-the elements of the DataFrame from lmfit.
+Simple example demonstrating how to read in the data using ``pandas`` and
+supply the elements of the ``DataFrame`` to lmfit.
 
 """
-import matplotlib.pyplot as plt
 import pandas as pd
 
 from lmfit.models import LorentzianModel
 
 ###############################################################################
-# read the data into a pandas DataFrame, and use the 'x' and 'y' columns:
+# read the data into a pandas DataFrame, and use the ``x`` and ``y`` columns:
 dframe = pd.read_csv('peak.csv')
 
 model = LorentzianModel()
@@ -21,8 +20,9 @@ params = model.guess(dframe['y'], x=dframe['x'])
 result = model.fit(dframe['y'], params, x=dframe['x'])
 
 ###############################################################################
-# and gives the plot and fitting results below:
-result.plot_fit()
-plt.show()
-
+# and gives the fitting results:
 print(result.fit_report())
+
+###############################################################################
+# and plot below:
+result.plot_fit()

--- a/lmfit/confidence.py
+++ b/lmfit/confidence.py
@@ -30,7 +30,7 @@ def f_compare(best_fit, new_fit):
     Returns
     -------
     float
-        Value of the calculated probality.
+        Value of the calculated probability.
 
     """
     nfree = best_fit.nfree

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -204,7 +204,7 @@ def dho(x, amplitude=1., center=1., sigma=1., gamma=1.0):
         bose = not_zero(bose)
     else:
         bose[where(isnan(bose))] = tiny
-        bose[where(abs(bose)<=tiny)] = tiny
+        bose[where(abs(bose) <= tiny)] = tiny
 
     lm = 1.0/((x-center)**2 + sigma**2)
     lp = 1.0/((x+center)**2 + sigma**2)

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -1,6 +1,6 @@
-"""Basic model line shapes and distribution functions."""
+"""Basic model lineshapes and distribution functions."""
 
-from numpy import (arctan, copysign, cos, exp, isclose, isnan, log, pi, real, 
+from numpy import (arctan, copysign, cos, exp, isclose, isnan, log, pi, real,
                    sin, sqrt, where)
 from scipy.special import erf, erfc
 from scipy.special import gamma as gamfcn
@@ -208,7 +208,7 @@ def dho(x, amplitude=1., center=1., sigma=1., gamma=1.0):
 
     lm = 1.0/((x-center)**2 + sigma**2)
     lp = 1.0/((x+center)**2 + sigma**2)
-    return factor * where(isclose(x, 0.0), 
+    return factor * where(isclose(x, 0.0),
                           4*gamma*center/(center**2+sigma**2)**2,
                           (lm - lp)/bose)
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1042,7 +1042,7 @@ class Minimizer:
 
         result._calculate_statistics()
 
-        # calculate the cov_x and estimate uncertanties/correlations
+        # calculate the cov_x and estimate uncertainties/correlations
         if (not result.aborted and self.calc_covar and HAS_NUMDIFFTOOLS and
                 len(result.residual) > len(result.var_names)):
             _covar_ndt = self._calculate_covariance_matrix(result.x)
@@ -1255,8 +1255,8 @@ class Minimizer:
             `lnprob` contains the log probability for each sample in
             `chain`. The sample with the highest probability corresponds
             to the maximum likelihood estimate. `acor` is an array
-            containing the autocorrelation time for each parameter if the
-            autocorrelation time can be computed from the chain. Finally,
+            containing the auto-correlation time for each parameter if the
+            auto-correlation time can be computed from the chain. Finally,
             `acceptance_fraction` (an array of the fraction of steps
             accepted for each walker).
 
@@ -1792,7 +1792,7 @@ class Minimizer:
 
         result._calculate_statistics()
 
-        # calculate the cov_x and estimate uncertanties/correlations
+        # calculate the cov_x and estimate uncertainties/correlations
         if (not result.aborted and self.calc_covar and HAS_NUMDIFFTOOLS and
                 len(result.residual) > len(result.var_names)):
             _covar_ndt = self._calculate_covariance_matrix(ret.x)
@@ -2094,7 +2094,7 @@ class Minimizer:
 
         result._calculate_statistics()
 
-        # calculate the cov_x and estimate uncertanties/correlations
+        # calculate the cov_x and estimate uncertainties/correlations
         if (not result.aborted and self.calc_covar and HAS_NUMDIFFTOOLS and
                 len(result.residual) > len(result.var_names)):
             _covar_ndt = self._calculate_covariance_matrix(result.ampgo_x0)
@@ -2168,7 +2168,7 @@ class Minimizer:
 
         result._calculate_statistics()
 
-        # calculate the cov_x and estimate uncertanties/correlations
+        # calculate the cov_x and estimate uncertainties/correlations
         if (not result.aborted and self.calc_covar and HAS_NUMDIFFTOOLS and
                 len(result.residual) > len(result.var_names)):
             result.covar = self._calculate_covariance_matrix(result.shgo_x)
@@ -2245,7 +2245,7 @@ class Minimizer:
 
         result._calculate_statistics()
 
-        # calculate the cov_x and estimate uncertanties/correlations
+        # calculate the cov_x and estimate uncertainties/correlations
         if (not result.aborted and self.calc_covar and HAS_NUMDIFFTOOLS and
                 len(result.residual) > len(result.var_names)):
             result.covar = self._calculate_covariance_matrix(result.da_x)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -2108,8 +2108,7 @@ class ModelResult(Minimizer):
 
         Returns
         -------
-        tuple
-            A tuple with matplotlib's Figure and GridSpec objects.
+        matplotlib.figure.Figure
 
         See Also
         --------
@@ -2175,4 +2174,4 @@ class ModelResult(Minimizer):
                             title=title)
         plt.setp(ax_res.get_xticklabels(), visible=False)
         ax_fit.set_title('')
-        return fig, gs
+        return fig

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -135,7 +135,7 @@ def propagate_err(z, dz, option):
     so a value of `math:pi` is returned.
 
     In the case where ``option='abs'`` and ``numpy.abs(z) == 0`` for any
-    value of `z` the mangnitude uncertainty is approximated by
+    value of `z` the magnitude uncertainty is approximated by
     ``numpy.abs(dz)`` for that value.
 
     """
@@ -807,7 +807,7 @@ class Model:
             if name in self._func_allargs or self._func_haskeywords:
                 out[name] = par.value
 
-        # 2. for each function argument, use 'prefx+varname' in params,
+        # 2. for each function argument, use 'prefix+varname' in params,
         # avoiding possible name collisions with unprefixed params
         if len(self._prefix) > 0:
             for fullname in self._param_names:

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -2024,7 +2024,7 @@ class ModelResult(Minimizer):
 
         x_array = self.userkws[independent_var]
 
-        ax.axhline(0, **fit_kws)
+        ax.axhline(0, **fit_kws, color='k')
 
         y_eval = self.model.eval(self.params, **{independent_var: x_array})
         if isinstance(self.model, (lmfit.models.ConstantModel,
@@ -2033,20 +2033,20 @@ class ModelResult(Minimizer):
 
         if yerr is None and self.weights is not None:
             yerr = 1.0/self.weights
+
+        residuals = reduce_complex(self.eval()) - reduce_complex(self.data)
         if yerr is not None:
-            ax.errorbar(x_array, reduce_complex(y_eval) - reduce_complex(self.data),
+            ax.errorbar(x_array, residuals,
                         yerr=propagate_err(self.data, yerr, parse_complex),
-                        fmt=datafmt, label='residuals', **data_kws)
+                        fmt=datafmt, **data_kws)
         else:
-            ax.plot(x_array, reduce_complex(y_eval) - reduce_complex(self.data),
-                    datafmt, label='residuals', **data_kws)
+            ax.plot(x_array, residuals, datafmt, **data_kws)
 
         if title:
             ax.set_title(title)
         elif ax.get_title() == '':
             ax.set_title(self.model.name)
         ax.set_ylabel('residuals')
-        ax.legend()
         return ax
 
     @_ensureMatplotlib

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,6 @@ pre-commit
 pycairo;platform_system=="Windows"
 pytest
 Sphinx
-sphinx-gallery>=0.8
+sphinx-gallery>=0.10
 sphinxcontrib-svg2pdfconverter
 sympy

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -413,7 +413,7 @@ def test_figure_default_title(peakdata):
     ax = result.plot_residuals()
     assert ax.axes.get_title() == 'Model(pvoigt)'
 
-    fig, _ = result.plot()
+    fig = result.plot()
     assert fig.axes[0].get_title() == 'Model(pvoigt)'  # default model.name
     assert fig.axes[1].get_title() == ''  # no title for fit subplot
 
@@ -433,7 +433,7 @@ def test_figure_title_using_title_keyword_argument(peakdata):
     ax = result.plot_residuals(title='test')
     assert ax.axes.get_title() == 'test'
 
-    fig, _ = result.plot(title='test')
+    fig = result.plot(title='test')
     assert fig.axes[0].get_title() == 'test'
     assert fig.axes[1].get_title() == ''  # no title for fit subplot
 
@@ -453,11 +453,11 @@ def test_figure_title_using_title_to_ax_kws(peakdata):
     ax = result.plot_residuals(ax_kws={'title': 'ax_kws'})
     assert ax.axes.get_title() == 'ax_kws'
 
-    fig, _ = result.plot(ax_res_kws={'title': 'ax_res_kws'})
+    fig = result.plot(ax_res_kws={'title': 'ax_res_kws'})
     assert fig.axes[0].get_title() == 'ax_res_kws'
     assert fig.axes[1].get_title() == ''
 
-    fig, _ = result.plot(ax_fit_kws={'title': 'ax_fit_kws'})
+    fig = result.plot(ax_fit_kws={'title': 'ax_fit_kws'})
     assert fig.axes[0].get_title() == 'Model(pvoigt)'  # default model.name
     assert fig.axes[1].get_title() == ''  # no title for fit subplot
 
@@ -477,11 +477,11 @@ def test_priority_setting_figure_title(peakdata):
     ax = result.plot_residuals(ax_kws={'title': 'ax_kws'}, title='test')
     assert ax.axes.get_title() == 'test'
 
-    fig, _ = result.plot(ax_res_kws={'title': 'ax_res_kws'}, title='test')
+    fig = result.plot(ax_res_kws={'title': 'ax_res_kws'}, title='test')
     assert fig.axes[0].get_title() == 'test'
     assert fig.axes[1].get_title() == ''
 
-    fig, _ = result.plot(ax_fit_kws={'title': 'ax_fit_kws'}, title='test')
+    fig = result.plot(ax_fit_kws={'title': 'ax_fit_kws'}, title='test')
     assert fig.axes[0].get_title() == 'test'
     assert fig.axes[1].get_title() == ''
 
@@ -1007,10 +1007,9 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         pars['g2_amplitude'].set(1)
 
         result = mod.fit(data, params=pars, x=self.x)
-        fig, ax = result.plot(show_init=True)
+        fig = result.plot(show_init=True)
 
         assert isinstance(fig, matplotlib.figure.Figure)
-        assert isinstance(ax, matplotlib.axes.GridSpec)
 
         comps = result.eval_components(x=self.x)
         assert len(comps) == 2


### PR DESCRIPTION
#### Description
- improve layout of examples in the gallery (i.e., show output at the appropriate places, suppress unwanted text output) 
- use higher resolution figures (requires `sphinx-gallery >= 0.10.0`)
- use as much as possible defaults from `matplotlib`

- minor changes to plotting of residuals in `ModelResult.plot_residuals()`: show line in black, do not show label
- only return the `matplotlib.figure.Figure` instance in `ModelResult.plot()`

###### Type of Changes
- [ ] Bug fix
- [x] New feature
- [x] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
Python: 3.9.7 (default, Sep  6 2021, 12:38:33)
[Clang 12.0.0 (clang-1200.0.32.29)]

lmfit: 1.0.2.post111+g65fae85, scipy: 1.7.1, numpy: 1.21.2, asteval: 0.9.25, uncertainties: 3.1.6


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
