### PR TITLE
ENH: handle plotting of (Complex)ConstantModel and specify return types

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -35,6 +35,8 @@ Bug fixes/enhancements:
 - improved handling of altered JSON data (Issue #739; PR #740, reported by Matthew Giammar)
 - map ``max_nfev`` to ``maxiter`` when using ``differential_evolution`` (PR #749, reported by Olivier B.)
 - correct use of noise versus experimental uncertainty in the documentation (PR #751, reported by Andrés Zelcer)
+- specify return type of ``eval`` method more precisely and allow for plotting of (Complex)ConstantModel by coercing their
+  ``float``, ``int``, or ``complex`` return value to a ``numpy.ndarray`` (Issue #684 and PR #754)
 
 Various:
 


### PR DESCRIPTION
#### Description
@newville this PR is possibly a bit more controversial as in the past you've been lukewarm about "fixing" this. I hope this strikes a good balance between convenience when working with built-in models without loosing any generality...I think clarifying the return type more specifically and stating that it is dependent on the model function never hurts. And while looking at this, it's clear that it isn't too difficult  to have the `ConstantModel` and `ComplexConstantModel` work out-of-the box with the `.plot_*()` functions. 

So here we go - let me know what you think:
- specify that the return type of .eval() depends on the model function and clarify the types for the built-in models
- allow for automatic plotting of the built-in `ConstantModel` and `ComplexConstantModel` by coercing their `float`/`int` or `complex` return value to a `numpy.ndarray`

Closes: #684

NB. this will need a rebase after merging of PR #753 and I'll take care of that if this PR is deemed acceptable.


###### Type of Changes
- [ ] Bug fix
- [x] New feature
- [x] Refactoring / maintenance
- [x] Documentation / examples

###### Tested on
Python: 3.9.7 (default, Sep  6 2021, 12:38:33)
[Clang 12.0.0 (clang-1200.0.32.29)]

lmfit: 1.0.2.post109+g6d3c8f1, scipy: 1.7.1, numpy: 1.21.2, asteval: 0.9.25, uncertainties: 3.1.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
