### PR TITLE
Fix dho lineshape

### DIFF
--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -185,7 +185,7 @@ def damped_oscillator(x, amplitude=1.0, center=1., sigma=0.1):
     return amplitude/sqrt((1.0 - (x/center)**2)**2 + (2*sigma*x/center)**2)
 
 
-def dho(x, amplitude=1., center=0., sigma=1., gamma=1.0):
+def dho(x, amplitude=1., center=1., sigma=1., gamma=1.0):
     """Return a Damped Harmonic Oscillator.
 
     Similar to the version from PAN:

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -200,10 +200,10 @@ def dho(x, amplitude=1., center=0., sigma=1., gamma=1.0):
     """
     bose = (1.0 - exp(-x/max(tiny, gamma)))
     if isinstance(bose, (int, float)):
-        bose = max(tiny, bose)
+        bose = not_zero(bose)
     else:
         bose[where(isnan(bose))] = tiny
-        bose[where(bose <= tiny)] = tiny
+        bose[where(abs(bose)<=tiny)] = tiny
 
     lm = 1.0/((x-center)**2 + sigma**2)
     lp = 1.0/((x+center)**2 + sigma**2)

--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -1,7 +1,7 @@
 """Basic model line shapes and distribution functions."""
 
-from numpy import (arctan, copysign, cos, exp, isnan, log, pi, real, sin, sqrt,
-                   where)
+from numpy import (arctan, copysign, cos, exp, isclose, isnan, log, pi, real, 
+                   sin, sqrt, where)
 from scipy.special import erf, erfc
 from scipy.special import gamma as gamfcn
 from scipy.special import wofz
@@ -198,6 +198,7 @@ def dho(x, amplitude=1., center=0., sigma=1., gamma=1.0):
         ``lp(x, center, sigma) = 1.0 / ((x+center)**2 + sigma**2)``
 
     """
+    factor = amplitude * sigma / pi
     bose = (1.0 - exp(-x/max(tiny, gamma)))
     if isinstance(bose, (int, float)):
         bose = not_zero(bose)
@@ -207,7 +208,9 @@ def dho(x, amplitude=1., center=0., sigma=1., gamma=1.0):
 
     lm = 1.0/((x-center)**2 + sigma**2)
     lp = 1.0/((x+center)**2 + sigma**2)
-    return amplitude*sigma/pi*(lm - lp)/bose
+    return factor * where(isclose(x, 0.0), 
+                          4*gamma*center/(center**2+sigma**2)**2,
+                          (lm - lp)/bose)
 
 
 def logistic(x, amplitude=1., center=0., sigma=1.):

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -980,6 +980,7 @@ class DampedHarmonicOscillatorModel(Model):
         self._set_paramhints_prefix()
 
     def _set_paramhints_prefix(self):
+        self.set_param_hint('center', min=0)
         self.set_param_hint('sigma', min=0)
         self.set_param_hint('gamma', min=1.e-19)
         fmt = ("({prefix:s}amplitude*{prefix:s}sigma)/"


### PR DESCRIPTION
#### Description
The current definition of the Damped Harmonic Oscillator lineshape fails for negative values of the independent variable, `x`. This PR fixes the issue in the `dho` function in lineshapes.py, and uses an analytic expression for the function value when `x=0`. This should work for all values of `gamma` and `sigma`. The default value of `center` is changed to 1, since a zero value makes the function zero for all `x`. In the DampedHarmonicOscillatorModel, the minimum value of `center` is set to 0.

This bug has been discussed in the [LMFIT Mailing List](https://groups.google.com/g/lmfit-py/c/6v2wxb3OSRc/m/Uwyv9mHhAAAJ).

###### Type of Changes
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples

###### Tested on
Python: 3.8.10 | packaged by conda-forge | (default, May 10 2021, 22:58:09) 
[Clang 11.1.0 ]

lmfit: 1.0.2.post110+geb5f9c1, scipy: 1.5.4, numpy: 1.20.3, asteval: 0.9.23, uncertainties: 3.1.6

###### Verification 
Have you
- [ ] included docstrings that follow PEP 257?
No changes to the docstrings are required.
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [ ] verified that the documentation builds locally?
No changes to the documentation were made.
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
There are no relevant tests in the existing test suite to update.
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
No changes to the documentation required.
- [ ] added an example?
This does not extend the documented functionality of the `dho` function.
