### PR TITLE
FIX: make sure `spercent` is defined

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -11,6 +11,15 @@ significant to the use and behavior of the library. This is not meant
 to be a comprehensive list of changes. For such a complete record,
 consult the `lmfit GitHub repository`_.
 
+.. _whatsnew_104_label:
+
+Version 1.0.4 Release Notes (unreleased)
+========================================
+
+Bug fixes/enhancements:
+
+- make sure variable ``spercent`` is always defined in ``params_html_table`` functions (Issue #768, PR #770)
+
 
 .. _whatsnew_103_label:
 

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -311,12 +311,13 @@ def params_html_table(params):
         rows = [par.name, gformat(par.value)]
         if has_err:
             serr = ''
+            spercent = ''
             if par.stderr is not None:
                 serr = gformat(par.stderr)
                 try:
                     spercent = f'({abs(par.stderr/par.value):.2%})'
                 except ZeroDivisionError:
-                    spercent = ''
+                    pass
             rows.extend([serr, spercent])
         rows.extend((par.init_value, gformat(par.min),
                      gformat(par.max), f'{par.vary}'))
@@ -325,7 +326,6 @@ def params_html_table(params):
             if par.expr is not None:
                 expr = par.expr
             rows.append(expr)
-
         if has_brute:
             brute_step = 'None'
             if par.brute_step is not None:

--- a/tests/test_printfuncs.py
+++ b/tests/test_printfuncs.py
@@ -7,7 +7,8 @@ from lmfit import (Minimizer, Parameters, ci_report, conf_interval, fit_report,
                    report_ci, report_fit)
 from lmfit.lineshapes import gaussian
 from lmfit.models import GaussianModel
-from lmfit.printfuncs import alphanumeric_sort, getfloat_attr, gformat
+from lmfit.printfuncs import (alphanumeric_sort, fitreport_html_table,
+                              getfloat_attr, gformat)
 
 np.random.seed(0)
 
@@ -325,6 +326,25 @@ def test_report_zero_value_spercent(fitresult):
     indx = [i for i, val in enumerate(html_params_split) if 'center' in val][0]
     assert '%' not in html_params_split[indx]
     assert '%' in html_params_split[indx+1]
+
+
+@pytest.mark.skipif(not lmfit.minimizer.HAS_EMCEE, reason="requires emcee v3")
+def test_spercent_html_table():
+    """Regression test for GitHub Issue #768."""
+    np.random.seed(2021)
+    x = np.random.uniform(size=100)
+    y = x + 0.1 * np.random.uniform(size=x.size)
+
+    def res(par, x, y):
+        return y - par['k'] * x + par['b']
+
+    params = lmfit.Parameters()
+    params.add('b', 0, vary=False)
+    params.add('k', 1)
+
+    fitter = lmfit.Minimizer(res, params, fcn_args=(x, y))
+    fit_res = fitter.minimize(method='emcee', steps=5)
+    fitreport_html_table(fit_res)
 
 
 def test_ci_report(confidence_interval):

--- a/tests/test_stepmodel.py
+++ b/tests/test_stepmodel.py
@@ -4,6 +4,7 @@ from lmfit.models import ConstantModel, StepModel
 
 
 def get_data():
+    np.random.seed(2021)
     x = np.linspace(0, 10, 201)
     dat = np.ones_like(x)
     dat[:48] = 0.0


### PR DESCRIPTION
#### Description
This fixes the issue reported in #768 regarding the undefined `spercent` variable.

###### Type of Changes
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples

###### Tested on
Python: 3.9.9 (main, Nov 16 2021, 07:21:43)
[Clang 11.0.3 (clang-1103.0.32.62)]

lmfit: 1.0.3.post6+g1b9a88f, scipy: 1.7.3, numpy: 1.21.4, asteval: 0.9.25, uncertainties: 3.1.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [ ] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
