### PR TITLE
ENH: initialize a few more MinimizerResult attributes

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -717,6 +717,9 @@ class Minimizer:
         result.call_kws = {}
         result.errorbars = False
         result.aborted = False
+        result.success = True
+        result.covar = None
+
         for name, par in self.result.params.items():
             par.stderr = None
             par.correl = None


### PR DESCRIPTION
#### Description
This PR initializes a few more attributes of the `MinimizerResult` class, as discussed on the [mailinglist](https://groups.google.com/g/lmfit-py/c/8o0gezZqs-M/m/Y5M-74inBQAJ).

###### Type of Changes
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.9.9 (main, Nov 16 2021, 07:21:43)
[Clang 11.0.3 (clang-1103.0.32.62)]

lmfit: 1.0.3.post10+ga7298d4, scipy: 1.7.3, numpy: 1.21.4, asteval: 0.9.25, uncertainties: 3.1.6

###### Verification <!-- (delete not applicable items) -->
Have you
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?