### PR TITLE
Improve performance of emcee

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -21,7 +21,7 @@ Bug fixes/enhancements:
 - make sure variable ``spercent`` is always defined in ``params_html_table`` functions (reported by @MySlientWind; Issue #768, PR #770)
 - always initialize the variables ``success`` and ``covar`` the ``MinimizerResult`` (reported by Marc W. Pound; PR #771)
 - build package following PEP517/PEP518; use pyproject.toml and setup.cfg; leave setup.py for now (PR #777)
-
+- improve speed of emcee fitting (PR #781)
 
 .. _whatsnew_103_label:
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1072,7 +1072,7 @@ class Minimizer:
             The names of the parameters that are varying.
         bounds : numpy.ndarray
             Lower and upper bounds of parameters, with shape
-            ``(nvarys, 2)``.
+            ``(2, nvarys)``.
         userargs : tuple, optional
             Extra positional arguments required for user objective function.
         userkws : dict, optional
@@ -1099,7 +1099,7 @@ class Minimizer:
         # the comparison has to be done on theta and bounds. DO NOT inject theta
         # values into Parameters, then compare Parameters values to the bounds.
         # Parameters values are clipped to stay within bounds.
-        if np.any(theta > bounds[:, 1]) or np.any(theta < bounds[:, 0]):
+        if np.any(theta > bounds[1, :]) or np.any(theta < bounds[0, :]):
             return -np.inf
         for name, val in zip(var_names, theta):
             params[name].value = val
@@ -1131,7 +1131,7 @@ class Minimizer:
                 # marginalise over a constant data uncertainty
                 __lnsigma = params['__lnsigma'].value
                 c = np.log(2 * np.pi) + 2 * __lnsigma
-                lnprob = -0.5 * np.sum((lnprob / np.exp(__lnsigma)) ** 2 + c)
+                lnprob = -0.5 * (np.sum((lnprob / np.exp(__lnsigma)) ** 2) + c * lnprob.size)
             else:
                 lnprob = -0.5 * (lnprob * lnprob).sum()
         else:
@@ -1392,7 +1392,7 @@ class Minimizer:
 
         # function arguments for the log-probability functions
         # these values are sent to the log-probability functions by the sampler.
-        lnprob_args = (self.userfcn, params, result.var_names, bounds)
+        lnprob_args = (self.userfcn, params, result.var_names, np.ascontiguousarray(bounds.T))
         lnprob_kwargs = {'is_weighted': is_weighted,
                          'float_behavior': float_behavior,
                          'userargs': self.userargs,


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

This PR improves the performance of emcee by improving the internal `_lnprob` method.

* The `bounds` argument is passed in transposed format. This aligns better (assuming standard numpy memory layout) with the operation in `_lnprob` performed with the `bounds`.
* Move addition of the variable `c` out of the `sum`

All changes are internal, the public api is unchanged.

There are more options to improve performance, but these require more extensive changes or changes to the public api.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

Python: 3.9.9 (tags/v3.9.9:ccb0e6a, Nov 15 2021, 18:08:50) [MSC v.1929 64 bit (AMD64)]

lmfit: 1.0.2+29.gcd28293.dirty, scipy: 1.7.0, numpy: 1.21.5, asteval: 0.9.25, uncertainties: 3.1.5

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257? Public api unchanged
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list? None found
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [ ] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes? Not required
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example? Only performance improvements
