### PR TITLE
enabled use of different independent_vars... 

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -21,6 +21,7 @@ Bug fixes/enhancements:
 - make sure variable ``spercent`` is always defined in ``params_html_table`` functions (reported by @MySlientWind; Issue #768, PR #770)
 - always initialize the variables ``success`` and ``covar`` the ``MinimizerResult`` (reported by Marc W. Pound; PR #771)
 - build package following PEP517/PEP518; use ``pyproject.toml`` and ``setup.cfg``; leave ``setup.py`` for now (PR #777)
+- components used to create a ``CompositeModel`` can now have different independent variables (@Julian-Hochhaus; Discussion #787; PR #788))
 
 
 Deprecations:

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1094,7 +1094,7 @@ class CompositeModel(Model):
 
         Notes
         -----
-        The two models must use the same independent variable.
+        The two models can use different independent variables.
 
         """
         if not isinstance(left, Model):
@@ -1116,9 +1116,11 @@ class CompositeModel(Model):
                         "use distinct names.")
             raise NameError(msg)
 
-        # we assume that all the sub-models have the same independent vars
+        # the unique ``independent_vars`` of the left and right model are
+        # combined to ``independent_vars`` of the ``CompositeModel``
         if 'independent_vars' not in kws:
-            kws['independent_vars'] = self.left.independent_vars
+            ivars = self.left.independent_vars + self.right.independent_vars
+            kws['independent_vars'] = list(np.unique(ivars))
         if 'nan_policy' not in kws:
             kws['nan_policy'] = self.left.nan_policy
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1247,6 +1247,21 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         self.assertTrue(abs(result.params['a'].value - 2.0) < 0.05)
         self.assertTrue(abs(result.params['b'].value - 3.0) < 0.41)
 
+    def test_different_independent_vars_composite_modeld(self):
+        """Regression test for different independent variables in CompositeModel.
+
+        See: https://github.com/lmfit/lmfit-py/discussions/787
+
+        """
+        def two_independent_vars(y, z, a):
+            return a * y + z
+
+        BackgroundModel = Model(two_independent_vars,
+                                independent_vars=["y", "z"], prefix="yz_")
+        PeakModel = Model(gaussian, independent_vars=["x"], prefix="x_")
+        CompModel = BackgroundModel + PeakModel
+        assert CompModel.independent_vars == ['x', 'y', 'z']
+
 
 class TestLinear(CommonTests, unittest.TestCase):
 


### PR DESCRIPTION
... in Composite Model
The independent_vars in the CompositeModel are now no longer only the independent_vars of the left model. 
Now, the independent_vars of the left model and right model are both passed to the independent_vars of the CompositeModel.
To reach that, I simply changed l.1120 in `model.py` from:

```
if 'independent_vars' not in kws:

    kws['independent_vars'] = self.left.independent_vars
```
to :

```      
if 'independent_vars' not in kws:

    kws['independent_vars'] = list(dict.fromkeys([*self.left.independent_vars, *self.right.independent_vars]))
```

This fix solves the problem described in [detail here](https://github.com/lmfit/lmfit-py/discussions/787).




###### Type of Changes
- [x] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.8.3 (default, Jul  2 2020, 16:21:59)
[GCC 7.3.0]

lmfit: 1.0.3.post31+gb930dde.d20220613, scipy: 1.5.0, numpy: 1.18.5, asteval: 0.9.26, uncertainties: 3.1.6

###### Verification 
Have you
- [x] included docstrings that follow PEP 257? --> only small modification in Docstring (CompositeModel--> NOTES)
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example? 
