### PR TITLE
always save function name and importer, load saved function with dill…

### DIFF
--- a/doc/model.rst
+++ b/doc/model.rst
@@ -596,11 +596,11 @@ saving a model will always save the *name* of the model function. The
 contain a dictionary of function definitions with the function names as
 keys and function objects as values. If one of the dictionary keys matches
 the saved name, the corresponding function object will be used as the model
-function. If it is not found by ne=ame, and if ``dill`` was used to save
+function. If it is not found by name, and if ``dill`` was used to save
 the model, and if ``dill`` is available at run-time, the ``dill``-encoded
 function will try to be used.  Note that this approach will generally allow
-you to save a model that can be used by the same other installation of the
-same version of Python, but may not work across versions.  For preserving
+you to save a model that can be used by another installation of the
+same version of Python, but may not work across Python versions.  For preserving
 fits for extended periods of time (say, archiving for documentation of
 scientific results), we strongly encourage you to save the full Python code
 used for the model function and fit process.

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -589,15 +589,22 @@ emphasized that if you are willing to save or reuse the definition of the
 model function as Python code, then saving the Parameters and rest of the
 components that make up a model presents no problem.
 
-If the ``dill`` package is installed, the model function will be saved using
-it. But because saving the model function is not always reliable, saving a
-model will always save the *name* of the model function. The :func:`load_model`
-takes an optional :attr:`funcdefs` argument that can contain a dictionary of
-function definitions with the function names as keys and function objects as
-values. If one of the dictionary keys matches the saved name, the
-corresponding function object will be used as the model function. With this
-approach, if you save a model and can provide the code used for the model
-function, the model can be saved and reliably reloaded and used.
+If the ``dill`` package is installed, the model function will also be saved
+using it. But because saving the model function is not always reliable,
+saving a model will always save the *name* of the model function. The
+:func:`load_model` takes an optional :attr:`funcdefs` argument that can
+contain a dictionary of function definitions with the function names as
+keys and function objects as values. If one of the dictionary keys matches
+the saved name, the corresponding function object will be used as the model
+function. If it is not found by ne=ame, and if ``dill`` was used to save
+the model, and if ``dill`` is available at run-time, the ``dill``-encoded
+function will try to be used.  Note that this approach will generally allow
+you to save a model that can be used by the same other installation of the
+same version of Python, but may not work across versions.  For preserving
+fits for extended periods of time (say, archiving for documentation of
+scientific results), we strongly encourage you to save the full Python code
+used for the model function and fit process.
+
 
 .. autofunction:: save_model
 

--- a/doc/parameters.rst
+++ b/doc/parameters.rst
@@ -81,6 +81,16 @@ The :class:`Parameters` class
     .. automethod:: load
 
 
+.. _dumpload_warning:
+
+.. warning::
+
+   Saving Parameters with user-added functions to the ``_asteval``
+   interpreter using :meth::`dump` and :meth:`dumps` may not be easily
+   recovered with the :meth:`load` and :meth:`loads`. See
+   :ref:`model_saveload_sec` for further discussion.
+
+
 Simple Example
 ==============
 


### PR DESCRIPTION
…-encoded data as a last resort, update doc

<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->


This changes the order of loading of functions in `jsonutils` so that loading with `dill` is the last resort.  That is, loading a function will now always try to use the function name and import module first.  This should do a better job of working across Python versions, and sort of helps to address #792, or at least give a clearer warning message for when loading a dumped Parameters, Model, or ModelResult does not work.


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
