### PR TITLE
Draft: Improve handling of covariance calculation

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -25,6 +25,7 @@ Bug fixes/enhancements:
 - fixed function definition for ``StepModel(form='linear')``, was not consistent with the other ones. (@matpompili; PR #794)
 - fixed height factor for ``Gaussian2dModel``, was not correct. (@matpompili; PR #795)
 - added ``Pearson4`` fitting model
+- for covariances with negative diagonal elements, we set the covariance to ``None`` (PR #813)
 
 Deprecations:
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -789,9 +789,14 @@ class Minimizer:
             hessian_ndt = Hfun(fvars)
             cov_x = inv(hessian_ndt) * 2.0
         except (LinAlgError, ValueError):
-            return None
+            nvar = len(fvars)
+            cov_x = np.full((nvar, nvar), -1, dtype=np.float64)
         finally:
             self.result.nfev = nfev
+
+        if cov_x.diagonal().min() < 0:
+            # we know the calculated covariance is incorrect, so we set the covariance to None
+            cov_x = None
 
         # restore original values
         for name in self.result.var_names:

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -788,15 +788,14 @@ class Minimizer:
             Hfun = ndt.Hessian(self.penalty, step=1.e-4)
             hessian_ndt = Hfun(fvars)
             cov_x = inv(hessian_ndt) * 2.0
+
+            if cov_x.diagonal().min() < 0:
+                # we know the calculated covariance is incorrect, so we set the covariance to None
+                cov_x = None
         except (LinAlgError, ValueError):
-            nvar = len(fvars)
-            cov_x = np.full((nvar, nvar), -1, dtype=np.float64)
+            cov_x = None
         finally:
             self.result.nfev = nfev
-
-        if cov_x.diagonal().min() < 0:
-            # we know the calculated covariance is incorrect, so we set the covariance to None
-            cov_x = None
 
         # restore original values
         for name in self.result.var_names:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

In this PR we make two changes to the calculation of the covariance

* If one of the diagonal elements of the calculated covariance is negative we know the result is not good, and we set the covariance to `None`. The `None` value was already used when no covariance calculation was made, or for other issues with the calculation, so this should have limited impact on users.
* In case of a `LinAlgError`  or `ValueError` in the calculation a `None` is returned for the covariance (as before) and the original parameter values are restored. 

A discussion on the changes is in #812. Because of the first change, the warnings  generated when the square root of the negative diagonal elements of the covariance matrix are taken have been removed. If this behaviour is not acceptable, I suggest adding a dedicated warning, e.g.
```
     if cov_x.diagonal().min() < 0:
            # we know the calculated covariance is incorrect, so we set the covariance to None
            warnings.warn('calculated covariance has negative elements, setting to None', CovarianceWarning)
            cov_x = None
```
###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.10.8 (tags/v3.10.8:aaaf517, Oct 11 2022, 16:50:30) [MSC v.1933 64 bit (AMD64)]

lmfit: 1.0.3, scipy: 1.9.2, numpy: 1.23.4, asteval: 0.9.27, uncertainties: 3.1.7

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257? 
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally? Documentation does not build (error: `FileNotFoundError: test_splinepeak.dat not found.`)
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
