### PR TITLE
Fix deprecation warnings in the tests of lmfit.lineshapes

### DIFF
--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -436,8 +436,8 @@ def step(x, amplitude=1.0, center=0.0, sigma=1.0, form='linear'):
         out = 0.5 + arctan(out)/pi
     elif form == 'linear':
         out = out + 0.5
-        out[where(out < 0)] = 0.0
-        out[where(out > 1)] = 1.0
+        out[out < 0] = 0.0
+        out[out > 1] = 1.0
     else:
         msg = (f"Invalid value ('{form}') for argument 'form'; should be one "
                "of 'erf', 'logistic', 'atan', 'arctan', or 'linear'.")
@@ -475,10 +475,10 @@ def rectangle(x, amplitude=1.0, center1=0.0, sigma1=1.0,
     elif form in ('atan', 'arctan'):
         out = (arctan(arg1) + arctan(arg2))/pi
     elif form == 'linear':
-        arg1[where(arg1 < 0)] = 0.0
-        arg1[where(arg1 > 1)] = 1.0
-        arg2[where(arg2 > 0)] = 0.0
-        arg2[where(arg2 < -1)] = -1.0
+        arg1[arg1 < 0] = 0.0
+        arg1[arg1 > 1] = 1.0
+        arg2[arg2 > 0] = 0.0
+        arg2[arg2 < -1] = -1.0
         out = arg1 + arg2
     else:
         msg = (f"Invalid value ('{form}') for argument 'form'; should be one "


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

This PR fixes some deprecation warnings in the tests for `lmfit.lineshapes`. The warnings are of the type:
```
tests/test_lineshapes.py::test_x_float_value[rectangle]
  c:\projects\misc\lmfit-py\lmfit\lineshapes.py:478: DeprecationWarning: Calling nonzero on 0d arrays is deprecated, as it behaves surprisingly. Use `atleast_1d(cond).nonzero()` if the old behavior was intended. If the context of this warning is of the form `arr[nonzero(cond)]`, just use `arr[cond]`.
    arg1[where(arg1 < 0)] = 0.0
```
###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.10.8 (tags/v3.10.8:aaaf517, Oct 11 2022, 16:50:30) [MSC v.1933 64 bit (AMD64)]

lmfit: 1.0.3, scipy: 1.9.2, numpy: 1.23.4, asteval: 0.9.27, uncertainties: 3.1.7

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257? Not relevant
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list? No links available
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally? No documentation changes
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes? Not relevant
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)? Not relevant
- [ ] added an example? Not relevant
