### PR TITLE
fix 'linear' mode for RectangleModel (lmfit#815)

### DIFF
--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -1,7 +1,7 @@
 """Basic model lineshapes and distribution functions."""
 
-from numpy import (arctan, copysign, cos, exp, isclose, isnan, log, log1p, pi,
-                   real, sin, sqrt, where)
+from numpy import (arctan, copysign, cos, exp, isclose, isnan, log, log1p,
+                   maximum, minimum, pi, real, sin, sqrt, where)
 from scipy.special import betaln as betalnfcn
 from scipy.special import erf, erfc
 from scipy.special import gamma as gamfcn
@@ -431,13 +431,11 @@ def step(x, amplitude=1.0, center=0.0, sigma=1.0, form='linear'):
     if form == 'erf':
         out = 0.5*(1 + erf(out))
     elif form == 'logistic':
-        out = (1. - 1./(1. + exp(out)))
+        out = 1. - 1./(1. + exp(out))
     elif form in ('atan', 'arctan'):
         out = 0.5 + arctan(out)/pi
     elif form == 'linear':
-        out = out + 0.5
-        out[out < 0] = 0.0
-        out[out > 1] = 1.0
+        out = minimum(1, maximum(0, out + 0.5))
     else:
         msg = (f"Invalid value ('{form}') for argument 'form'; should be one "
                "of 'erf', 'logistic', 'atan', 'arctan', or 'linear'.")
@@ -471,15 +469,11 @@ def rectangle(x, amplitude=1.0, center1=0.0, sigma1=1.0,
     if form == 'erf':
         out = 0.5*(erf(arg1) + erf(arg2))
     elif form == 'logistic':
-        out = (1. - 1./(1. + exp(arg1)) - 1./(1. + exp(arg2)))
+        out = 1. - 1./(1. + exp(arg1)) - 1./(1. + exp(arg2))
     elif form in ('atan', 'arctan'):
         out = (arctan(arg1) + arctan(arg2))/pi
     elif form == 'linear':
-        arg1[arg1 < 0] = 0.0
-        arg1[arg1 > 1] = 1.0
-        arg2[arg2 > 0] = 0.0
-        arg2[arg2 < -1] = -1.0
-        out = arg1 + arg2
+        out = 0.5*(minimum(1, maximum(-1, arg1)) + minimum(1, maximum(-1, arg2)))
     else:
         msg = (f"Invalid value ('{form}') for argument 'form'; should be one "
                "of 'erf', 'logistic', 'atan', 'arctan', or 'linear'.")

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1480,7 +1480,7 @@ class StepModel(Model):
         & f(x; A, \mu, \sigma, {\mathrm{form={}'linear{}'}})  & = A \min{[1, \max{(0, \alpha + 1/2)}]} \\
         & f(x; A, \mu, \sigma, {\mathrm{form={}'arctan{}'}})  & = A [1/2 + \arctan{(\alpha)}/{\pi}] \\
         & f(x; A, \mu, \sigma, {\mathrm{form={}'erf{}'}})     & = A [1 + {\operatorname{erf}}(\alpha)]/2 \\
-        & f(x; A, \mu, \sigma, {\mathrm{form={}'logistic{}'}})& = A [1 - \frac{1}{1 + e^{\alpha}} ]
+        & f(x; A, \mu, \sigma, {\mathrm{form={}'logistic{}'}})& = A \left[1 - \frac{1}{1 + e^{\alpha}} \right]
         \end{eqnarray*}
 
     where :math:`\alpha = (x - \mu)/{\sigma}`.
@@ -1535,10 +1535,10 @@ class RectangleModel(Model):
         :nowrap:
 
         \begin{eqnarray*}
-        &f(x; A, \mu, \sigma, {\mathrm{form={}'linear{}'}})   &= A \{ \min{[1, \max{(0, \alpha_1)}]} + \min{[-1, \max{(0, \alpha_2)}]} \} \\
+        &f(x; A, \mu, \sigma, {\mathrm{form={}'linear{}'}})   &= A \{ \min{[1, \max{(-1, \alpha_1)}]} + \min{[1, \max{(-1, \alpha_2)}]} \}/2 \\
         &f(x; A, \mu, \sigma, {\mathrm{form={}'arctan{}'}})   &= A [\arctan{(\alpha_1)} + \arctan{(\alpha_2)}]/{\pi} \\
-        &f(x; A, \mu, \sigma, {\mathrm{form={}'erf{}'}})      &= A [{\operatorname{erf}}(\alpha_1) + {\operatorname{erf}}(\alpha_2)]/2 \\
-        &f(x; A, \mu, \sigma, {\mathrm{form={}'logistic{}'}}) &= A [1 - \frac{1}{1 + e^{\alpha_1}} - \frac{1}{1 + e^{\alpha_2}} ]
+        &f(x; A, \mu, \sigma, {\mathrm{form={}'erf{}'}})      &= A \left[{\operatorname{erf}}(\alpha_1) + {\operatorname{erf}}(\alpha_2)\right]/2 \\
+        &f(x; A, \mu, \sigma, {\mathrm{form={}'logistic{}'}}) &= A \left[1 - \frac{1}{1 + e^{\alpha_1}} - \frac{1}{1 + e^{\alpha_2}} \right]
         \end{eqnarray*}
 
 

--- a/tests/test_lineshapes.py
+++ b/tests/test_lineshapes.py
@@ -73,13 +73,8 @@ def test_x_float_value(lineshape):
                 if par_name != 'x']:
         fnc_args.append(sig.parameters[par].default)
 
-    if lineshape in ('step', 'rectangle'):
-        msg = r"'float' object does not support item assignment"
-        with pytest.raises(TypeError, match=msg):
-            fnc_output = func(*fnc_args)
-    else:
-        fnc_output = func(*fnc_args)
-        assert isinstance(fnc_output, float)
+    fnc_output = func(*fnc_args)
+    assert isinstance(fnc_output, float)
 
 
 rising_form = ['erf', 'logistic', 'atan', 'arctan', 'linear', 'unknown']
@@ -109,6 +104,18 @@ def test_form_argument_step_rectangle(form, lineshape):
     else:
         fnc_output = func(*fnc_args)
         assert len(fnc_output) == len(xvals)
+
+
+@pytest.mark.parametrize('form', rising_form)
+@pytest.mark.parametrize('lineshape', ['step', 'rectangle'])
+def test_value_step_rectangle(form, lineshape):
+    """Test values at mu1/mu2 for step- and rectangle-functions."""
+    func = getattr(lmfit.lineshapes, lineshape)
+    # at position mu1 we should be at A/2
+    assert_almost_equal(func(0), 0.5)
+    # for a rectangular shape we have the same at mu2
+    if lineshape == 'rectangle':
+        assert_almost_equal(func(1), 0.5)
 
 
 thermal_form = ['bose', 'maxwell', 'fermi', 'Bose-Einstein', 'unknown']


### PR DESCRIPTION
#### Description

Fix the linear mode for RectangleModel. Also update the documentation and update the tests. (#815)

Tests:
  * Using numpy functions now allows lineshape.rectangle to handle single floats, so the tests needed to be updated
  * added tests for step and rectangle to make sure we get A/2 at mu1 (and mu2)

Docs:
  * update to reflect code and make brackets in LaTeX equations a bit nicer

###### Type of Changes
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

Python: 3.10.8 (main, Oct 13 2022, 09:48:40) [Clang 14.0.0 (clang-1400.0.29.102)]

lmfit: 1.0.0.post473+g125c830.d20221024, scipy: 1.9.3, numpy: 1.23.4, asteval: 0.9.27, uncertainties: 3.1.7


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
