### PR TITLE
Correct init_vals

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -2215,8 +2215,7 @@ class Minimizer:
         result.method = 'dual_annealing'
         self.set_max_nfev(max_nfev, 200000*(result.nvarys+1))
 
-        da_kws = dict(maxiter=1000, local_search_options={},
-                      initial_temp=5230.0, restart_temp_ratio=2e-05,
+        da_kws = dict(initial_temp=5230.0, restart_temp_ratio=2e-05,
                       visit=2.62, accept=-5.0, maxfun=2*self.max_nfev,
                       seed=None, no_local_search=False, callback=None,
                       x0=None)

--- a/tests/test_NIST_Strd.py
+++ b/tests/test_NIST_Strd.py
@@ -118,7 +118,7 @@ options:
 --------
   -m  name of fitting method.  One of:
           leastsq, nelder, powell, lbfgsb, bfgs,
-          tnc, cobyla, slsqp, cg, newto-cg
+          tnc, cobyla, slsqp, cg, newton-cg
       leastsq (Levenberg-Marquardt) is the default
 """
     return usage
@@ -183,115 +183,114 @@ def RunNIST_Model(model):
     out1 = NIST_Dataset(model, start='start1', plot=False, verbose=False)
     out2 = NIST_Dataset(model, start='start2', plot=False, verbose=False)
     assert(out1 or out2)
-    return out1 or out2
 
 
 def test_Bennett5():
-    return RunNIST_Model('Bennett5')
+    RunNIST_Model('Bennett5')
 
 
 def test_BoxBOD():
-    return RunNIST_Model('BoxBOD')
+    RunNIST_Model('BoxBOD')
 
 
 def test_Chwirut1():
-    return RunNIST_Model('Chwirut1')
+    RunNIST_Model('Chwirut1')
 
 
 def test_Chwirut2():
-    return RunNIST_Model('Chwirut2')
+    RunNIST_Model('Chwirut2')
 
 
 def test_DanWood():
-    return RunNIST_Model('DanWood')
+    RunNIST_Model('DanWood')
 
 
 def test_ENSO():
-    return RunNIST_Model('ENSO')
+    RunNIST_Model('ENSO')
 
 
 def test_Eckerle4():
-    return RunNIST_Model('Eckerle4')
+    RunNIST_Model('Eckerle4')
 
 
 def test_Gauss1():
-    return RunNIST_Model('Gauss1')
+    RunNIST_Model('Gauss1')
 
 
 def test_Gauss2():
-    return RunNIST_Model('Gauss2')
+    RunNIST_Model('Gauss2')
 
 
 def test_Gauss3():
-    return RunNIST_Model('Gauss3')
+    RunNIST_Model('Gauss3')
 
 
 def test_Hahn1():
-    return RunNIST_Model('Hahn1')
+    RunNIST_Model('Hahn1')
 
 
 def test_Kirby2():
-    return RunNIST_Model('Kirby2')
+    RunNIST_Model('Kirby2')
 
 
 def test_Lanczos1():
-    return RunNIST_Model('Lanczos1')
+    RunNIST_Model('Lanczos1')
 
 
 def test_Lanczos2():
-    return RunNIST_Model('Lanczos2')
+    RunNIST_Model('Lanczos2')
 
 
 def test_Lanczos3():
-    return RunNIST_Model('Lanczos3')
+    RunNIST_Model('Lanczos3')
 
 
 def test_MGH09():
-    return RunNIST_Model('MGH09')
+    RunNIST_Model('MGH09')
 
 
 def test_MGH10():
-    return RunNIST_Model('MGH10')
+    RunNIST_Model('MGH10')
 
 
 def test_MGH17():
-    return RunNIST_Model('MGH17')
+    RunNIST_Model('MGH17')
 
 
 def test_Misra1a():
-    return RunNIST_Model('Misra1a')
+    RunNIST_Model('Misra1a')
 
 
 def test_Misra1b():
-    return RunNIST_Model('Misra1b')
+    RunNIST_Model('Misra1b')
 
 
 def test_Misra1c():
-    return RunNIST_Model('Misra1c')
+    RunNIST_Model('Misra1c')
 
 
 def test_Misra1d():
-    return RunNIST_Model('Misra1d')
+    RunNIST_Model('Misra1d')
 
 
 def test_Nelson():
-    return RunNIST_Model('Nelson')
+    RunNIST_Model('Nelson')
 
 
 def test_Rat42():
-    return RunNIST_Model('Rat42')
+    RunNIST_Model('Rat42')
 
 
 def test_Rat43():
-    return RunNIST_Model('Rat43')
+    RunNIST_Model('Rat43')
 
 
 def test_Roszman1():
-    return RunNIST_Model('Roszman1')
+    RunNIST_Model('Roszman1')
 
 
 def test_Thurber():
-    return RunNIST_Model('Thurber')
+    RunNIST_Model('Thurber')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

This ensures that `result.init_vals` is the "user" / "external" values, and adds a new attribute `result._init_vals_internal` to store the initial "internal" values which are needed as initial values.

This addresses #820 


When running tests, I saw some deprecations and addressed some of those, but it seems there are other deprecation warnings that might need more work.
 


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

>>> import sys, lmfit, numpy, scipy, asteval, uncertainties
>>> print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
...       .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
...       asteval.__version__, uncertainties.__version__))
Python: 3.9.13 | packaged by conda-forge | (main, May 27 2022, 17:00:52)
[Clang 13.0.1 ]

lmfit: 1.0.3.post69+g99952a2.d20221031, scipy: 1.9.0, numpy: 1.23.2, asteval: 0.9.27.post12+ge349473, uncertainties: 3.1.7

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?

closes #820 
