### PR TITLE
Fix documentation typos

### DIFF
--- a/doc/constraints.rst
+++ b/doc/constraints.rst
@@ -13,7 +13,7 @@ highly desirable to place mathematical constraints on parameter values.
 For example, one might want to require that two Gaussian peaks have the
 same width, or have amplitudes that are constrained to add to some value.
 Of course, one could rewrite the objective or model function to place such
-requirements, but this is somewhat error prone, and limits the flexibility
+requirements, but this is somewhat error-prone, and limits the flexibility
 so that exploring constraints becomes laborious.
 
 To simplify the setting of constraints, Parameters can be assigned a

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -476,7 +476,7 @@ be used to abort a fit.
    :type  resid:  numpy.ndarray
    :param args:  Positional arguments. Must match ``args`` argument to :func:`minimize`
    :param kws:   Keyword arguments. Must match ``kws`` argument to :func:`minimize`
-   :return:      Residual array (generally ``data-model``) to be minimized in the least-squares sense.
+   :return:      Iteration abort flag.
    :rtype:    None for normal behavior, any value like ``True`` to abort the fit.
 
 

--- a/doc/fitting.rst
+++ b/doc/fitting.rst
@@ -129,7 +129,7 @@ Choosing Different Fitting Methods
 By default, the `Levenberg-Marquardt
 <https://en.wikipedia.org/wiki/Levenberg-Marquardt_algorithm>`_ algorithm is
 used for fitting. While often criticized, including the fact it finds a
-*local* minima, this approach has some distinct advantages. These include
+*local* minimum, this approach has some distinct advantages. These include
 being fast, and well-behaved for most curve-fitting needs, and making it
 easy to estimate uncertainties for and correlations between pairs of fit
 variables, as discussed in :ref:`fit-results-label`.

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -378,7 +378,7 @@ Parameters if the supplied default value was a valid number (but not
 .. jupyter-execute::
 
     def decay2(t, tau, N=10, check_positive=False):
-        if check_small:
+        if check_positive:
             arg = abs(t)/max(1.e-9, abs(tau))
         else:
             arg = t/tau


### PR DESCRIPTION
#### Description
I noticed some typos on my readthrough of the documentation and decided to fix them.

Two were just minor spelling mistakes, but the erroneous return description of `iter_cb()` and the inconsistent variable name in the `decay2()` example were quite confusing to me when I first read them.

###### Type of Changes
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples

###### Tested on
```
Python: 3.9.13 | packaged by conda-forge | (main, May 27 2022, 16:50:36) [MSC v.1929 64 bit (AMD64)]

lmfit: 0.0.post2650+gcda59fc, scipy: 1.9.3, numpy: 1.23.4, asteval: 0.9.27, uncertainties: 3.1.7
```

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
  (Only changed `rst` files.)
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
  (Does not apply.)
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [ ] verified that existing tests pass locally?
  (Only changed documentation.)
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
  I tried, I really did. Since `CONTRIBUTING.md` does not specify with which target to build, I did `make html`. It gets throgh almost everything (building `whatsnew`, showing `100%`) and then fails because it treats the warning `WARNING:root:Pandas support in corner is deprecated; use ArviZ directly` as an error. Since I am quite certain that this is unrelated to my edits, I decided to open the pull request anyways. Not sure if this is a bug or something to do with my setup..
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
  Not sure if you consider four commits with separate messages more useful or a single commit cleaner. If you ask me, I will squash.
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
  (Does not apply.)
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
  Not sure if minor documentation fixes warrant being mentioned in the release notes. Will edit if you ask me to.
- [ ] added an example?
  (Does not apply.)
