### PR TITLE
Include residual in model result json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.1.0
+    rev: v3.2.2
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
@@ -22,8 +22,8 @@ repos:
     -   id: fix-encoding-pragma
         args: [--remove]
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+-   repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-deprecated, flake8-mutable]

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1656,7 +1656,7 @@ class ModelResult(Minimizer):
                      'ci_out', 'col_deriv', 'covar', 'errorbars', 'flatchain',
                      'ier', 'init_values', 'lmdif_message', 'message',
                      'method', 'nan_policy', 'ndata', 'nfev', 'nfree',
-                     'nvarys', 'redchi', 'rsquared', 'scale_covar',
+                     'nvarys', 'redchi', 'residual', 'rsquared', 'scale_covar',
                      'calc_covar', 'success', 'userargs', 'userkws', 'values',
                      'var_names', 'weights', 'user_options'):
 

--- a/tests/test_1variable.py
+++ b/tests/test_1variable.py
@@ -26,7 +26,7 @@ def linear_chisq(params, x, data, errs=None):
     if errs is not None:
         residuals = residuals/errs
 
-    return(residuals)
+    return residuals
 
 
 def test_1var():

--- a/tests/test_NIST_Strd.py
+++ b/tests/test_NIST_Strd.py
@@ -182,7 +182,7 @@ def RunNIST_Model(model):
 
     out1 = NIST_Dataset(model, start='start1', plot=False, verbose=False)
     out2 = NIST_Dataset(model, start='start2', plot=False, verbose=False)
-    assert(out1 or out2)
+    assert (out1 or out2)
 
 
 def test_Bennett5():

--- a/tests/test_model_saveload.py
+++ b/tests/test_model_saveload.py
@@ -144,7 +144,7 @@ def test_save_load_modelresult(dill):
     text = ''
     with open(SAVE_MODELRESULT) as fh:
         text = fh.read()
-    assert 12000 < len(text) < 15000  # depending on whether dill is present
+    assert 18000 < len(text) < 21000  # depending on whether dill is present
 
     # load the saved ModelResult from file and compare results
     result_saved = load_modelresult(SAVE_MODELRESULT)

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -360,7 +360,7 @@ def test_value_setter(parameter):
     par.value = -200.0  # below minimum
     assert_allclose(par.value, -100.0)
 
-    del(par._expr_eval)
+    del par._expr_eval
     par.value = 10.0
     assert_allclose(par.value, 10.0)
     assert hasattr(par, '_expr_eval')


### PR DESCRIPTION

<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
Good day to you!  

We do a lot of fits, and have plans to store them for later use in a database using the `dumps` method of `ModelResult`.

However, we have discovered that the JSON produced by `dumps` does not contain the `residual` field and so the ModelResult that we load from the JSON using `loads` does not properly represent the original for our purposes.  Behold:

```python
import numpy as np

from lmfit.model import Model, ModelResult
from lmfit.parameter import Parameters, Parameter

def mysine(x, amp, freq, shift):
    return amp * np.sin(x*freq + shift)

sinemodel = Model(mysine)
pars = sinemodel.make_params(amp=1, freq=0.25, shift=0)
pars['shift'].max = 1
pars['shift'].min = -1
pars['amp'].min = 0.0

xs = np.linspace(0,1)
ys = 0.5 + np.exp(-5*xs) + np.random.normal(scale=0.1, size=50)

original_result = sinemodel.fit(ys, pars, x=xs)
json_str = original_result.dumps()

restored_result = ModelResult(Model(mysine), Parameters())
restored_result.loads(json_str, funcdefs=dict(mysine=mysine))

print(original_result.params == restored_result.params)  # True
print(original_result.init_params == restored_result.init_params)  # True
print(type(original_result.residual))  # ndarray
print(type(restored_result.residual))  # NoneType



```

A 1-word addition to `dumps` method will include the residual in the JSON (`residual` is already a listed field in `loads`), and we wonder if you will accept this PR containing that single change.

Thus far I have only updated the single unit test case that was broken by this change.  If you would like me to provide additional test coverage for round-tripping model results through JSON, I am happy to do so.

Thank you for your time! 



###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
```
Python: 3.9.7 (default, Dec  2 2021, 13:20:29) 
[Clang 12.0.5 (clang-1205.0.22.11)]

lmfit: 1.0.3.post72+g60eedb0, scipy: 1.9.3, numpy: 1.23.4, asteval: 0.9.28, uncertainties: 3.1.7

```

