### PR TITLE
add calculation of dely for components of a composite model

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,8 +85,9 @@ stages:
             swig libmpc-dev
           displayName: 'Install dependencies'
         - script: |
-            python -m pip install --upgrade build pip wheel
-            python -m pip install asteval==0.9.22 numpy==1.18 scipy==1.4.0 uncertainties==3.1.4
+            python -m pip install --upgrade pip wheel
+            pip install setuptools==57.5.0
+            python -m pip install asteval==0.9.22 numpy==1.18 scipy==1.4.0 uncertainties==3.1.4 pytest coverage codecov flaky
           displayName: 'Install minimum required version of dependencies'
         - script: |
             python -m build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,8 +71,6 @@ stages:
             python.version: '3.7'
           Python38:
             python.version: '3.8'
-          Python39:
-            python.version: '3.9'
 
       steps:
         - task: UsePythonVersion@0
@@ -85,8 +83,7 @@ stages:
             swig libmpc-dev
           displayName: 'Install dependencies'
         - script: |
-            python -m pip install --upgrade pip wheel
-            pip install setuptools==57.5.0
+            python -m pip install --upgrade build pip wheel
             python -m pip install asteval==0.9.22 numpy==1.18 scipy==1.4.0 uncertainties==3.1.4 pytest coverage codecov flaky
           displayName: 'Install minimum required version of dependencies'
         - script: |

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -714,6 +714,17 @@ and ``bic``.
 
    numpy.ndarray of data to compare to model.
 
+.. attribute:: dely
+
+   numpy.ndarray of estimated uncertainties in the ``y`` values of the model
+   from :meth:`ModelResult.eval_uncertainty`  (see :ref:`eval_uncertainty_sec`).
+
+.. attribute:: dely_comps
+
+   a dictionary of estimated uncertainties in the ``y`` values of the model
+   components, from :meth:`ModelResult.eval_uncertainty` (see
+   :ref:`eval_uncertainty_sec`).
+
 .. attribute:: errorbars
 
    Boolean for whether error bars were estimated by fit.
@@ -822,6 +833,8 @@ and ``bic``.
    array, so that ``weights*(data - fit)`` is minimized in the
    least-squares sense.
 
+.. _eval_uncertainty_sec:
+
 Calculating uncertainties in the model function
 -----------------------------------------------
 
@@ -859,6 +872,21 @@ figure below.
                      label='3-$\sigma$ uncertainty band')
     plt.legend()
     plt.show()
+
+
+.. versionadded:: 1.0.4
+
+If the model is a composite built from multiple components, the
+:meth:`ModelResult.eval_uncertainty` method will evaluate the uncertainty of
+both the full model (often the sum of multiple components) as well as the
+uncertainty in each component.  The uncertainty of the full model will be held in
+``result.dely``, and the uncertainties for each component will be held in the dictionary
+``result.dely_comps``, with keys that are the component prefixes.
+
+An example script shows how the uncertainties in components of a composite
+model can be calculated and used:
+
+.. jupyter-execute:: ../examples/doc_model_uncertainty2.py
 
 
 .. _modelresult_saveload_sec:

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -16,6 +16,14 @@ consult the `lmfit GitHub repository`_.
 Version 1.0.4 Release Notes (unreleased)
 ========================================
 
+New features:
+
+- add calculation of ``dely`` for model components of composite models (Issue #761; PR #826)
+- add R^2 ``rsquared`` statistic to fit outputs and reports for Model fits (Issue #803; PR #810)
+- add ``SplineModel`` (PR #804)
+- add ``Pearson4Model`` (@lellid; PR #800)
+
+
 Bug fixes/enhancements:
 
 - make sure variable ``spercent`` is always defined in ``params_html_table`` functions (reported by @MySlientWind; Issue #768, PR #770)
@@ -24,8 +32,10 @@ Bug fixes/enhancements:
 - components used to create a ``CompositeModel`` can now have different independent variables (@Julian-Hochhaus; Discussion #787; PR #788))
 - fixed function definition for ``StepModel(form='linear')``, was not consistent with the other ones. (@matpompili; PR #794)
 - fixed height factor for ``Gaussian2dModel``, was not correct. (@matpompili; PR #795)
-- added ``Pearson4`` fitting model
 - for covariances with negative diagonal elements, we set the covariance to ``None`` (PR #813)
+- fixed linear mode for ``RectangleModel`` (@arunpersaud; Issue #815; PR #816)
+- report correct initial values for parameters with bounds (Issue #820; PR #821)
+- allow recalculation of confidence intervals (@jagerber48; PR #798)
 
 Deprecations:
 

--- a/examples/doc_model_uncertainty2.py
+++ b/examples/doc_model_uncertainty2.py
@@ -1,0 +1,84 @@
+# <examples/doc_model_uncertainty2.py>
+import matplotlib.pyplot as plt
+import numpy as np
+
+from lmfit.models import ExponentialModel, GaussianModel
+
+dat = np.loadtxt('NIST_Gauss2.dat')
+x = dat[:, 1]
+y = dat[:, 0]
+
+model = (GaussianModel(prefix='g1_') +
+         GaussianModel(prefix='g2_') +
+         ExponentialModel(prefix='bkg_'))
+
+params = model.make_params(bkg_amplitude=100, bkg_decay=80,
+                           g1_amplitude=3000,
+                           g1_center=100,
+                           g1_sigma=10,
+                           g2_amplitude=3000,
+                           g2_center=150,
+                           g2_sigma=10)
+
+result = model.fit(y, params, x=x)
+
+print(result.fit_report(min_correl=0.5))
+
+
+comps = result.eval_components(x=x)
+dely = result.eval_uncertainty(sigma=3)
+
+
+fig, axes = plt.subplots(2, 2, figsize=(12.8, 9.6))
+
+axes[0][0].plot(x, y, 'o', color='#99002299', markersize=3, label='data')
+axes[0][0].plot(x, result.best_fit, '-', label='best fit')
+axes[0][0].plot(x, result.init_fit, '--', label='initial fit')
+axes[0][0].set_title('data, initial fit, and best-fit')
+axes[0][0].legend()
+
+axes[0][1].plot(x, y, 'o', color='#99002299', markersize=3, label='data')
+axes[0][1].plot(x, result.best_fit, '-', label='best fit')
+axes[0][1].fill_between(x, result.best_fit-dely, result.best_fit+dely,
+                        color="#8A8A8A", label=r'3-$\sigma$ band')
+axes[0][1].set_title('data, best-fit, and uncertainty band')
+axes[0][1].legend()
+
+
+axes[1][0].plot(x, result.best_fit, '-', label=r'best fit, 3-$\sigma$ band')
+axes[1][0].fill_between(x,
+                        result.best_fit-result.dely,
+                        result.best_fit+result.dely,
+                        color="#8A8A8A")
+
+axes[1][0].plot(x, comps['bkg_'], label=r'background, 3-$\sigma$ band')
+axes[1][0].fill_between(x,
+                        comps['bkg_']-result.dely_comps['bkg_'],
+                        comps['bkg_']+result.dely_comps['bkg_'],
+                        color="#8A8A8A")
+
+axes[1][0].plot(x, comps['g1_'], label=r'Gaussian #1, 3-$\sigma$ band')
+axes[1][0].fill_between(x,
+                        comps['g1_']-result.dely_comps['g1_'],
+                        comps['g1_']+result.dely_comps['g1_'],
+                        color="#8A8A8A")
+
+axes[1][0].plot(x, comps['g2_'], label=r'Gaussian #2, 3-$\sigma$ band')
+axes[1][0].fill_between(x,
+                        comps['g2_']-result.dely_comps['g2_'],
+                        comps['g2_']+result.dely_comps['g2_'],
+                        color="#8A8A8A")
+axes[1][0].set_title('model components with uncertainty bands')
+axes[1][0].legend()
+#
+axes[1][1].plot(x, result.best_fit, '-', label='best fit')
+axes[1][1].plot(x, 10*result.dely, label=r'3-$\sigma$ total (x10)')
+axes[1][1].plot(x, 10*result.dely_comps['bkg_'], label=r'3-$\sigma$ background (x10)')
+axes[1][1].plot(x, 10*result.dely_comps['g1_'], label=r'3-$\sigma$ Gaussian #1 (x10)')
+axes[1][1].plot(x, 10*result.dely_comps['g2_'], label=r'3-$\sigma$ Gaussian #2 (x10)')
+axes[1][1].set_title('uncertainties for model components')
+axes[1][1].legend()
+
+plt.show()
+
+# <end examples/doc_model_uncertainty2.py>

--- a/tests/test_model_saveload.py
+++ b/tests/test_model_saveload.py
@@ -144,7 +144,7 @@ def test_save_load_modelresult(dill):
     text = ''
     with open(SAVE_MODELRESULT) as fh:
         text = fh.read()
-    assert 18000 < len(text) < 21000  # depending on whether dill is present
+    assert 12000 < len(text) < 60000  # depending on whether dill is present
 
     # load the saved ModelResult from file and compare results
     result_saved = load_modelresult(SAVE_MODELRESULT)

--- a/tests/test_model_uncertainties.py
+++ b/tests/test_model_uncertainties.py
@@ -1,10 +1,11 @@
 """Tests of ModelResult.eval_uncertainty()"""
+import os
 
 import numpy as np
 from numpy.testing import assert_allclose
 
 from lmfit.lineshapes import gaussian
-from lmfit.models import GaussianModel, LinearModel
+from lmfit.models import ExponentialModel, GaussianModel, LinearModel
 
 
 def get_linearmodel(slope=0.8, intercept=0.5, noise=1.5):
@@ -93,3 +94,36 @@ def test_gauss_noiselevel():
     dely_hinoise = ret2.eval_uncertainty(sigma=1)
 
     assert_allclose(dely_hinoise.mean(), 10*dely_lonoise.mean(), rtol=1.e-2)
+
+
+def test_component_uncertainties():
+    "test dely_comps"
+    y, x = np.loadtxt(os.path.join(os.path.dirname(__file__), '..',
+                                   'examples', 'NIST_Gauss2.dat')).T
+    model = (GaussianModel(prefix='g1_') +
+             GaussianModel(prefix='g2_') +
+             ExponentialModel(prefix='bkg_'))
+
+    params = model.make_params(bkg_amplitude=100, bkg_decay=80,
+                               g1_amplitude=3000,
+                               g1_center=100,
+                               g1_sigma=10,
+                               g2_amplitude=3000,
+                               g2_center=150,
+                               g2_sigma=10)
+
+    result = model.fit(y, params, x=x)
+    comps = result.eval_components(x=x)
+    dely = result.eval_uncertainty(sigma=3)
+
+    assert 'g1_' in comps
+    assert 'g2_' in comps
+    assert 'bkg_' in comps
+    assert dely.mean() > 0.8
+    assert dely.mean() < 2.0
+    assert result.dely_comps['g1_'].mean() > 0.5
+    assert result.dely_comps['g1_'].mean() < 1.5
+    assert result.dely_comps['g2_'].mean() > 0.5
+    assert result.dely_comps['g2_'].mean() < 1.5
+    assert result.dely_comps['bkg_'].mean() > 0.5
+    assert result.dely_comps['bkg_'].mean() < 1.5


### PR DESCRIPTION

This adds calculation of dely for model components to ModelResult.eval_uncertainties, addressing https://github.com/lmfit/lmfit-py/issues/761

It replaces #826 


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.9.13 | packaged by conda-forge | (main, May 27 2022, 17:01:00)
[Clang 13.0.1 ]

lmfit: 1.0.3.post76+g44eb363.d20221120, scipy: 1.9.3, numpy: 1.23.4, asteval: 0.9.28, uncertainties: 3.1.7

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [x] added an example?
