### PR TITLE
MAINT: support py311, bump dependencies, update keywords SciPy minimizers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,7 +84,7 @@ stages:
           displayName: 'Install dependencies'
         - script: |
             python -m pip install --upgrade build pip wheel
-            python -m pip install asteval==0.9.22 numpy==1.18 scipy==1.4.0 uncertainties==3.1.4 pytest coverage codecov flaky
+            python -m pip install asteval==0.9.28 numpy==1.19.0 scipy==1.6.0 uncertainties==3.1.4
           displayName: 'Install minimum required version of dependencies'
         - script: |
             python -m build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -261,7 +261,7 @@ stages:
           displayName: 'Install build, pip, setuptools, wheel, pybind11, and cython'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            export numpy_version=1.23.4
+            export numpy_version=1.23.5
             wget https://github.com/numpy/numpy/releases/download/v${numpy_version}/numpy-${numpy_version}.tar.gz
             tar xzvf numpy-${numpy_version}.tar.gz
             cd numpy-${numpy_version}

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -35,9 +35,9 @@ Lmfit works with `Python`_ versions 3.7 and higher. Version
 0.9.15 is the final version to support Python 2.7.
 
 Lmfit requires the following Python packages, with versions given:
-   * `NumPy`_ version 1.18 or higher.
-   * `SciPy`_ version 1.4 or higher.
-   * `asteval`_ version 0.9.22 or higher.
+   * `NumPy`_ version 1.19 or higher.
+   * `SciPy`_ version 1.6 or higher.
+   * `asteval`_ version 0.9.28 or higher.
    * `uncertainties`_ version 3.1.4 or higher.
 
 All of these are readily available on PyPI, and are installed

--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -18,11 +18,10 @@ Version 1.0.4 Release Notes (unreleased)
 
 New features:
 
-- add calculation of ``dely`` for model components of composite models (Issue #761; PR #826)
-- add R^2 ``rsquared`` statistic to fit outputs and reports for Model fits (Issue #803; PR #810)
-- add ``SplineModel`` (PR #804)
 - add ``Pearson4Model`` (@lellid; PR #800)
-
+- add ``SplineModel`` (PR #804)
+- add R^2 ``rsquared`` statistic to fit outputs and reports for Model fits (Issue #803; PR #810)
+- add calculation of ``dely`` for model components of composite models (Issue #761; PR #826)
 
 Bug fixes/enhancements:
 
@@ -36,6 +35,8 @@ Bug fixes/enhancements:
 - fixed linear mode for ``RectangleModel`` (@arunpersaud; Issue #815; PR #816)
 - report correct initial values for parameters with bounds (Issue #820; PR #821)
 - allow recalculation of confidence intervals (@jagerber48; PR #798)
+- include 'residual' in JSON output of ModelResult.dumps (@mac01021; PR #830)
+- supports and is tested against Python 3.11; updated minimum required version of SciPy, NumPy, and asteval (PR #832)
 
 Deprecations:
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1776,9 +1776,14 @@ class Minimizer:
         result.method = 'basinhopping'
         self.set_max_nfev(max_nfev, 200000*(result.nvarys+1))
         basinhopping_kws = dict(niter=100, T=1.0, stepsize=0.5,
-                                minimizer_kwargs={}, take_step=None,
+                                minimizer_kwargs=None, take_step=None,
                                 accept_test=None, callback=None, interval=50,
                                 disp=False, niter_success=None, seed=None)
+
+        # FIXME: update when SciPy requirement is >= 1.8
+        if int(scipy_version.split('.')[1]) >= 8:
+            basinhopping_kws.update({'target_accept_rate': 0.5,
+                                     'stepwise_factor': 0.9})
 
         basinhopping_kws.update(self.kws)
         basinhopping_kws.update(kws)

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -22,6 +22,7 @@ import numbers
 import warnings
 
 import numpy as np
+from scipy import __version__ as scipy_version
 from scipy.linalg import LinAlgError, inv
 from scipy.optimize import basinhopping as scipy_basinhopping
 from scipy.optimize import brute as scipy_brute
@@ -2215,13 +2216,18 @@ class Minimizer:
         result.method = 'dual_annealing'
         self.set_max_nfev(max_nfev, 200000*(result.nvarys+1))
 
-        da_kws = dict(initial_temp=5230.0, restart_temp_ratio=2e-05,
+        da_kws = dict(maxiter=1000, local_search_options={},
+                      initial_temp=5230.0, restart_temp_ratio=2e-05,
                       visit=2.62, accept=-5.0, maxfun=2*self.max_nfev,
-                      seed=None, no_local_search=False, callback=None,
-                      x0=None)
+                      seed=None, no_local_search=False, callback=None, x0=None)
 
         da_kws.update(self.kws)
         da_kws.update(kws)
+
+        # FIXME: update when SciPy requirement is >= 1.8
+        # ``local_search_options`` deprecated in favor of ``minimizer_kwargs``
+        if int(scipy_version.split('.')[1]) >= 8:
+            da_kws.update({'minimizer_kwargs': da_kws.pop('local_search_options')})
 
         varying = np.asarray([par.vary for par in self.params.values()])
         bounds = np.asarray([(par.min, par.max) for par in

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -2149,6 +2149,10 @@ class Minimizer:
                         minimizer_kwargs=None, options=None,
                         sampling_method='simplicial')
 
+        # FIXME: update when SciPy requirement is >= 1.7
+        if int(scipy_version.split('.')[1]) >= 7:
+            shgo_kws['n'] = None
+
         shgo_kws.update(self.kws)
         shgo_kws.update(kws)
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1623,22 +1623,7 @@ class Minimizer:
         from the covariance matrix.
 
         This method calls :scipydoc:`optimize.leastsq` and, by default,
-        numerical derivatives are used, and the following arguments are
-        set:
-
-        +------------------+----------------+------------------------+
-        | :meth:`leastsq`  |  Default Value | Description            |
-        | arg              |                |                        |
-        +==================+================+========================+
-        |  `xtol`          |  1.e-7         | Relative error in the  |
-        |                  |                | approximate solution   |
-        +------------------+----------------+------------------------+
-        |  `ftol`          |  1.e-7         | Relative error in the  |
-        |                  |                | desired sum-of-squares |
-        +------------------+----------------+------------------------+
-        |  `Dfun`          | None           | Function to call for   |
-        |                  |                | Jacobian calculation   |
-        +------------------+----------------+------------------------+
+        numerical derivatives are used.
 
         Parameters
         ----------
@@ -1667,12 +1652,14 @@ class Minimizer:
         result.nfev -= 2  # correct for "pre-fit" initialization/checks
         variables = result._init_vals_internal
 
-        # note we set the max number of function evaluations here, and send twice that
-        # value to the solver so it essentially never stops on its own
+        # Note: we set max number of function evaluations here, and send twice
+        # that value to the solver so it essentially never stops on its own
         self.set_max_nfev(max_nfev, 2000*(result.nvarys+1))
 
-        lskws = dict(full_output=1, xtol=1.e-7, ftol=1.e-7, col_deriv=False,
-                     gtol=1.e-7, maxfev=2*self.max_nfev, Dfun=None)
+        lskws = dict(Dfun=None, full_output=1, col_deriv=0, ftol=1.49012e-08,
+                     xtol=1.49012e-08, gtol=0.0, maxfev=2*self.max_nfev,
+                     epsfcn=None, factor=100, diag=None)
+
         if 'maxfev' in kws:
             warnings.warn(maxeval_warning.format('maxfev', thisfuncname()),
                           RuntimeWarning)
@@ -1681,6 +1668,7 @@ class Minimizer:
         lskws.update(self.kws)
         lskws.update(kws)
         self.col_deriv = False
+
         if lskws['Dfun'] is not None:
             self.jacfcn = lskws['Dfun']
             self.col_deriv = lskws['col_deriv']

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 keywords = curve-fitting, least-squares minimization
@@ -34,9 +35,9 @@ packages = find:
 python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
-    asteval>=0.9.22
-    numpy>=1.18
-    scipy>=1.4
+    asteval>=0.9.28
+    numpy>=1.19
+    scipy>=1.6
     uncertainties>=3.1.4
 
 [options.packages.find]

--- a/tests/test_basinhopping.py
+++ b/tests/test_basinhopping.py
@@ -2,6 +2,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
+from scipy import __version__ as scipy_version
 from scipy.optimize import basinhopping
 
 import lmfit
@@ -60,6 +61,11 @@ def test_basinhopping_2d_lmfit_vs_scipy():
     assert_allclose(out.residual, ret.fun)
     assert_allclose(out.params['x0'].value, ret.x[0], rtol=1e-5)
     assert_allclose(out.params['x1'].value, ret.x[1], rtol=1e-5)
+
+    # FIXME: update when SciPy requirement is >= 1.8
+    if int(scipy_version.split('.')[1]) >= 8:
+        assert 'target_accept_rate' in out.call_kws
+        assert 'stepwise_factor' in out.call_kws
 
 
 def test_basinhopping_Alpine02(minimizer_Alpine02):

--- a/tests/test_dual_annealing.py
+++ b/tests/test_dual_annealing.py
@@ -3,6 +3,7 @@
 import numpy as np
 from numpy.testing import assert_allclose
 import scipy
+from scipy import __version__ as scipy_version
 
 import lmfit
 
@@ -52,6 +53,13 @@ def test_da_Alpine02(minimizer_Alpine02):
     assert_allclose(min(out_x), min(global_optimum), rtol=1e-3)
     assert_allclose(max(out_x), max(global_optimum), rtol=1e-3)
     assert out.method == 'dual_annealing'
+
+    # FIXME: update when SciPy requirement is >= 1.8
+    # ``local_search_options`` deprecated in favor of ``minimizer_kwargs``
+    if int(scipy_version.split('.')[1]) >= 8:
+        assert 'minimizer_kwargs' in out.call_kws
+    else:
+        assert 'local_search_options' in out.call_kws
 
 
 def test_da_bounds(minimizer_Alpine02):

--- a/tests/test_shgo.py
+++ b/tests/test_shgo.py
@@ -96,6 +96,12 @@ def test_shgo_sobol_Alpine02(minimizer_Alpine02):
     assert_allclose(min(out_x), min(global_optimum), rtol=1e-3)
     assert_allclose(max(out_x), max(global_optimum), rtol=1e-3)
 
+    # FIXME: update when SciPy requirement is >= 1.7
+    if int(scipy_version.split('.')[1]) >= 7:
+        assert out.call_kws['n'] is None
+    else:
+        assert out.call_kws['n'] == 100
+
 
 def test_shgo_bounds(minimizer_Alpine02):
     """Test SHGO algorithm with bounds."""


### PR DESCRIPTION
#### Description
This PR contains the following changes:
- bump minimum requirements for SciPy and NumPy (releases from 2 years ago) and asteval  (to support Python 3.11)
- update keywords for a few minimizers so that they will work with all ScPy version between "minimum required" and "current" version.
 

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
Python: 3.10.8 (main, Nov 13 2022, 11:11:37) [Clang 14.0.0 (clang-1400.0.29.202)]

lmfit: 1.0.3.post81+g9b024d5, scipy: 1.9.3, numpy: 1.23.4, asteval: 0.9.28, uncertainties: 3.1.7
-->


###### Verification <!-- (delete not applicable items) -->
Have you
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
