### PR TITLE
BLD: Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+requires = ["setuptools>=45", "setuptools_scm>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
#### Description
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a


###### Type of Changes
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
n/a


###### Verification
Have you
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)? [should I add one for such a trivial and not-really-user-facing change?]

--------
Yes, I read the instructions and I am sure this is a GitHub Issue.