### PR TITLE
Fix deepcopy of user data

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -109,7 +109,7 @@ class Parameters(dict):
                 param.correl = par.correl
                 param.init_value = par.init_value
                 param.expr = par.expr
-                param.user_data = par.user_data
+                param.user_data = deepcopy(par.user_data)
                 parameter_list.append(param)
 
         _pars.add_many(*parameter_list)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -20,9 +20,9 @@ def parameters():
                              user_data=1))
     pars.add(lmfit.Parameter(name='b', value=0.0, vary=True, min=-250.0,
                              max=250.0, expr="2.0*a", brute_step=25.0,
-                             user_data=2.5))
+                             user_data={'test': 123}))
     exp_attr_values_A = ('a', 10.0, True, -100.0, 100.0, None, 5.0, 1)
-    exp_attr_values_B = ('b', 20.0, False, -250.0, 250.0, "2.0*a", 25.0, 2.5)
+    exp_attr_values_B = ('b', 20.0, False, -250.0, 250.0, "2.0*a", 25.0, {'test': 123})
     assert_parameter_attributes(pars['a'], exp_attr_values_A)
     assert_parameter_attributes(pars['b'], exp_attr_values_B)
     return pars, exp_attr_values_A, exp_attr_values_B
@@ -58,7 +58,9 @@ def test_parameters_copy(parameters):
     pars_copy = pars.copy()
     pars__copy__ = pars.__copy__()
 
+    # modifying the original parameters should not modify the copies
     pars['a'].set(value=100)
+    pars['b'].user_data['test'] = 456
 
     for copied in [copy_pars, pars_copy, pars__copy__]:
         assert isinstance(copied, lmfit.Parameters)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description

I was making use of the `user_data` attribute of a `Parameter`, and noticed that it is not deep-copied when using the `copy()` method of `Parameters`. Here is a simple example:
```python
import lmfit

def func(x, a):
    return a * x

model = lmfit.Model(func)

params = model.make_params()
params.get("a").user_data = {"foo": 123 }

params2 = params.copy()
params2.get("a").user_data["foo"] = 456

print(params.get("a").user_data) # prints {'foo': 456}
```

This PR fixes this behavior.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on

Python: 3.10.9 (main, Dec 08 2022, 14:49:06) [GCC]

lmfit: 1.1.0.post1+g1a3b1009, scipy: 1.10.0, numpy: 1.24.1, asteval: 0.9.28, uncertainties: 3.1.7

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257? - N/A
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list? - N/A
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally? - N/A, no changes to docs
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages? - let me know if you want me to squash them into one commit
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example? - N/A
