### PR TITLE
Update isort to 5.12 in pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         additional_dependencies: [flake8-deprecated, flake8-mutable]
 
 -   repo: https://github.com/PyCQA/isort/
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
     -   id: isort
 


### PR DESCRIPTION
#### Description

While working on #837, I noticed that the pre-commit failed, because the latest version of poetry is apparently incompatible with isort 5.11, see
- https://stackoverflow.com/questions/75269700/pre-commit-fails-to-install-isort-5-11-4-with-error-runtimeerror-the-poetry-co
- https://github.com/PyCQA/isort/issues/2077
- https://github.com/PyCQA/isort/pull/2078

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.10.9 (main, Dec 08 2022, 14:49:06) [GCC]

lmfit: 1.1.0.post1+g1a3b1009, scipy: 1.10.0, numpy: 1.24.1, asteval: 0.9.28, uncertainties: 3.1.7