### PR TITLE
Improve error messages when users try to plot multi-dimensional data

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1879,6 +1879,11 @@ class ModelResult(Minimizer):
         -------
         matplotlib.axes.Axes
 
+        Raises
+        ------
+        RuntimeError
+            Raised if the independent variable is not one dimensional.
+
         See Also
         --------
         ModelResult.plot_residuals : Plot the fit residuals using matplotlib.
@@ -1913,12 +1918,12 @@ class ModelResult(Minimizer):
         # The function reduce_complex will convert complex vectors into real vectors
         reduce_complex = get_reducer(parse_complex)
 
-        if len(self.model.independent_vars) == 1:
+        if (len(self.model.independent_vars) == 1
+                and len(self.userkws[self.model.independent_vars[0]].shape) == 1):
             independent_var = self.model.independent_vars[0]
         else:
-            print('Fit can only be plotted if the model function has one '
-                  'independent variable.')
-            return False
+            raise RuntimeError('Fit can only be plotted if the model function has one '
+                               'independent variable.')
 
         if not isinstance(ax, plt.Axes):
             ax = plt.axes(**ax_kws)
@@ -2141,6 +2146,11 @@ class ModelResult(Minimizer):
         -------
         matplotlib.figure.Figure
 
+        Raises
+        ------
+        RuntimeError
+            Raised if the independent variable is not one dimensional.
+
         See Also
         --------
         ModelResult.plot_fit : Plot the fit results using matplotlib.
@@ -2181,10 +2191,10 @@ class ModelResult(Minimizer):
         if fig_kws is not None:
             fig_kws_.update(fig_kws)
 
-        if len(self.model.independent_vars) != 1:
-            print('Fit can only be plotted if the model function has one '
-                  'independent variable.')
-            return False
+        if (len(self.model.independent_vars) != 1
+                or len(self.userkws[self.model.independent_vars[0]].shape) > 1):
+            raise RuntimeError('Fit can only be plotted if the model function has one '
+                               'independent variable.')
 
         if not isinstance(fig, plt.Figure):
             fig = plt.figure(**fig_kws_)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -95,7 +95,7 @@ def get_reducer(option):
             Returned array will be purely real.
 
         """
-        if any(np.iscomplex(array)):
+        if np.iscomplex(array).any():
             parsed_array = getattr(np, option)(array)
         else:
             parsed_array = array
@@ -149,7 +149,7 @@ def propagate_err(z, dz, option):
         raise ValueError(f"shape of z: {z.shape} != shape of dz: {dz.shape}")
 
     # Check the main vector for complex. Do nothing if real.
-    if any(np.iscomplex(z)):
+    if np.iscomplex(z).any():
         # if uncertainties are real, apply them equally to
         # real and imaginary parts
         if all(np.isreal(dz)):


### PR DESCRIPTION
#### Description

When I tried to plot a model that is inherently 2-dimensional (e.g. an image, with independent variable shape `(2,N,N)`), I got the following matplotlib exception:

```
ValueError: x and y must have same first dimension, but have shapes (2, 10, 10) and (10, 10)
```

There is an existing check on whether there is more than one independent variable, but that doesn't help if there's e.g. an x/y grid passed in as a single variable (as is suggested in some of the docs). This branch gives one way to fix that, but I don't know if it's generic enough. I also changed the "print message" to "raise exception", to make it much more explicit what's going wrong.

On a separate commit, I changed `any(np.iscomplex(z))` to `np.iscomplex(z).any()`, as the former doesn't work on data with a dimension (`len(shape)`) greater than 1.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix
- [ ] New feature
- [ x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on

Python: 3.10.9 | packaged by conda-forge | (main, Feb  2 2023, 20:20:04) [GCC 11.3.0]
lmfit: 0.0.post2673+g729491d, scipy: 1.10.0, numpy: 1.21.6, asteval: 0.9.28, uncertainties: 3.1.7


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x ] included docstrings that follow PEP 257?
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x ] verified that existing tests pass locally?
- [x ] verified that the documentation builds locally?
-- The only error I got was in a doc file I didn't touch: `examples/index.rst`.
- [x ] squashed/minimized your commits and written descriptive commit messages?
- [x ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
-- Not sure what to add to whatsnew yet.
- [ ] added an example?
