### PR TITLE
make Parameter.vary a property

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -26,6 +26,7 @@ New features:
 
 Bug fixes/enhancements:
 
+- fix bug when setting ``param.vary=True`` for a constrained parameter (Issue #859; PR #860)
 - fix bug in reported uncertainties for constrained parameters by better propating uncertainties (Issue #855; PR #856)
 - Coercing of user input data and independent data for ``Model`` to float64 ndarrays is somewhat less aggressive and
   will not increase the precision of numpy ndarrays (see :ref:`model_data_coercion_section` for details). The resulting

--- a/examples/doc_builtinmodels_peakmodels.py
+++ b/examples/doc_builtinmodels_peakmodels.py
@@ -49,9 +49,11 @@ axes[0].plot(x, y, '-')
 axes[0].plot(x, out.best_fit, '-', label='Voigt Model\ngamma constrained')
 axes[0].legend()
 
-# free gamma parameter
-pars['gamma'].set(value=0.7, vary=True, expr='')
+# allow the gamma parameter to vary in the fit
+pars['gamma'].vary = True
 out_gamma = mod.fit(y, pars, x=x)
+print(out.fit_report(correl_mode='table'))
+
 axes[1].plot(x, y, '-')
 axes[1].plot(x, out_gamma.best_fit, '-', label='Voigt Model\ngamma unconstrained')
 axes[1].legend()

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -639,7 +639,7 @@ class Parameter:
         self.min = min
         self.max = max
         self.brute_step = brute_step
-        self.vary = vary
+        self._vary = vary
         self._expr = expr
         self._expr_ast = None
         self._expr_eval = None
@@ -702,7 +702,7 @@ class Parameter:
 
         """
         if vary is not None:
-            self.vary = vary
+            self._vary = vary
             if vary:
                 self.__set_expression('')
 
@@ -751,13 +751,13 @@ class Parameter:
 
     def __getstate__(self):
         """Get state for pickle."""
-        return (self.name, self.value, self.vary, self.expr, self.min,
+        return (self.name, self.value, self._vary, self.expr, self.min,
                 self.max, self.brute_step, self.stderr, self.correl,
                 self.init_value, self.user_data)
 
     def __setstate__(self, state):
         """Set state for pickle."""
-        (self.name, _value, self.vary, self.expr, self.min, self.max,
+        (self.name, _value, self._vary, self.expr, self.min, self.max,
          self.brute_step, self.stderr, self.correl, self.init_value,
          self.user_data) = state
         self._expr_ast = None
@@ -772,7 +772,7 @@ class Parameter:
         """Return printable representation of a Parameter object."""
         s = []
         sval = f"value={repr(self._getval())}"
-        if not self.vary and self._expr is None:
+        if not self._vary and self._expr is None:
             sval += " (fixed)"
         elif self.stderr is not None:
             sval += f" +/- {self.stderr:.3g}"
@@ -883,6 +883,18 @@ class Parameter:
             self._expr_eval.symtable[self.name] = self._val
 
     @property
+    def vary(self):
+        """Return whether the parameter is variable"""
+        return self._vary
+
+    @vary.setter
+    def vary(self, val):
+        """Set whether a parameter is varied"""
+        self._vary = val
+        if val:
+            self.__set_expression('')
+
+    @property
     def expr(self):
         """Return the mathematical expression used to constrain the value in fit."""
         return self._expr
@@ -901,7 +913,7 @@ class Parameter:
             val = None
         self._expr = val
         if val is not None:
-            self.vary = False
+            self._vary = False
         if not hasattr(self, '_expr_eval'):
             self._expr_eval = None
         if val is None:


### PR DESCRIPTION
This makes `Parameter.vary` into a property, wrapping an underlying `._vary` attribute, so that setting `Parameter.vary=True` will erase an existing constraint expression

This addresses the problem described in #859 

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on

Python: 3.11.0 | packaged by conda-forge | (main, Jan 15 2023, 05:44:48) [Clang 14.0.6 ]

lmfit: 1.2.0rc1.post0+g52012fd.d20230405, scipy: 1.10.1, numpy: 1.24.2, asteval: 0.9.29, uncertainties: 3.1.7

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [x] added an example?
