### PR TITLE
Remove heading tags in html table

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1693,7 +1693,7 @@ class ModelResult(Minimizer):
         report = fitreport_html_table(self, show_correl=show_correl,
                                       min_correl=min_correl)
         modname = self.model._reprstring(long=True)
-        return f"<h2> Model</h2> {modname} {report}"
+        return f"<b> Model</b> {modname} {report}"
 
     def summary(self):
         """Return a dictionary with statistics and attributes of a ModelResult.

--- a/lmfit/printfuncs.py
+++ b/lmfit/printfuncs.py
@@ -249,7 +249,7 @@ def fitreport_html_table(result, show_correl=True, min_correl=0.1):
     def stat_row(label, val, val2=''):
         add(f'<tr><td>{label}</td><td>{val}</td><td>{val2}</td></tr>')
 
-    add('<h2>Fit Statistics</h2>')
+    add('<b>Fit Statistics</b>')
     add('<table>')
     stat_row('fitting method', result.method)
     stat_row('# function evals', result.nfev)
@@ -262,7 +262,7 @@ def fitreport_html_table(result, show_correl=True, min_correl=0.1):
     if hasattr(result, 'rsquared'):
         stat_row('R-squared', gformat(result.rsquared))
     add('</table>')
-    add('<h2>Variables</h2>')
+    add('<b>Variables</b>')
     add(params_html_table(result.params))
     if show_correl:
         correls = []
@@ -280,7 +280,7 @@ def fitreport_html_table(result, show_correl=True, min_correl=0.1):
             sort_correls = sorted(correls, key=lambda val: abs(val[2]))
             sort_correls.reverse()
             extra = f'(unreported correlations are < {min_correl:.3f})'
-            add(f'<h2>Correlations {extra}</h2>')
+            add(f'<b>Correlations {extra}</b>')
             add('<table>')
             for name1, name2, val in sort_correls:
                 stat_row(name1, name2, f"{val:+.4f}")


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

The html fit reports contain `h2` tags, which are interpreted as section headings by the table of contents sidebar of JupyterLab. I'm assuming that's undesirable behavior for everyone, so I just replaced the `h2` tags with `b`.

If there is a specific reason for the `h2` tags, I could instead add function parameters to specify which tag is desired.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples




###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

Python: 3.8.15 | packaged by conda-forge | (default, Nov 22 2022, 08:53:40) 
[Clang 14.0.6 ]
lmfit: 1.2.1.post1+ga246cbc7, scipy: 1.9.3, numpy: 1.23.5, asteval: 0.9.28, uncertainties: 3.1.7

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
