### PR TITLE
Fix test_hints_for_peakmodels from test_models.py

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,7 +5,7 @@ import unittest
 import warnings
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_almost_equal
 import pytest
 from scipy import __version__ as scipy_version
 
@@ -1107,7 +1107,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         _m = m1 + m2  # noqa: F841
 
         param_values = {name: p.value for name, p in params.items()}
-        self.assertTrue(param_values['m1_intercept'] < -0.0)
+        assert_almost_equal(param_values['m1_intercept'], 0.)
         self.assertEqual(param_values['m2_amplitude'], 1)
 
     def test_weird_param_hints(self):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples

The `test_hints_for_peakmodels` from `test_model.py` is failing on my system. I suspect due to changes in the accuracy of np.sin and np.cos in the upcoming numpy 1.25 release. See https://github.com/numpy/numpy/pull/23399. The test  `test_hints_for_peakmodels` fails at the comparison
```
   self.assertTrue(param_values['m1_intercept'] < -0.0)
```
due to numerical rounding errors. 

In this PR we increase the threshold of the comparison. Since the test itself is not about the values (according to the docstring about checking asteval), this seems safe.

###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.11.0 (main, Oct 24 2022, 18:26:48) [MSC v.1933 64 bit (AMD64)]

lmfit: 1.0.2.post286+g980a5d1, scipy: 1.10.1, numpy: 1.25.0rc1+97.g4e69d516c, asteval: 0.9.30, uncertainties: 3.1.7

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x] included docstrings that follow PEP 257? Only tests have changed
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)? Not required, internal change
