### PR TITLE
lmfit.Minimizer.least_squares: Bug fix

### DIFF
--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -561,8 +561,9 @@ class Minimizer:
         else:
             return coerce_float64(out, nan_policy=self.nan_policy)
 
-    def __jacobian(self, fvars):
-        """Return analytical jacobian to be used with Levenberg-Marquardt.
+    def __jacobian(self, fvars, **unused):
+        """Return analytical jacobian to be used with Trust Region 
+        Reflective, Levenberg-Marquardt, or dogleg.
 
         modified 02-01-2012 by Glenn Jones, Aberystwyth University
         modified 06-29-2015 by M Newville to apply gradient scaling for
@@ -1533,6 +1534,10 @@ class Minimizer:
 
         least_squares_kws.update(self.kws)
         least_squares_kws.update(kws)
+
+        self.jacfcn = least_squares_kws['jac']
+        if callable(least_squares_kws['jac']):
+            least_squares_kws['jac'] = self.__jacobian
 
         least_squares_kws['kwargs'].update({'apply_bounds_transformation': False})
         result.call_kws = least_squares_kws


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
lmfit.Minimizer.leastsq successfully passes a user Jacobian function to Scipy, while lmfit.Minimizer.least_squares hits an exception. See stack trace in link below.

The discrepancy is apparently due to leastsq passing lmfit.Minimizer.__jacobian to scipy.optimize.leastsq, while lmfit.Minimizer.least_squares passes the unmodified user Jacobian.

(Note that scipy.optimize.leastsq and scipy.optimize.least_squares respectively refer to user Jacobians as 'Dfun' and 'jac'.)

lmfit.Minimizer.__jacobian was also modified to accept unused args. Because Scipy will pass the same args to the user function and Jacobian, and the apply_bounds_transformation kwarg is unnecessary to __jacobian (and this kwarg is not passed to Scipy by leastsq), 

https://groups.google.com/g/lmfit-py/c/dTgC_hn-lsw/m/RjsshTLgBwAJ?utm_medium=email&utm_source=footer&pli=1


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.11.4 | packaged by conda-forge | (main, Jun 10 2023, 18:08:17) [GCC 12.2.0]

lmfit: 0.0.post2787+gfc3f7f8, scipy: 1.11.1, numpy: 1.25.2, asteval: 0.9.31, uncertainties: 3.1.7


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [x] added an example?
