### PR TITLE
ensure result.params has uvars attribute

### DIFF
--- a/examples/doc_uvars_params.py
+++ b/examples/doc_uvars_params.py
@@ -24,10 +24,10 @@ print(out.fit_report(min_correl=0.5))
 # Area and Centroid of the combined peaks
 # option 1: from output uncertainties values
 
-uvar_g1amp = out.uvars['g1_amplitude']
-uvar_g2amp = out.uvars['g2_amplitude']
-uvar_g1cen = out.uvars['g1_center']
-uvar_g2cen = out.uvars['g2_center']
+uvar_g1amp = out.params.uvars['g1_amplitude']
+uvar_g2amp = out.params.uvars['g2_amplitude']
+uvar_g1cen = out.params.uvars['g1_center']
+uvar_g2cen = out.params.uvars['g2_center']
 
 print("### Peak Area: ")
 print(f"Peak1: {out.params['g1_amplitude'].value:.5f}+/-{out.params['g1_amplitude'].stderr:.5f}")

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -818,7 +818,8 @@ class Minimizer:
             except ZeroDivisionError:
                 self.result.errorbars = False
         if self.result.errorbars:
-            self.result.uvars = self.result.params.create_uvars(covar=self.result.covar)
+            self.result.params.uvars = self.result.params.create_uvars(covar=self.result.covar)
+            self.result.uvars = self.result.params.uvars    # preserve for back compat for some time? (August, 2023)
 
     def scalar_minimize(self, method='Nelder-Mead', params=None, max_nfev=None,
                         **kws):

--- a/tests/test_params_uvars.py
+++ b/tests/test_params_uvars.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 
+from lmfit import create_params, minimize
 from lmfit.models import ExponentialModel, GaussianModel
 
 y, x = np.loadtxt(os.path.join(os.path.dirname(__file__), '..',
@@ -27,8 +28,8 @@ def test_uvars_calc_afterfit():
     assert out.chisqr > 1000
     assert out.chisqr < 3000
 
-    u_g1amp = out.uvars['g1_amplitude']
-    u_g2amp = out.uvars['g2_amplitude']
+    u_g1amp = out.params.uvars['g1_amplitude']
+    u_g2amp = out.params.uvars['g2_amplitude']
 
     # stderr in area of Gauss1 + Gauss2 in quadrature, ignoring correlations
     area_stderr_quad = np.sqrt(out.params['g1_amplitude'].stderr**2 +
@@ -96,3 +97,36 @@ def test_uvars_calc_post_fit_method():
 
     assert post_area.stderr > 43
     assert post_area.stderr < 48
+
+
+def test_uvars_with_minimize():
+    "test that uvars is an attribute of params GH #911"
+    def residual(pars, x, data=None):
+        """Model a decaying sine wave and subtract data."""
+        vals = pars.valuesdict()
+        amp = vals['amp']
+        per = vals['period']
+        shift = vals['shift']
+        decay = vals['decay']
+
+        if abs(shift) > np.pi/2:
+            shift = shift - np.sign(shift)*np.pi
+        model = amp * np.sin(shift + x/per) * np.exp(-x*x*decay*decay)
+        if data is None:
+            return model
+        return model - data
+
+    p_true = create_params(amp=14.0, period=5.46, shift=0.123, decay=0.032)
+    np.random.seed(0)
+    x = np.linspace(0.0, 250., 1001)
+    noise = np.random.normal(scale=0.7215, size=x.size)
+    data = residual(p_true, x) + noise
+
+    fit_params = create_params(amp=13, period=2, shift=0, decay=0.02)
+    out = minimize(residual, fit_params, args=(x,), kws={'data': data})
+
+    assert hasattr(out.params, 'uvars')
+    assert out.params.uvars['amp'].nominal_value > 10
+    assert out.params.uvars['amp'].nominal_value < 20
+    assert out.params.uvars['amp'].std_dev > 0.05
+    assert out.params.uvars['amp'].std_dev < 0.50


### PR DESCRIPTION


#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

As at #911, this makes the `uvars` calculated with `Parameters.create_uvars` be an attribute of the `Parameters` instance after a fit.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?

(example updated)
