### PR TITLE
Fix problems with arguments that are neither fit parameters nor independent variables

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1047,9 +1047,9 @@ class Model:
                 params[name].set(value=p)
             del kwargs[name]
 
-        # All remaining kwargs should correspond to independent variables.
+        # Check for spurious kwargs.
         for name in kwargs:
-            if name not in self.independent_vars:
+            if name not in self._func_allargs:
                 warnings.warn(f"The keyword argument {name} does not " +
                               "match any arguments of the model function. " +
                               "It will be ignored.", UserWarning)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -2079,7 +2079,7 @@ class ModelResult(Minimizer):
             ax.plot(x_array, reduce_complex(self.data),
                     datafmt, label='data', **data_kws)
 
-        y_eval = self.model.eval(self.params, **{independent_var: x_array_dense})
+        y_eval = self.eval(self.params, **{independent_var: x_array_dense})
         if isinstance(self.model, (lmfit.models.ConstantModel,
                                    lmfit.models.ComplexConstantModel)):
             y_eval *= np.ones(x_array_dense.size)


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->
Model function arguments that are neither fit parameters nor independent variables were handled incorrect in two places.
- They were incorrectly identified to not correspond to a model function argument in `Model.fit()` and thus a misleading spurious warning was issued.
- They were not considered in `ModelResult.plot_fit()`, causing `ModelResult.plot()` to produce contradictory plots.

This PR remedies both issues and fixes #917 (moved to #920).

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
```
Python: 3.11.6 | packaged by conda-forge | (main, Oct  3 2023, 10:29:11) [MSC v.1935 64 bit (AMD64)]

lmfit: 0.0.post2796+g4e2470a.d20231118, scipy: 1.11.3, numpy: 1.26.0, asteval: 0.9.31, uncertainties: 3.1.7
```

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
  (No API changes.)
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
  (I get several warnings and three skipped tests, though.)
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
  (Except for issues that also appeared when building on `master`, as described in #924.)
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
  (No tests were affected by the change.)
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
  (I did not add anything to `doc/whatsnew.rst` yet. I had a look at the file history and other PRs and it seems to be done in batch, separate from the PRs. I will add an entry if you ask me to.)
- [ ] added an example?
  (Same as for test, I don't think any example was affected and I did not add a new one.)
