### PR TITLE
propagate funcdefs to Parameters in model.loads

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1891,7 +1891,7 @@ class ModelResult(Minimizer):
                 _par = Parameter(name='')
                 _par.__setstate__(parstate)
                 state['params'].append(_par)
-            _params = Parameters()
+            _params = Parameters(usersyms=funcdefs)
             _params.__setstate__(state)
             setattr(self, target, _params)
 

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1861,7 +1861,7 @@ class ModelResult(Minimizer):
         funcdefs : dict, optional
             Dictionary of custom function names and definitions.
         **kws : optional
-            Keyword arguments that are passed to `json.dumps`.
+            Keyword arguments that are passed to `json.loads`.
 
         Returns
         -------
@@ -1885,6 +1885,9 @@ class ModelResult(Minimizer):
         self.model = _buildmodel(decode4js(modres['model']), funcdefs=funcdefs)
 
         # params
+        if funcdefs:
+            # Remove model function so as not pass it into the _asteval.symtable
+            funcdefs.pop(self.model.func.__name__, None)
         for target in ('params', 'init_params'):
             state = {'unique_symbols': modres['unique_symbols'], 'params': []}
             for parstate in modres['params']:

--- a/tests/test_model_saveload.py
+++ b/tests/test_model_saveload.py
@@ -254,8 +254,10 @@ def test_saveload_modelresult_roundtrip_user_expr_function():
     result2 = ModelResult(model, Parameters())
     result2.loads(result1.dumps(), funcdefs={'mfunc': mfunc, 'expr_func': expr_func})
 
+    assert result1.userfcn == result2.userfcn
     assert result1.params == result2.params
     assert result1.init_params == result2.init_params
+    assert set(result1.params._asteval.symtable) == set(result2.params._asteval.symtable)
 
 
 def test_saveload_modelresult_eval_uncertainty():

--- a/tests/test_model_saveload.py
+++ b/tests/test_model_saveload.py
@@ -230,6 +230,34 @@ def test_saveload_modelresult_roundtrip(method):
     assert_allclose(result3.params['b'], 0.22, rtol=1.0e-2)
 
 
+def test_saveload_modelresult_roundtrip_user_expr_function():
+    """Test for modelresult.loads()/dumps() for a model with user defined expr function."""
+
+    def mfunc(x, a, b):
+        return a * (x-b)
+
+    def expr_func(x):
+        return 3 * x
+
+    model = Model(mfunc)
+    params = Parameters(usersyms={"expr_func": expr_func})
+    params.add("a", min=.01, max=1)
+    params.add("b", min=.01, max=3.1)
+    params.add("c", expr="expr_func(a)")
+
+    np.random.seed(2020)
+    xx = np.linspace(-5, 5, 201)
+    yy = 0.5 * (xx - 0.22) + np.random.normal(scale=0.01, size=xx.size)
+
+    result1 = model.fit(yy, params=params, x=xx)
+
+    result2 = ModelResult(model, Parameters())
+    result2.loads(result1.dumps(), funcdefs={'mfunc': mfunc, 'expr_func': expr_func})
+
+    assert result1.params == result2.params
+    assert result1.init_params == result2.init_params
+
+
 def test_saveload_modelresult_eval_uncertainty():
     """Test for ModelResult.loads() and eval_uncertainty
     GH Issue #909


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
From ISSUE # #931

Using the `dumps` and `loads` methods on the `ModelResult` class does not properly take into account loading user added functional parameter expressions. The `funcdefs` keyword in `loads` enables users to pass functions to add to the the asteval interpreter, but these are not subsequently passed into `Parameters()` where they are actually added to the asteval symtable. This caused deserialization to not work with `ModelResults` that have parameters with user defined functions as expressions.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:-->

Python: 3.9.7 (default, Oct 15 2021, 14:20:07) 
[Clang 13.0.0 (clang-1300.0.29.3)]

lmfit: 1.2.2, scipy: 1.11.1, numpy: 1.23.5,asteval: 0.9.31, uncertainties: 3.1.7

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [ x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)? 
- [ ] added an example? N/A
