### PR TITLE
Saveload custom func

### DIFF
--- a/lmfit/jsonutils.py
+++ b/lmfit/jsonutils.py
@@ -106,6 +106,8 @@ def decode4js(obj):
         return obj
     out = obj
     classname = obj.pop('__class__', None)
+    if classname is None and isinstance(obj, dict):
+        classname = 'dict'
     if classname is None:
         return obj
     if classname == 'Complex':

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -906,11 +906,9 @@ class Minimizer:
             fmin_kws['options']['maxfun'] = 2*self.max_nfev
         elif method == 'COBYLA':
             # for this method, we explicitly let the solver reach
-            # the users max nfev, and do not abort in _residual.
+            # the users max nfev, and do not abort in _residual
             fmin_kws['options']['maxiter'] = self.max_nfev
             self.max_nfev = 5*self.max_nfev
-
-        # fmin_kws = dict(method=method, options={'maxfun': 2*self.max_nfev})
         fmin_kws.update(self.kws)
 
         if 'maxiter' in kws:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1079,6 +1079,10 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
     def test_composite_plotting(self):
         # test that a composite model has non-empty best_values
         import matplotlib
+        try:
+            matplotlib.pyplot.close('all')
+        except ValueError:
+            pass
         matplotlib.use('Agg')
 
         model1 = models.GaussianModel(prefix='g1_')


### PR DESCRIPTION

This fixes some of the save/load issues lingering after #932, and fixes some test deprecatiosn

Here we add a "version 2" of the JSON encoding of `ModelResult`, now relying on `Parameter.dumps()`. 
Tests are not altered, and should still all pass.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [ ] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
