### PR TITLE
Collection of small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ examples/documentation
 doc/*.pdf
 doc/*.dat
 doc/*.csv
+doc/sg_execution_times.rst
 doc/extensions.py
 build
 dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,13 +23,13 @@ repos:
         args: [--remove]
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-deprecated, flake8-mutable, Flake8-pyproject]
 
 -   repo: https://github.com/PyCQA/isort/
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
     -   id: isort
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -256,7 +256,7 @@ stages:
           displayName: 'Install build, pip, setuptools, wheel, pybind11, and cython'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            export numpy_version=1.26.2
+            export numpy_version=1.26.3
             wget https://github.com/numpy/numpy/releases/download/v${numpy_version}/numpy-${numpy_version}.tar.gz
             tar xzvf numpy-${numpy_version}.tar.gz
             cd numpy-${numpy_version}
@@ -269,7 +269,7 @@ stages:
           displayName: 'Install pythran'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            export scipy_version=1.11.3
+            export scipy_version=1.12.0
             wget https://github.com/scipy/scipy/releases/download/v${scipy_version}/scipy-${scipy_version}.tar.gz
             tar xzvf scipy-${scipy_version}.tar.gz
             cd scipy-${scipy_version}

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,6 +20,7 @@ ALLSPHINXOPTS   = $(SPHINX_OUTPUT) $(SPHINXOPTS) .
 html:  gallery
 	cp sphinx/ext_mathjax.py extensions.py
 	$(SPHINXBUILD) -b html $(SPHINX_OUTPUT) $(SPHINX_OPTS) . $(BUILDDIR)/html
+	./filter_spurious_link_from_html.py
 	@echo
 	@echo "html build finished: $(BUILDDIR)/html."
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -76,6 +76,7 @@ clean:
 	-rm -rf examples/*
 	-rm -rf ../examples/documentation
 	-rm -rf __pycache__
+	-rm -rf sg_execution_times.rst
 
 dirhtml:  gallery
 	$(SPHINXBUILD) -b dirhtml $(SPHINX_OUTPUT) $(SPHINX_OPTS) . $(BUILDDIR)/dirhtml

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,7 +36,7 @@ autoclass_content = 'both'
 # shpinx.ext.intersphinx settings
 intersphinx_mapping = {'py': ('https://docs.python.org/3', None),
                        'numpy': ('https://numpy.org/doc/stable/', None),
-                       'scipy': ('https://matplotlib.org/stable/', None),
+                       'scipy': ('https://docs.scipy.org/doc/scipy/', None),
                        'matplotlib': ('https://matplotlib.org/stable/', None),
                        'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
                        'sympy': ('https://docs.sympy.org/latest/', None),

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -100,7 +100,7 @@ and install using::
 to install the required build dependencies and then do::
 
    python -m build
-   pip install ".[all]'
+   pip install ".[all]"
 
 to generate the wheel and install ``lmfit`` with all its dependencies.
 

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -242,7 +242,7 @@ function as a fitting model.
 
    See :ref:`model_param_hints_section`.
 
-..  automethod:: Model.post_fit
+.. automethod:: Model.post_fit
 
    See :ref:`modelresult_uvars_postfit_section`.
 
@@ -407,6 +407,7 @@ because it has a boolean default value. In some sense,
 However, because it has a default value it is not required to be given for
 each model evaluation or fit, as independent variables are.
 
+
 Defining a ``prefix`` for the Parameters
 ----------------------------------------
 
@@ -547,6 +548,7 @@ initial values for parameters. The methods can be combined, so that you
 can set parameter hints but then change the initial value explicitly with
 :meth:`Model.fit`.
 
+
 .. _model_param_hints_section:
 
 Using parameter hints
@@ -604,24 +606,24 @@ of:
 With that definition, the value (and uncertainty) of the ``fwhm`` parameter
 will be reported in the output of any fit done with that model.
 
+
 .. _model_data_coercion_section:
 
 Data Types for data  and independent data with ``Model``
--------------------------------------------------------------
+--------------------------------------------------------
 
 The model as defined by your model function will use the independent
-variable(s) you specify to best match the data you provide.  The model is meant
+variable(s) you specify to best match the data you provide. The model is meant
 to be an abstract representation for data, but when you do a fit with
 :meth:`Model.fit`, you really need to pass in values for the data to be modeled
 and the independent data used to calculate that data.
 
-
 As discussed in :ref:`fit-data-label`, the mathematical solvers used by
 ``lmfit`` all work exclusively with 1-dimensional numpy arrays of datatype
-(dtype) "float64".  The value of the calculation ``(model-data)*weights`` using
+(dtype) "float64". The value of the calculation ``(model-data)*weights`` using
 the calculation of your model function, and the data and weights you pass in
 **will always be coerced** to an 1-dimensional ndarray with dtype "float64"
-when it is passed to the solver.  If it cannot be coerced, an error will occur
+when it is passed to the solver. If it cannot be coerced, an error will occur
 and the fit will be aborted.
 
 That coercion will usually work for "array like" data that is not already a
@@ -630,25 +632,24 @@ the model function may not always work well for some "array like" data types
 - especially independent data that are in list of numbers and ndarrays of type
 "float32" or "int16" or less precision.
 
-
 To be clear, independent data for models using ``Model`` are meant to be truly
 independent, and not **not** required to be strictly numerical or objects that
-are easily converted to arrays of numbers.  The could, for example, be a
+are easily converted to arrays of numbers. The could, for example, be a
 dictionary, an instance of a user-defined class, or other type of structured
-data.  You can use independent data any way you want in your model function.
+data. You can use independent data any way you want in your model function.
 But, as with almost all the examples given here, independent data is often also
 a 1-dimensional array of values, say ``x``, and a simple view of the fit would
-be to plot the data as ``y`` as a function of ``x``.  Again, this is not
+be to plot the data as ``y`` as a function of ``x``. Again, this is not
 required, but it is very common, especially for novice users.
 
 By default, all data and independent data passed to :meth:`Model.fit` that is
 "array like" - a list or tuple of numbers, a ``pandas.Series``, and
 ``h5py.Dataset``, or any object that has an ``__array__()`` method -- will be
-converted to a "float64" ndarray before the fit begins.  If the array-like data
+converted to a "float64" ndarray before the fit begins. If the array-like data
 is complex, it will be converted to a "complex128" ndarray, which will always
-work too.  This conversion before the fit begins ensures that the model
+work too. This conversion before the fit begins ensures that the model
 function sees only "float64 ndarrays", and nearly guarantees that data type
-conversion will not cause problems for the fit.  But it also means that if you
+conversion will not cause problems for the fit. But it also means that if you
 have passed a ``pandas.Series`` as data or independent data, not all of the
 methods or attributes of that ``Series`` will be available by default within
 the model function.
@@ -668,7 +669,6 @@ types of data to use when fitting data.
 
 Saving and Loading Models
 -------------------------
-
 
 It is sometimes desirable to save a :class:`Model` for later use outside of
 the code used to define the model. Lmfit provides a :func:`save_model`
@@ -719,6 +719,7 @@ To load that later, one might do:
     :hide-output:
 
 See also :ref:`modelresult_saveload_sec`.
+
 
 The :class:`ModelResult` class
 ==============================
@@ -775,7 +776,6 @@ and ``bic``.
 
 .. automethod:: ModelResult.plot_residuals
 
-
 .. method:: ModelResult.iter_cb
 
    Optional callable function, to be called at each fit iteration. This
@@ -798,7 +798,7 @@ categories.
 
 
 Parameters and Variables
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. attribute:: best_values
 
@@ -830,19 +830,18 @@ Parameters and Variables
    List of variable Parameter names used in optimization in the
    same order as the values in :attr:`init_vals` and :attr:`covar`.
 
+
 Fit Arrays and Model
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 .. attribute:: best_fit
 
    numpy.ndarray result of model function, evaluated at provided
    independent variables and with best-fit parameters.
 
-
 .. attribute:: covar
 
    numpy.ndarray (square) covariance matrix returned from fit.
-
 
 .. attribute:: data
 
@@ -866,7 +865,6 @@ Fit Arrays and Model
    interval* in the ``y`` values of the model from
    :meth:`ModelResult.eval_uncertainty` (see :ref:`eval_uncertainty_sec`).
 
-
 .. attribute:: init_fit
 
    numpy.ndarray result of model function, evaluated at provided
@@ -888,9 +886,8 @@ Fit Arrays and Model
    List of components of the :class:`Model`.
 
 
-
 Fit Status
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~
 
 .. attribute:: aborted
 
@@ -943,9 +940,8 @@ Fit Status
    keyword arguments passed to :meth:`Model.fit`, a dict, which will have independent data arrays such as ``x``.
 
 
-
 Fit Statistics
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 .. attribute:: aic
 
@@ -982,7 +978,6 @@ Fit Statistics
 
    Integer number of independent, freely varying variables in fit.
 
-
 .. attribute::  redchi
 
    Floating point reduced chi-square statistic (see :ref:`fit-results-label`).
@@ -1002,7 +997,6 @@ Fit Statistics
 
    Boolean value of whether fit succeeded. This is an optimistic
    view of success, meaning that the method finished without error.
-
 
 
 .. _eval_uncertainty_sec:
@@ -1062,12 +1056,10 @@ model can be calculated and used:
 
 .. versionadded:: 1.2.3
 
-
-
 In addition to the "confidence interval" ``result.dely``, the
 :meth:`ModelResult.eval_uncertainty` method will also estimate the "predicted
 interval" -- the expected range for data matching the model, and hold this in
-``result.dely_predicted``.  An example script showing both confidence and
+``result.dely_predicted``. An example script showing both confidence and
 predicted intervals is shown below:
 
 .. jupyter-execute:: ../examples/doc_model_uncertainty_pred.py
@@ -1076,7 +1068,7 @@ predicted intervals is shown below:
 .. _modelresult_uvars_postfit_section:
 
 Using uncertainties in the fitted parameters for post-fit calculations
---------------------------------------------------------------------------
+----------------------------------------------------------------------
 
 .. versionadded:: 1.2.2
 
@@ -1154,6 +1146,7 @@ To load that later, one might do:
     :hide-output:
 
 .. index:: Composite models
+
 
 .. _composite_models_section:
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1382,7 +1382,7 @@ class Minimizer:
         # a ValueError. Note, you can't initialise with a position if you are
         # reusing the sampler.
         if pos is not None and not reuse_sampler:
-            tpos = np.asfarray(pos)
+            tpos = np.asarray(pos, dtype=np.float64)
             if p0.shape == tpos.shape:
                 pass
             # trying to initialise with a previous chain
@@ -2379,16 +2379,16 @@ def coerce_float64(arr, nan_policy='raise', handle_inf=True,
 
     Notes
     -----
-    Parts of this function are based on scipy/stats/stats.py/_contains_nan
+    Parts of this fudtype=np.float64nction are based on scipy/stats/stats.py/_contains_nan
 
-    support for 'array-like` objects is from numpy `asfarray`, which includes
+    support for 'array-like` objects is from numpy `asarray`, which includes
     lists of numbers, pandas.Series, h5py.Datasets, and many other array-like
     Python objects
     """
     if np.iscomplexobj(arr):
-        arr = np.asfarray(arr, dtype=np.complex128).view(np.float64)
+        arr = np.asarray(arr, dtype=np.complex128).view(np.float64)
     else:
-        arr = np.asfarray(arr, dtype=np.float64)
+        arr = np.asarray(arr, dtype=np.float64)
 
     if ravel:
         arr = arr.ravel(order=ravel_order)

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -22,6 +22,7 @@ import numbers
 import warnings
 
 import numpy as np
+from scipy import __version__ as scipy_version
 from scipy.linalg import LinAlgError, inv
 from scipy.optimize import basinhopping as scipy_basinhopping
 from scipy.optimize import brute as scipy_brute
@@ -904,11 +905,19 @@ class Minimizer:
         fmin_kws = dict(method=method, options={'maxiter': 2*self.max_nfev})
         if method == 'L-BFGS-B':
             fmin_kws['options']['maxfun'] = 2*self.max_nfev
+
         elif method == 'COBYLA':
             # for this method, we explicitly let the solver reach
             # the users max nfev, and do not abort in _residual
             fmin_kws['options']['maxiter'] = self.max_nfev
             self.max_nfev = 5*self.max_nfev
+
+        # FIXME: update when SciPy requirement is >= 1.8
+        # ``maxiter`` deprecated in favor of ``maxfun``
+        elif method == "TNC" and int(scipy_version.split('.')[1]) >= 11:
+            fmin_kws['options']['maxfun'] = 2*self.max_nfev
+            fmin_kws['options'].pop('maxiter')
+
         fmin_kws.update(self.kws)
 
         if 'maxiter' in kws:

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -198,9 +198,9 @@ def coerce_arraylike(x):
     """
     if isinstance(x, (list, tuple, Series)) or hasattr(x, '__array__'):
         if np.isrealobj(x):
-            return np.asfarray(x)
+            return np.asarray(x, dtype=np.float64)
         if np.iscomplexobj(x):
-            return np.asfarray(x, dtype=np.complex128)
+            return np.asarray(x, dtype=np.complex128)
     return x
 
 

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -815,11 +815,11 @@ class Model:
 
         diff = model - data
 
-        if diff.dtype == complex:
+        if diff.dtype is complex:
             # data/model are complex
             diff = diff.ravel().view(float)
             if weights is not None:
-                if weights.dtype == complex:
+                if weights.dtype is complex:
                     # weights are complex
                     weights = weights.ravel().view(float)
                 else:

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1546,7 +1546,7 @@ class ModelResult(Minimizer):
         sigma : float, optional
             Confidence level, i.e. how many sigma (default is 1).
         dscale : float, optional
-            scale for derivative steps (default is 0.01)
+            Scale for derivative steps (default is 0.01).
         **kwargs : optional
             Values of options, independent variables, etcetera.
 
@@ -1568,12 +1568,12 @@ class ModelResult(Minimizer):
            ``sigma=1`` and ``sigma=0.6827`` will give the same results,
            within precision errors.
         3. The derivatives are calculated by stepping each Parameter from its best value to
-           to +/- stderr*dscale, where dscale can be passed in and defaults to 0.01.
-        4. sets attributes of `dely` for the uncertainty of the model
+           to +/- stderr*dscale, where `dscale` can be passed in and defaults to 0.01.
+        4. Sets attributes of `dely` for the uncertainty of the model
            (which will be the same as the array returned by this method) and
            `dely_comps`, a dictionary of `dely` for each component.
-        5. sets the attribute of `dely_predicted` for the 'predicted interval', the sigma-scaled
-           quadrature sum of the uncertainty interval dely and reduced chi-square.  This should
+        5. Sets the attribute of `dely_predicted` for the 'predicted interval', the sigma-scaled
+           quadrature sum of the uncertainty interval `dely` and reduced chi-square. This should
            give an idea of the expected range in the data.
 
         Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ doc = [
     "jupyter_sphinx>=0.2.4",
     "matplotlib",
     "numdifftools",
-    "numexpr",
     "pandas",
     "Pillow",
     "pycairo;platform_system=='Windows'",


### PR DESCRIPTION
#### Description
This PR contains a number of commits with small fixes and housekeeping items:
- update NumPy / SciPy versions in CI
- code changes for NumPy v2 compatibility (backwards compatible) 
- documentation changes for style, fix intersphinx mapping, filter spurious link in Gallery
- fix deprecation in SciPy v11.0

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
Python: 3.12.1 (main, Dec  9 2023, 08:07:48) [Clang 15.0.0 (clang-1500.0.40.1)]
lmfit: 1.2.2.post32+gf4e1e98e, scipy: 1.12.0, numpy: 1.26.3, asteval: 0.9.31, uncertainties: 3.1.7

###### Verification <!-- (delete not applicable items) -->
Have you
- [ ] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
