### PR TITLE
More uniform independent vars

### DIFF
--- a/doc/model.rst
+++ b/doc/model.rst
@@ -323,12 +323,12 @@ have multiple independent variables.
 
 
 By convention and default, the positional arguments (that is, those without
-default values specified in the function signature) other the first argument
-are marked as being Parameters -- these will have an invalid default value (or
-``-Inf``) that must be supplied before using the Parameter. Keyword arguments
-to the model function that have numerical values will also be marked as being
-Parameters, and the supplied numerical value will be used as the default value
-for that Parameter.
+default values specified in the function signature) other than the first
+argument are marked as being Parameters -- these will have an invalid default
+value (or ``-Inf``) that must be supplied before using the Parameter. Keyword
+arguments to the model function that have numerical values will also be marked
+as being Parameters, and the supplied numerical value will be used as the
+default value for that Parameter.
 
 Keyword arguments to the model function that have non-numerical values
 (including ``None``, ``False``, and ``True``, but also strings) will be marked
@@ -426,8 +426,8 @@ Here, ``check_positive`` is listed as an independent variable, because it
 has a default value of ``False``.
 
 The function argument ``N`` is expected to be an Parameter, because it has a
-numerical default value.  This value will be kept as the default value when
-building the Parameters (and note that the default value for ``tau`` is
+numerical default value. This value will be kept as the default value when
+building the Parameters. Also, note that the default value for ``tau`` is
 ``-np.inf``, which will need to be fixed before really be used.
 
 Function arguments with default values of ``None``, ``False``, and ``True`` are
@@ -464,7 +464,7 @@ this makes sense depends on the details of the implementation of the model
 function: it can be sensible (and even intended) for ``gamma`` in the ``voigt``
 function above to be a numerical value that could be a variable Parameter, but
 it is not sensible for the ``check_positive`` argument in ``decay2`` to be
-continuously-valued variable.
+variable that can take any numeric value.
 
 
 

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -6,29 +6,29 @@ Modeling Data and Curve Fitting
 
 .. module:: lmfit.model
 
-A common use of least-squares minimization is *curve fitting*, where one
-has a parametrized model function meant to explain some phenomena and wants
-to adjust the numerical values for the model so that it most closely
-matches some data. With :mod:`scipy`, such problems are typically solved
-with :scipydoc:`optimize.curve_fit`, which is a wrapper around
-:scipydoc:`optimize.leastsq`. Since lmfit's
-:func:`~lmfit.minimizer.minimize` is also a high-level wrapper around
-:scipydoc:`optimize.leastsq` it can be used for curve-fitting problems.
-While it offers many benefits over :scipydoc:`optimize.leastsq`, using
-:func:`~lmfit.minimizer.minimize` for many curve-fitting problems still
-requires more effort than using :scipydoc:`optimize.curve_fit`.
+A common use of least-squares minimization is *curve fitting*, where one has a
+parametrized model function meant to explain some phenomena and wants to adjust
+the numerical values for the model so that it most closely matches some
+data. With :mod:`scipy`, such problems are typically solved with
+:scipydoc:`optimize.curve_fit`, which is a wrapper around
+:scipydoc:`optimize.least_squares`.  While :func:`~lmfit.minimizer.minimize`
+can be used for curve-fitting problems, it is more general and not aimed
+specifically at this common use-case.
 
-The :class:`Model` class in lmfit provides a simple and flexible approach
-to curve-fitting problems. Like :scipydoc:`optimize.curve_fit`, a
-:class:`Model` uses a *model function* -- a function that is meant to
-calculate a model for some phenomenon -- and then uses that to best match
-an array of supplied data. Beyond that similarity, its interface is rather
-different from :scipydoc:`optimize.curve_fit`, for example in that it uses
-:class:`~lmfit.parameter.Parameters`, but also offers several other
-important advantages.
+
+The :class:`Model` class in lmfit provides a simple and flexible approach to
+curve-fitting problems. Like :scipydoc:`optimize.curve_fit`, a :class:`Model`
+uses a *model function* -- a function that is meant to calculate a model for
+some phenomenon -- and then uses that to best match an array of supplied
+data.  Beyond that similarity, the :class:`Model` interface is rather different
+from :scipydoc:`optimize.curve_fit`.  These differences include a) being
+class-based and so having multiple methods for working with :class:`Model`s,
+b) using :class:`~lmfit.parameter.Parameters`, and all of the advantages they
+provide, and c) being easy to combine into composite models.
+
 
 In addition to allowing you to turn any model function into a curve-fitting
-method, lmfit also provides canonical definitions for many known lineshapes
+model, lmfit also provides canonical definitions for many known line shapes
 such as Gaussian or Lorentzian peaks and Exponential decays that are widely
 used in many scientific domains. These are available in the :mod:`models`
 module that will be discussed in more detail in the next chapter
@@ -41,10 +41,10 @@ turning Python functions into high-level fitting models with the
 Motivation and simple example: Fit data to Gaussian profile
 ===========================================================
 
-Let's start with a simple and common example of fitting data to a Gaussian
-peak. As we will see, there is a built-in :class:`GaussianModel` class that
-can help do this, but here we'll build our own. We start with a simple
-definition of the model function:
+We start with a simple and common example of fitting data to a Gaussian
+peak. As we will see, there is a built-in :class:`GaussianModel` class that can
+help do this, but here we'll build our own. We start with a simple definition
+of the model function:
 
 .. jupyter-execute::
     :hide-code:
@@ -62,7 +62,8 @@ definition of the model function:
     def gaussian(x, amp, cen, wid):
         return amp * exp(-(x-cen)**2 / wid)
 
-We want to use this function to fit to data :math:`y(x)` represented by the
+With that function, we can easily calculate a model for our data, and the goal
+here is to use this function to fit to data :math:`y(x)` represented by the
 arrays ``y`` and ``x``.  With :scipydoc:`optimize.curve_fit`, this would be:
 
 .. jupyter-execute::
@@ -76,11 +77,10 @@ arrays ``y`` and ``x``.  With :scipydoc:`optimize.curve_fit`, this would be:
     init_vals = [1, 0, 1]  # for [amp, cen, wid]
     best_vals, covar = curve_fit(gaussian, x, y, p0=init_vals)
 
-That is, we create data, make an initial guess of the model values, and run
-:scipydoc:`optimize.curve_fit` with the model function, data arrays, and
-initial guesses. The results returned are the optimal values for the
-parameters and the covariance matrix. It's simple and useful, but it
-misses the benefits of lmfit.
+That is, we create data (maybe adding a little noise), make an initial guess of
+the model values, and run :scipydoc:`optimize.curve_fit` with the model
+function, data arrays, and initial guesses. The results returned are the
+optimal values for the parameters and the covariance matrix.
 
 With lmfit, we create a :class:`Model` that wraps the ``gaussian`` model
 function, which automatically generates the appropriate residual function,
@@ -95,26 +95,27 @@ signature itself:
     print(f'parameter names: {gmodel.param_names}')
     print(f'independent variables: {gmodel.independent_vars}')
 
-As you can see, the Model ``gmodel`` determined the names of the parameters
-and the independent variables. By default, the first argument of the
-function is taken as the independent variable, held in
-:attr:`independent_vars`, and the rest of the functions positional
-arguments (and, in certain cases, keyword arguments -- see below) are used
-for Parameter names. Thus, for the ``gaussian`` function above, the
-independent variable is ``x``, and the parameters are named ``amp``,
-``cen``, and ``wid``, and -- all taken directly from the signature of the
-model function. As we will see below, you can modify the default
-assignment of independent variable / arguments and specify yourself what
-the independent variable is and which function arguments should be identified
-as parameter names.
+As you can see, the Model ``gmodel`` determined the names of the parameters and
+the independent variables. By default, the first argument of the function is
+taken as the independent variable, held in :attr:`independent_vars`, and the
+rest of the functions positional arguments (and, in certain cases, keyword
+arguments -- see below) are used for Parameter names. Thus, for the
+``gaussian`` function above, the independent variable is ``x``, and the
+parameters are named ``amp``, ``cen``, and ``wid``.  These are all taken
+directly from the signature of the model function. As discussed below, you can
+modify the default assignment of independent variable / arguments and specify
+yourself what the independent variable.
 
+Although the model determines what the parameters should be named,
 :class:`~lmfit.parameter.Parameters` are *not* created when the model is
-created. The model knows what the parameters should be named, but nothing about
-the scale and range of your data. To help you create Parameters for a Model,
-each model has a :meth:`make_params` method that will generate parameters with
-the expected names. You will have to do this, or make Parameters some other way
-(say, with :func:`~lmfit.parameter.create_params`), and assign initial values
-for all Parameters. You can also assign other attributes when doing this:
+created.  That is, the model knows the parameters names, but nothing about the
+scale and range of your data.  You will have to make Parameters for a Model
+yourself.  To help you create Parameters for a Model, each model has a
+:meth:`make_params` method that will generate parameters with the
+expected names.  You can use this method or create Parameters some other way
+(say, with :func:`~lmfit.parameter.create_params`), but you will have to create
+Parameters and assign initial values for all Parameters. You can also assign
+other attributes when doing this:
 
 .. jupyter-execute::
 
@@ -301,21 +302,43 @@ function as a fitting model.
 Determining parameter names and independent variables for a function
 --------------------------------------------------------------------
 
-The :class:`Model` created from the supplied function ``func`` will create a
-:class:`~lmfit.parameter.Parameters` object, and names are inferred from the
-function` arguments, and a residual function is automatically constructed.
+The :class:`Model` created from the supplied function ``func`` will guess which
+function arguments of the model function should be made into
+:class:`~lmfit.parameter.Parameters` object, and which should be considered
+non-varying **independent variables** that need to be specified when evaluating
+or fitting with the Model.
 
-By default, the independent variable is taken as the first argument to the
-function. You can, of course, explicitly set this, and will need to do so
-if the independent variable is not first in the list, or if there is actually
-more than one independent variable.
+By convention and by default, the first argument to the model function is taken
+to be the independent variable -- this is often the ``x`` value for the model.
+You can explicitly set this to be a different functional argument, and will
+need to do so if the independent variable is not first in the list, or if there
+is more than one independent variable.  Since curve fitting most commonly fits
+some function :math:`y(x)`, it is common for the independent variable to be a
+numpy float ndarray of the same length as the data to be fit. While this is
+common, it is not actually required.  The independent variable does not not
+need to be an ndarray, and can be any Python data type, and it is fine to
+have multiple independent variables.
 
-If not specified, Parameters are constructed from all positional arguments
-and all keyword arguments that have a default value that is numerical, except
-the independent variable, of course. Importantly, the Parameters can be
-modified after creation. In fact, you will have to do this because none of the
-parameters have valid initial values. In addition, one can place bounds and
-constraints on Parameters, or fix their values.
+.. versionchanged:: 1.2.3
+
+
+By convention and default, the positional arguments (that is, those without
+default values specified in the function signature) other the first argument
+are marked as being Parameters -- these will have an invalid default value (or
+``-Inf``) that must be supplied before using the Parameter. Keyword arguments
+to the model function that have numerical values will also be marked as being
+Parameters, and the supplied numerical value will be used as the default value
+for that Parameter.
+
+Keyword arguments to the model function that have non-numerical values
+(including ``None``, ``False``, and ``True``, but also strings) will be marked
+as being independent variables and their default value will be stored and used
+unless overwritten.  There is some ambiguity for function arguments that have a
+value supplied in the function signature of ``None``, ``False``, or ``True``.
+These function arguments are tagged as independent variables, but can be made
+into a Parameter with :meth:`Model.make_params`, in which case, they will be
+treated as variables.  An example is given below.
+
 
 
 Explicitly specifying ``independent_vars``
@@ -342,9 +365,9 @@ function is fairly easy. Let's try another one:
     for pname, par in params.items():
         print(pname, par)
 
-Here, ``t`` is assumed to be the independent variable because it is the
-first argument to the function. The other function arguments are used to
-create parameters for the model.
+Here, ``t`` is assumed to be the independent variable because it is the first
+argument to the function. The other function arguments are used to create
+parameters for the model.
 
 If you want ``tau`` to be the independent variable in the above example,
 you can say so:
@@ -370,16 +393,16 @@ independent variable
     keyword argument for each fit with :meth:`Model.fit` or evaluation
     with :meth:`Model.eval`.
 
-Note that independent variables are not required to be arrays, or even
-floating point numbers.
+Note that independent variables are not required to be arrays, or even floating
+point numbers.  Dictionaries or Objects from user-defined classes can be
+independent variables.
 
 
 Functions with keyword arguments
 --------------------------------
 
 If the model function had keyword parameters, these would be turned into
-Parameters if the supplied default value was a valid number (but not
-``None``, ``True``, or ``False``).
+Parameters if the supplied default value was a valid number:
 
 .. jupyter-execute::
 
@@ -392,32 +415,70 @@ Parameters if the supplied default value was a valid number (but not
 
 
     mod = Model(decay2)
+    print(f'independent variables: {mod.independent_vars}')
+
     params = mod.make_params()
     print('Parameters:')
     for pname, par in params.items():
         print(pname, par)
 
-Here, even though ``N`` is a keyword argument to the function, it is turned
-into a parameter, with the default numerical value as its initial value.
-By default, it is permitted to be varied in the fit -- the 10 is taken as
-an initial value, not a fixed value. On the other hand, the
-``check_positive`` keyword argument, was not converted to a parameter
-because it has a boolean default value. In some sense,
-``check_positive`` becomes like an independent variable to the model.
-However, because it has a default value it is not required to be given for
-each model evaluation or fit, as independent variables are.
+Here, ``check_positive`` is listed as an independent variable, because it
+has a default value of ``False``.
+
+The function argument ``N`` is expected to be an Parameter, because it has a
+numerical default value.  This value will be kept as the default value when
+building the Parameters (and note that the default value for ``tau`` is
+``-np.inf``, which will need to be fixed before really be used.
+
+Function arguments with default values of ``None``, ``False``, and ``True`` are
+slightly ambiguous whether they should be considered independent variables or
+Parameters.  That is, in many contexts (including basic arithmetic) ``True``
+acts like the integer 1, and ``False`` acts like 0.  A default value of
+``None`` might be used to signal some default behavior.  For example, the
+builtin :func:`lmfit.lineshapes.voigt` function is defined as
+
+.. jupyter-execute::
+
+
+    def voigt(x, amplitude=1.0, center=0.0, sigma=1.0, gamma=None):
+        """Return a 1-dimensional Voigt function.
+            ...
+        """
+        if gamma is None:
+            gamma = sigma
+        z = (x-center + 1j*gamma) / max(tiny, (sigma*s2))
+        return amplitude*real(wofz(z)) / max(tiny, (sigma*s2pi))
+
+    mod = Model(voigt)
+    print(f'independent variables: {mod.independent_vars}')
+
+    params = mod.make_params(amplitude=10, center=5, sigma=2)
+
+    # or
+    params2 = mod.make_params(amplitude=10, center=5, sigma=2, gamma=1.5)
+
+In this case, ``gamma`` will be listed as an independent variable.  But because
+its default value is ``None`` (or ``True`` or ``False``) it can be made a
+Parameter that can be varied independently as shown above.  Of course, whether
+this makes sense depends on the details of the implementation of the model
+function: it can be sensible (and even intended) for ``gamma`` in the ``voigt``
+function above to be a numerical value that could be a variable Parameter, but
+it is not sensible for the ``check_positive`` argument in ``decay2`` to be
+continuously-valued variable.
+
+
 
 
 Defining a ``prefix`` for the Parameters
 ----------------------------------------
 
-As we will see in the next chapter when combining models, it is sometimes
-necessary to decorate the parameter names in the model, but still have them
-be correctly used in the underlying model function. This would be
-necessary, for example, if two parameters in a composite model (see
-:ref:`composite_models_section` or examples in the next chapter) would have
-the same name. To avoid this, we can add a ``prefix`` to the
-:class:`Model` which will automatically do this mapping for us.
+As we will see below when combining models, it is sometimes necessary to
+decorate the parameter names in the model, but still have them be correctly
+used in the underlying model function. This would be necessary, for example, if
+two parameters in a composite model (see :ref:`composite_models_section` or
+examples in the next chapter) would have the same name. To avoid this, we can
+add a ``prefix`` to the :class:`Model` which will automatically do this mapping
+for us.
 
 .. jupyter-execute::
 

--- a/examples/example_basinhopping.py
+++ b/examples/example_basinhopping.py
@@ -1,0 +1,59 @@
+"""
+Fit comparing leastsq and basin hopping, or other methods
+============================================================
+
+This example compares the ``leastsq`` and ``basinhopping`` algorithms
+on a decaying sine wave.  Note that this can be used to compare other
+fitting algorithms too.
+"""
+
+import sys
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import lmfit
+
+VALID_METHODS = ['least_squares', 'differential_evolution', 'brute',
+                 'basinhopping', 'ampgo', 'nelder', 'lbfgsb', 'powell', 'cg',
+                 'newton', 'cobyla', 'bfgs', 'tnc', 'trust-ncg', 'trust-exact',
+                 'trust-krylov', 'trust-constr', 'dogleg', 'slsqp', 'emcee',
+                 'shgo', 'dual_annealing']
+
+
+def sine_decay(x, amplitude, frequency, decay, offset):
+    return offset + amplitude * np.sin(x*frequency) * np.exp(-x/decay)
+
+
+x = np.linspace(0, 20, 201)
+np.random.seed(2)
+
+ydat = sine_decay(x, 12.5, 2.0, 4.5, 1.25) + np.random.normal(size=len(x), scale=0.40)
+
+model = lmfit.Model(sine_decay)
+params = model.make_params(amplitude={'value': 10, 'min': 0, 'max': 1000},
+                           frequency={'value': 2.0, 'min': 0, 'max': 6.0},
+                           decay={'value': 2.0, 'min': 0.001, 'max': 12},
+                           offset=1.0)
+
+# fit with leastsq
+result0 = model.fit(ydat, params, x=x, method='leastsq')
+print("# Fit using leastsq:")
+print(result0.fit_report())
+
+method2 = 'basinhopping'
+if len(sys.argv) > 1 and sys.argv[1] in VALID_METHODS:
+    method2 = sys.argv[1]
+
+
+# fit with other method
+result = model.fit(ydat, params, x=x, method=method2)
+print(f"\n#####################\n# Fit using {method2}:")
+print(result.fit_report())
+
+# plot comparison
+plt.plot(x, ydat, 'o', label='data')
+plt.plot(x, result0.best_fit, '+', label='leastsq')
+plt.plot(x, result.best_fit, '-', label=method2)
+plt.legend()
+plt.show()

--- a/examples/example_sympy.py
+++ b/examples/example_sympy.py
@@ -25,7 +25,6 @@ exp_back = sympy_parser.parse_expr('B*exp(-x/xw)')
 
 model_list = sympy.Array((gauss_peak1, gauss_peak2, exp_back))
 model = sum(model_list)
-print(model)
 
 ###############################################################################
 # We are using SymPy's lambdify function to make a function from the model
@@ -50,7 +49,7 @@ for c in yi:
 
 ###############################################################################
 # Next, we will just create a lmfit model from the function and fit the data.
-lm_mod = lmfit.Model(model_func, independent_vars=('x'))
+lm_mod = lmfit.Model(model_func, independent_vars=('x',))
 res = lm_mod.fit(data=yn, **param_values)
 
 ###############################################################################
@@ -65,9 +64,10 @@ plt.legend()
 # reason. Both can be expressed by just substituting the variables.
 model2 = model.subs('sigma2', 'sigma1').subs('A2', '3/2*A1')
 model2_func = sympy.lambdify(list(model2.free_symbols), model2)
-lm_mod = lmfit.Model(model2_func, independent_vars=('x'))
+lm_mod = lmfit.Model(model2_func, independent_vars=('x',))
 param2_values = dict(x=x, A1=2, sigma1=1, xc1=2, xc2=5, xw=4, B=5)
 res2 = lm_mod.fit(data=yn, **param2_values)
 res2.plot_fit()
 plt.plot(x, y, label='true')
 plt.legend()
+plt.show()

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -2248,7 +2248,7 @@ class Minimizer:
             - `'basinhopping'`: basinhopping
             - `'ampgo'`: Adaptive Memory Programming for Global
               Optimization
-            - '`nelder`': Nelder-Mead
+            - `'nelder'`: Nelder-Mead
             - `'lbfgsb'`: L-BFGS-B
             - `'powell'`: Powell
             - `'cg'`: Conjugate-Gradient

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -253,7 +253,7 @@ class Model:
         3. Specifying `independent_vars` here will explicitly name the
         independent variables for the Model.  in contrast, `param_names` is
         meant to help infer Parameter names for keyword arguments defined with
-        **kws in the Model function.
+        ``**kws`` in the Model function.
 
         4. `nan_policy` sets what to do when a NaN or missing value is
         seen in the data. Should be one of:

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -793,12 +793,13 @@ class Model:
 
         # check for parameters that were initially flagged as independent
         # variables because the function signature used "key=None", "key=True",
-        # or "key=False" these could actually be variables
+        # or "key=False": these could actually be variables
         for key, val in kwargs.items():
             if key in params:
                 continue
             if key in self.independent_vars:
-                if self.independent_vars_defvals.get(key, inspect._empty) is None:
+                dxval = self.independent_vars_defvals.get(key, inspect._empty)
+                if dxval is None or isinstance(dxval, bool):
                     name = f"{self._prefix}{key}"
                     par = Parameter(name=name)
                     setpar(par, val)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -244,13 +244,18 @@ class Model:
 
         Notes
         -----
-        1. Parameter names are inferred from the function arguments, and a
-        residual function is automatically constructed.
-
-        2. The model function must return an array that will be the same
+        1. The model function must return an array that will be the same
         size as the data being modeled.
 
-        3. `nan_policy` sets what to do when a NaN or missing value is
+        2. Parameter names are inferred from the function arguments by default,
+        and a residual function is automatically constructed.
+
+        3. Specifying `independent_vars` here will explicitly name the
+        independent variables for the Model.  in contrast, `param_names` is
+        meant to help infer Parameter names for keyword arguments defined with
+        **kws in the Model function.
+
+        4. `nan_policy` sets what to do when a NaN or missing value is
         seen in the data. Should be one of:
 
            - `'raise'` : raise a `ValueError` (default)
@@ -294,6 +299,7 @@ class Model:
 
         self.opts = kws
         # the following has been changed from OrderedSet for the time being
+        self.independent_vars_defvals = {}
         self.param_hints = {}
         self._param_names = []
         self._parse_params()
@@ -515,40 +521,62 @@ class Model:
         # 2. modern, best-practice approach: use inspect.signature
         else:
             pos_args = []
+            default_vals = {}
+            indep_vars = []
             sig = inspect.signature(self.func)
             for fnam, fpar in sig.parameters.items():
                 if fpar.kind == fpar.VAR_KEYWORD:
                     keywords_ = fnam
-                elif fpar.kind == fpar.POSITIONAL_OR_KEYWORD:
-                    if fpar.default == fpar.empty:
+                elif fpar.kind in (fpar.POSITIONAL_ONLY, fpar.POSITIONAL_OR_KEYWORD):
+                    default_vals[fnam] = fpar.default
+                    if (isinstance(fpar.default, (float, int, complex))
+                       and not isinstance(fpar.default, bool)):
+                        kw_args[fnam] = fpar.default
+                    elif fpar.default == fpar.empty:
                         pos_args.append(fnam)
                     else:
                         kw_args[fnam] = fpar.default
+                        indep_vars.append(fnam)
                 elif fpar.kind == fpar.VAR_POSITIONAL:
                     raise ValueError(f"varargs '*{fnam}' is not supported")
         # inspection done
 
         self._func_haskeywords = keywords_ is not None
-        self._func_allargs = pos_args + list(kw_args.keys())
-        allargs = self._func_allargs
+        self._func_allargs = list(default_vals.keys())
+        for key in kw_args:
+            if key not in self._func_allargs:
+                self._func_allargs.append(key)
 
-        if len(allargs) == 0 and keywords_ is not None:
+        if len(self._func_allargs) == 0 and keywords_ is not None:
             return
 
+        self.independent_vars_defvals = {}
         # default independent_var = 1st argument
         if self.independent_vars is None:
-            self.independent_vars = [pos_args[0]]
+            self.independent_vars = [pos_args.pop(0)]
+            # default values for independent variables
+            for vnam in indep_vars:
+                dval = default_vals[vnam]
+                if vnam in self.opts:
+                    dval = self.opts[vnam]
+                self.independent_vars_defvals[vnam] = dval
+                if vnam not in self.independent_vars:
+                    self.independent_vars.append(vnam)
 
         # default param names: all positional args
         # except independent variables
         self.def_vals = {}
         might_be_param = []
         if self._param_root_names is None:
-            self._param_root_names = pos_args[:]
+            self._param_root_names = []
+            for pname in pos_args:
+                if pname not in self.independent_vars:
+                    self._param_root_names.append(pname)
             for key, val in kw_args.items():
                 if (not isinstance(val, bool) and
                         isinstance(val, (float, int))):
-                    self._param_root_names.append(key)
+                    if key not in self._param_root_names:
+                        self._param_root_names.append(key)
                     self.def_vals[key] = val
                 elif val is None:
                     might_be_param.append(key)
@@ -574,10 +602,10 @@ class Model:
         # The implicit magic in fit() requires us to disallow some
         fname = self.func.__name__
         for arg in self.independent_vars:
-            if arg not in allargs or arg in self._forbidden_args:
+            if arg not in self._func_allargs or arg in self._forbidden_args:
                 raise ValueError(self._invalid_ivar % (arg, fname))
         for arg in names:
-            if (self._strip_prefix(arg) not in allargs or
+            if (self._strip_prefix(arg) not in self._func_allargs or
                     arg in self._forbidden_args):
                 raise ValueError(self._invalid_par % (arg, fname))
         # the following as been changed from OrderedSet for the time being.
@@ -763,6 +791,19 @@ class Model:
             if name not in self._param_names:
                 self._param_names.append(name)
 
+        # check for parameters that were initially flagged as independent
+        # variables because the function signature used "key=None", "key=True",
+        # or "key=False" these could actually be variables
+        for key, val in kwargs.items():
+            if key in params:
+                continue
+            if key in self.independent_vars:
+                if self.independent_vars_defvals.get(key, inspect._empty) is None:
+                    name = f"{self._prefix}{key}"
+                    par = Parameter(name=name)
+                    setpar(par, val)
+                    params.add(par)
+
         for p in params.values():
             p._delay_asteval = False
         return params
@@ -862,8 +903,9 @@ class Model:
         if kwargs is None:
             kwargs = {}
         out = {}
-        out.update(self.opts)
-
+        for key, val in self.independent_vars_defvals.items():
+            if val is not inspect._empty:
+                out[key] = val
         # 0: if a keyword argument is going to overwrite a parameter,
         #    save that value so it can be restored before returning
         saved_values = {}
@@ -892,10 +934,12 @@ class Model:
                         out[name] = params[fullname].value
 
         # 3. kwargs might directly update function arguments
+        validnames = [ivar for ivar in self.independent_vars]
+        validnames.extend(self._func_allargs)
         for name, val in kwargs.items():
             if strip:
                 name = self._strip_prefix(name)
-            if name in self._func_allargs or self._func_haskeywords:
+            if name in validnames or self._func_haskeywords:
                 out[name] = val
 
         # 4. finally, reset any values that have overwritten parameter values
@@ -1105,15 +1149,19 @@ class Model:
         # If independent_vars and data are alignable (pandas), align them,
         # and apply the mask from above if there is one.
         for var in self.independent_vars:
-            if not np.isscalar(kwargs[var]):
-                kwargs[var] = _align(kwargs[var], mask, data)
+            if var not in params:
+                if var not in kwargs:
+                    raise ValueError(f"'Missing independent variable '{var}'")
+                if not np.isscalar(kwargs[var]):
+                    kwargs[var] = _align(kwargs[var], mask, data)
 
         if coerce_farray:
             # coerce data and independent variable(s) that are 'array-like' (list,
             # tuples, pandas Series) to float64/complex128.
             data = coerce_arraylike(data)
             for var in self.independent_vars:
-                kwargs[var] = coerce_arraylike(kwargs[var])
+                if var not in params and var in kwargs:
+                    kwargs[var] = coerce_arraylike(kwargs[var])
 
         if fit_kws is None:
             fit_kws = {}


### PR DESCRIPTION


#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

This is a change to ``Model`` to make the assignment of independent variables from function arguments a bit clearer.   This is a more complete version of what @schtandard was trying to do with #925 and #926 (and apologies for taking so long on this!)

With this change, function arguments with non-numeric default values will now be listed as independent variables, by default.  That is, with a mode function of 
```
def mymodel(x, center=5, check_positive=True):
  . ...

mod = Model(mymodel)
print(mod.independent_vars)
```
will now give ``['x', 'check_positive']``.  The default value will be kept and used as a default value. 

There is sort of an interesting case of `lmfit.lineshapes.voigt`, which has

```
def voigt(x, amplitude=1.0, center=0.0, sigma=1.0, gamma=None):
    """Return a 1-dimensional Voigt function.
        ...
    """
    if gamma is None:
        gamma = sigma
    ...
```

With the change here, ``gamma`` is initially listed as an independent variable, with default value ``None``.  But it can still be turned into a Parameter to vary (or, I suppose constrain some other way) in the fit.     I sort of struggled with this, and currently this "turn a function argument that would be an independent variable into a Parameter" can only be done when the default value is ``None`` or a boolean (``True`` / ``False``)

After review, this should probably be squashed and merged.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.11.5 | packaged by conda-forge | (main, Aug 27 2023, 03:35:23) [Clang 15.0.7 ]

lmfit: 1.2.2.post35+gc9c2b2d.d20240223, scipy: 1.11.4, numpy: 1.26.2, asteval: 0.9.31, uncertainties: 3.1.7


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
