### PR TITLE
Allow model opts

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -309,7 +309,7 @@ class Model:
             name = self.func.__name__
         self._name = name
 
-    def _reprstring(self, long=False):
+    def _reprstring(self, long=True):
         out = self._name
         opts = []
         if len(self._prefix) > 0:
@@ -468,7 +468,7 @@ class Model:
     @property
     def name(self):
         """Return Model name."""
-        return self._reprstring(long=False)
+        return self._reprstring(long=True)
 
     @name.setter
     def name(self, value):
@@ -497,8 +497,7 @@ class Model:
 
     def __repr__(self):
         """Return representation of Model."""
-        # could be just self._reprstring(long=True)
-        return f"<lmfit.Model: {self.name}>"
+        return self._reprstring(long=True)
 
     def copy(self, **kwargs):
         """DOES NOT WORK."""
@@ -1273,7 +1272,7 @@ class CompositeModel(Model):
         self.opts = deepcopy(self.right.opts)
         self.opts.update(self.left.opts)
 
-    def _reprstring(self, long=False):
+    def _reprstring(self, long=True):
         return (f"({self.left._reprstring(long=long)} "
                 f"{self._known_ops.get(self.op, self.op)} "
                 f"{self.right._reprstring(long=long)})")

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -497,6 +497,7 @@ class Model:
 
     def __repr__(self):
         """Return representation of Model."""
+        # could be just self._reprstring(long=True)
         return f"<lmfit.Model: {self.name}>"
 
     def copy(self, **kwargs):
@@ -904,6 +905,7 @@ class Model:
         if kwargs is None:
             kwargs = {}
         out = {}
+        out.update(self.opts)
         for key, val in self.independent_vars_defvals.items():
             if val is not inspect._empty:
                 out[key] = val
@@ -1150,7 +1152,7 @@ class Model:
         # If independent_vars and data are alignable (pandas), align them,
         # and apply the mask from above if there is one.
         for var in self.independent_vars:
-            if var not in params:
+            if var not in params and var not in self.opts:
                 if var not in kwargs:
                     raise ValueError(f"'Missing independent variable '{var}'")
                 if not np.isscalar(kwargs[var]):

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -509,6 +509,8 @@ class Model:
             return
         kw_args = {}
         keywords_ = None
+        indep_vars = []
+        default_vals = {}
         # need to fetch the following from the function signature:
         #   pos_args: list of positional argument names
         #   kw_args: dict of keyword arguments with default values
@@ -516,13 +518,13 @@ class Model:
         # 1. limited support for asteval functions as the model functions:
         if hasattr(self.func, 'argnames') and hasattr(self.func, 'kwargs'):
             pos_args = self.func.argnames[:]
+            default_vals = {v: inspect._empty for v in pos_args}
             for name, defval in self.func.kwargs:
                 kw_args[name] = defval
+                default_vals[name] = defval
         # 2. modern, best-practice approach: use inspect.signature
         else:
             pos_args = []
-            default_vals = {}
-            indep_vars = []
             sig = inspect.signature(self.func)
             for fnam, fpar in sig.parameters.items():
                 if fpar.kind == fpar.VAR_KEYWORD:

--- a/lmfit/models.py
+++ b/lmfit/models.py
@@ -1383,8 +1383,8 @@ class ThermalDistributionModel(Model):
 
     valid_forms = ('bose', 'maxwell', 'fermi')
 
-    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
-                 form='bose', **kwargs):
+    def __init__(self, independent_vars=['x', 'form'], prefix='',
+                 nan_policy='raise', form='bose', **kwargs):
         kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'form': form, 'independent_vars': independent_vars})
         super().__init__(thermal_distribution, **kwargs)
@@ -1544,8 +1544,8 @@ class StepModel(Model):
 
     valid_forms = ('linear', 'atan', 'arctan', 'erf', 'logistic')
 
-    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
-                 form='linear', **kwargs):
+    def __init__(self, independent_vars=['x', 'form'], prefix='',
+                 nan_policy='raise', form='linear', **kwargs):
         kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'form': form, 'independent_vars': independent_vars})
         super().__init__(step, **kwargs)
@@ -1604,8 +1604,8 @@ class RectangleModel(Model):
 
     valid_forms = ('linear', 'atan', 'arctan', 'erf', 'logistic')
 
-    def __init__(self, independent_vars=['x'], prefix='', nan_policy='raise',
-                 form='linear', **kwargs):
+    def __init__(self, independent_vars=['x', 'form'], prefix='',
+                 nan_policy='raise', form='linear', **kwargs):
         kwargs.update({'prefix': prefix, 'nan_policy': nan_policy,
                        'form': form, 'independent_vars': independent_vars})
         super().__init__(rectangle, **kwargs)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -281,7 +281,7 @@ def test_Model_getter_param_names(gmodel):
 
 def test_Model__repr__(gmodel):
     """Test for Model class __repr__ method."""
-    assert gmodel.__repr__() == '<lmfit.Model: Model(gaussian)>'
+    assert 'Model(gaussian)' in gmodel.__repr__()
 
 
 def test_Model_copy(gmodel):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -884,10 +884,23 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         step:  form='linear'
         voigt: gamma=None,     can become a variable!!
         """
-        stepmod = Model(step)
-        assert 'x' in stepmod.independent_vars
-        assert 'form' in stepmod.independent_vars
-        assert 'linear' == stepmod.independent_vars_defvals.get('form', None)
+        stepmod1 = Model(step)
+        assert 'x' in stepmod1.independent_vars
+        assert 'form' in stepmod1.independent_vars
+        assert 'linear' == stepmod1.independent_vars_defvals.get('form', None)
+
+        stepmod2 = Model(step, form='arctan')
+        assert 'x' in stepmod2.independent_vars
+        assert 'form' in stepmod2.independent_vars
+        assert 'arctan' == stepmod2.independent_vars_defvals.get('form', None)
+
+        x = np.linspace(0, 30, 301)
+        pars = stepmod1.make_params(amplitude=10, center=14, sigma=2.5)
+        yline = stepmod1.eval(pars, x=x)
+        yatan = stepmod2.eval(pars, x=x)
+
+        assert (yatan-yline).std() > 0.1
+        assert (yatan-yline).ptp() > 1.0
 
         voigtmod = Model(voigt)
         assert 'x' in voigtmod.independent_vars


### PR DESCRIPTION


#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->

This restores the behavior of setting a non-default keyword value for a Model function argument when creating a Model.  That is, in 1.3.0, 

```
from lmfit import Model
from lmfit.lineshapes import step

mymodel  = Model(step, form='erf')
```

could sometimes fail to set the form to `erf`.  This is true in `StepModel`, for example, as it set the independent variables to ['x'].

The fix here is sort of "belt and suspenders" in that: the form above should normally work in 1.3.0, but now that new default value (held in `Model.opts = {'form': 'erf'}`) is used, and then any independent variables are set, and then any runtime keyword arguments.
 
See #947 

Not being able to leave well enough alone, I also tweaked `Model.__repr__()` to use `Model._reprsting()` and to use `long=True` by default.   With this, for example, the repr for `StepModel` will always show the `form`.


This can be squashed-and-merged or the repr string change can be removed.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

Python: 3.11.5 | packaged by conda-forge | (main, Aug 27 2023, 03:35:23) [Clang 15.0.7 ]

lmfit: 1.3.0.post2+gcf2626b.d20240407, scipy: 1.12.0, numpy: 1.26.4, asteval: 0.9.32, uncertainties: 3.1.7


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?

