### PR TITLE
transform 0-d arrays into 1-d to check their length

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1686,7 +1686,7 @@ class ModelResult(Minimizer):
         nvarys = self.nvarys
         # ensure fjac and df2 are correct size if independent var updated by kwargs
         feval = self.model.eval(params, **userkws)
-        ndata = feval.view('float64').ravel().size  # allows feval to be complex
+        ndata = np.atleast_1d(feval).view('float64').ravel().size  # allows feval to be complex
         covar = self.covar
         if any(p.stderr is None for p in params.values()):
             return np.zeros(ndata)
@@ -1717,8 +1717,8 @@ class ModelResult(Minimizer):
 
             pars[pname].value = val0
             for key in fjac:
-                fjac[key][i] = (res1[key].view('float64')
-                                - res2[key].view('float64')) / (2*dval)
+                fjac[key][i] = (np.atleast_1d(res1[key]).view('float64').ravel()
+                                - np.atleast_1d(res2[key]).view('float64').ravel()) / (2*dval)
 
         for i in range(nvarys):
             for j in range(nvarys):
@@ -1736,6 +1736,9 @@ class ModelResult(Minimizer):
         if feval.dtype in ('complex64', 'complex128'):
             for key in fjac:
                 df2[key] = df2[key].view(feval.dtype)
+
+        for key in fjac:
+            df2[key] = df2[key].reshape(feval.shape)
 
         df2_total = df2.pop('0')
         self.dely = scale * np.sqrt(df2_total)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1686,18 +1686,18 @@ class ModelResult(Minimizer):
         nvarys = self.nvarys
         # ensure fjac and df2 are correct size if independent var updated by kwargs
         feval = self.model.eval(params, **userkws)
-        ndata = np.atleast_1d(feval).view('float64').shape  # allows feval to be complex
+        ndata = feval.view('float64').ravel().size  # allows feval to be complex
         covar = self.covar
         if any(p.stderr is None for p in params.values()):
             return np.zeros(ndata)
 
         # '0' would be an invalid prefix, here signifying 'Full'
-        fjac = {'0': np.zeros((nvarys, *ndata), dtype='float64')}
+        fjac = {'0': np.zeros((nvarys, ndata), dtype='float64')}
         df2 = {'0': np.zeros(ndata, dtype='float64')}
 
         for comp in self.model.components:
             label = comp.prefix if len(comp.prefix) > 1 else comp._name
-            fjac[label] = np.zeros((nvarys, *ndata), dtype='float64')
+            fjac[label] = np.zeros((nvarys, ndata), dtype='float64')
             df2[label] = np.zeros(ndata, dtype='float64')
 
         # find derivative by hand!
@@ -1717,8 +1717,8 @@ class ModelResult(Minimizer):
 
             pars[pname].value = val0
             for key in fjac:
-                fjac[key][i] = (np.atleast_1d(res1[key]).view('float64')
-                                - np.atleast_1d(res2[key]).view('float64')) / (2*dval)
+                fjac[key][i] = (res1[key].view('float64')
+                                - res2[key].view('float64')) / (2*dval)
 
         for i in range(nvarys):
             for j in range(nvarys):

--- a/tests/test_model_uncertainties.py
+++ b/tests/test_model_uncertainties.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from lmfit.lineshapes import gaussian
+from lmfit.model import Model
 from lmfit.models import ExponentialModel, GaussianModel, LinearModel
 
 
@@ -127,3 +128,23 @@ def test_component_uncertainties():
     assert result.dely_comps['g2_'].mean() < 1.5
     assert result.dely_comps['bkg_'].mean() > 0.5
     assert result.dely_comps['bkg_'].mean() < 1.5
+
+
+def test_scalar_independent_vars():
+    """Github #951"""
+    mr = LinearModel().fit(data=[1, 2, 4], x=[1, 2, 3])
+
+    assert_allclose(mr.eval_uncertainty(x=1.2), np.array([0.60629034]))
+    assert_allclose(mr.eval_uncertainty(x=np.array(1.2j)), np.array([1.15903153+0.17475665j]))
+
+
+def test_multidim_model():
+    """test models that return a multi-dimension output"""
+    def fit(x, p=2):
+        return np.array([x, p*x])
+    model = Model(fit)
+
+    mr = model.fit(data=np.array([[1, 2, 3], [2, 3, 5]]), x=np.array([1, 2, 3]))
+
+    assert_allclose(mr.eval_uncertainty(x=np.array([3, 4])), np.array([[0, 0], [0.18432744, 0.24576991]]))
+    assert_allclose(mr.eval_uncertainty(x=np.array([3j, 4j])), np.array([[0, 0], [0.13033918+0.13033918j, 0.17378557+0.17378557j]]))


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
Closes: #951.
The solution implemented here is to transform 0-d arrays into 1-d using np.at_least_1d as recommended here: https://stackoverflow.com/a/4565910. 

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.10.14 (main, Mar 19 2024, 21:46:16) [Clang 15.0.0 (clang-1500.3.9.4)]

lmfit: 1.3.0.post2+gcf2626b7, scipy: 1.11.4, numpy: 1.26.3,asteval: 0.9.32, uncertainties: 3.1.6

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
