### PR TITLE
Numpy2 fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,13 @@ exclude: 'doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.16.0
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
     -   id: check-ast
     -   id: check-builtin-literals
@@ -23,7 +23,7 @@ repos:
         args: [--remove]
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+    rev: 7.1.0
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-deprecated, flake8-mutable, Flake8-pyproject]
@@ -51,14 +51,14 @@ repos:
     -   id: python-check-blanket-noqa
 
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.6
+    rev: v2.3.0
     hooks:
     -   id: codespell
         files: '.py|.rst'
         exclude: 'doc/doc_examples_to_gallery.py|.ipynb'
         # escaped characters currently do not work correctly
         # so \nnumber is considered a spelling error....
-        args: ["-L nnumber", "-L mone"]
+        args: ["-L nnumber", "-L mone", "-L assertIn", "-L efine",]
 
 -   repo: https://github.com/asottile/yesqa
     rev: v1.5.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -256,7 +256,7 @@ stages:
           displayName: 'Install build, pip, setuptools, wheel, pybind11, and cython'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            export numpy_version=1.26.4
+            export numpy_version=2.0.0
             wget https://github.com/numpy/numpy/releases/download/v${numpy_version}/numpy-${numpy_version}.tar.gz
             tar xzvf numpy-${numpy_version}.tar.gz
             cd numpy-${numpy_version}
@@ -269,7 +269,7 @@ stages:
           displayName: 'Install pythran'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            export scipy_version=1.13.0
+            export scipy_version=1.14.0
             wget https://github.com/scipy/scipy/releases/download/v${scipy_version}/scipy-${scipy_version}.tar.gz
             tar xzvf scipy-${scipy_version}.tar.gz
             cd scipy-${scipy_version}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ stages:
           displayName: 'Install dependencies'
         - script: |
             python -m pip install --upgrade build pip wheel
-            python -m pip install asteval==0.9.28 numpy==1.23.0 scipy==1.8.0 uncertainties==3.1.4
+            python -m pip install asteval==1.0 numpy==1.23.0 scipy==1.8.0 uncertainties==3.2.2
           displayName: 'Install minimum required version of dependencies'
         - script: |
             python -m build

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -38,8 +38,8 @@ Lmfit works with `Python`_ versions 3.8 and higher. Version
 Lmfit requires the following Python packages, with versions given:
    * `NumPy`_ version 1.23 or higher.
    * `SciPy`_ version 1.8 or higher.
-   * `asteval`_ version 0.9.28 or higher.
-   * `uncertainties`_ version 3.1.4 or higher.
+   * `asteval`_ version 1.0 or higher.
+   * `uncertainties`_ version 3.2.2 or higher.
    * `dill`_ version 0.3.4 or higher.
 
 All of these are readily available on PyPI, and are installed

--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -181,9 +181,8 @@ class Parameters(dict):
         params = [self[k] for k in self]
 
         # find the symbols from _asteval.symtable, that need to be remembered.
-        sym_unique = self._asteval.user_defined_symbols()
         unique_symbols = {key: deepcopy(self._asteval.symtable[key])
-                          for key in sym_unique}
+                          for key in self._asteval.user_defined_symbols()}
 
         return self.__class__, (), {'unique_symbols': unique_symbols,
                                     'params': params}
@@ -567,9 +566,8 @@ class Parameters(dict):
 
         """
         params = [p.__getstate__() for p in self.values()]
-        sym_unique = self._asteval.user_defined_symbols()
         unique_symbols = {key: encode4js(deepcopy(self._asteval.symtable[key]))
-                          for key in sym_unique}
+                          for key in self._asteval.user_defined_symbols()}
         return json.dumps({'unique_symbols': unique_symbols,
                            'params': params}, **kws)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ force_sort_within_sections = "True"
 [tool.rstcheck]
 report_level = "WARNING"
 ignore_substitutions = [
-    "release"
+    "release",
 ]
 ignore_roles = [
     "scipydoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,11 @@ build-backend = "setuptools.build_meta"
 name = "lmfit"
 dynamic = ["version"]
 dependencies = [
-    "asteval>=0.9.28",
+    "asteval>=1.0",
     "numpy>=1.19",
     "scipy>=1.6",
-    "uncertainties>=3.1.4",
-    "dill>=0.3.4"
+    "uncertainties>=3.2.2",
+    "dill>=0.3.4",
 ]
 requires-python = ">= 3.8"
 authors = [

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -900,7 +900,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
         yatan = stepmod2.eval(pars, x=x)
 
         assert (yatan-yline).std() > 0.1
-        assert (yatan-yline).ptp() > 1.0
+        assert np.ptp(yatan-yline) > 1.0
 
         voigtmod = Model(voigt)
         assert 'x' in voigtmod.independent_vars


### PR DESCRIPTION
#### Description

This fixes a few problems with NumPy 2.

It fixes #958 by explicitly removing a few odd non-serializable functions if using NumPy2 and a version of asteval that still includes those.  That is, this is really a problem with asteval exporting numpy functions that it shouldn't (and are deprecated and not really needed anyway).  But, until that is fixed in asteval (in progress), and that version of asteval is required, it is probably safest to look for and remove those offending functions,

This adds `packaging` as a dependency in order to compare versions.

This also updates the "latest" variations of the tests to use "numpy>=2.0"

This does not alter the test labeled "development version", but that might be slightly dated.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

Python: 3.12.4 | packaged by conda-forge | (main, Jun 17 2024, 10:11:10) [Clang 16.0.6 ]

lmfit: 1.3.1.post1+geee021f6.d20240629, scipy: 1.14.0, numpy: 2.0.0, asteval: 0.9.33, uncertainties: 3.2.1

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
