### PR TITLE
preserve Parameter subclass  when copying Parameters

### DIFF
--- a/lmfit/parameter.py
+++ b/lmfit/parameter.py
@@ -127,17 +127,7 @@ class Parameters(dict):
         parameter_list = []
         for key, par in self.items():
             if isinstance(par, Parameter):
-                param = Parameter(name=par.name,
-                                  value=par.value,
-                                  min=par.min,
-                                  max=par.max)
-                param.vary = par.vary
-                param.brute_step = par.brute_step
-                param.stderr = par.stderr
-                param.correl = deepcopy(par.correl)
-                param.init_value = par.init_value
-                param.expr = par.expr
-                param.user_data = deepcopy(par.user_data)
+                param = deepcopy(par)
                 parameter_list.append(param)
 
         _pars.add_many(*parameter_list)
@@ -989,6 +979,20 @@ class Parameter:
 
         """
         self.__set_expression(val)
+
+    def __deepcopy__(self, memo):
+        param = type(self)(name=self.name,
+                            value=self.value,
+                            min=self.min,
+                            max=self.max)
+        param.vary = self.vary
+        param.brute_step = self.brute_step
+        param.stderr = self.stderr
+        param.correl = deepcopy(self.correl)
+        param.init_value = self.init_value
+        param.expr = self.expr
+        param.user_data = deepcopy(self.user_data)
+        return param
 
     def __set_expression(self, val):
         if val == '':

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -101,6 +101,17 @@ def test_parameters_deepcopy(parameters):
                     deepcopy_pars._asteval.symtable[unique_symbol])
 
 
+def test_parameter_deepcopy_subclass():
+    """Test that a subclass of parameter is preserved when performing a deepcopy"""
+    class ParameterSubclass(lmfit.Parameter):
+        pass
+    
+    parameters = lmfit.Parameters()
+    parameters.add(ParameterSubclass('name'))
+    parameterscopy = deepcopy(parameters)
+    assert isinstance(parameterscopy['name'], ParameterSubclass)
+
+
 def test_parameters_deepcopy_subclass():
     """Test that a subclass of parameters is preserved when performing a deepcopy"""
     class ParametersSubclass(lmfit.Parameters):


### PR DESCRIPTION
#### Description
If an instance of a type derived from `Parameter` is added to a `Parameters` instance, 
and the `Parameters` instance is then copied, the copy contains a parameter of type `Parameter`.
This PR changes the contained parameter type to the derived one.

I moved the code copying `Parameter`  instances to `Parameter.__deepcopy__` so that the derived class can adds attributes.
This should not break any existing code unless someone uses `__deepcopy__` for something else than copying.


###### Type of Changes
- [x] Bug fix


###### Tested on
Python: 3.9.13
lmfit: 0.0.post2850+gb250ed7.d20240807, 
scipy: 1.13.1, 
numpy: 2.0.0, 
asteval: 1.0.2, 
uncertainties: 3.2.2


###### Verification
- [x] included docstrings that follow PEP 257?
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
    No, I have not opened nor found a relevant Issue.
- [ ] verified that existing tests pass locally?
    Tests do not pass, but the result is the same as on the master branch (the added test passes).
    FAILED tests/test_parameters.py::test_check_ast_errors - Failed: DID NOT RAISE <class 'NameError'>
    1 failed, 650 passed, 12 skipped, 6 warnings in 127.66s (0:02:07)
- [ ] verified that the documentation builds locally?
    Does not build:
    Extension error:
    Could not import extension sphinx.builders.epub3 (exception: cannot import name 'jsonimpl' from partially initialized
    module 'sphinxcontrib.serializinghtml' (most likely due to a circular import) 
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
