### PR TITLE
fix: catch import errors when checking sys.modules

### DIFF
--- a/lmfit/jsonutils.py
+++ b/lmfit/jsonutils.py
@@ -27,7 +27,10 @@ def find_importer(obj):
     for modname, module in sys.modules.copy().items():
         if modname.startswith('__main__'):
             continue
-        t = getattr(module, oname, None)
+        try:
+            t = getattr(module, oname, None)
+        except (ModuleNotFoundError, ImportError):
+            pass
         if t is obj:
             return modname
     return None


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
`getattr` handles missing attributes by catching and swallowing an `AttributeError`.

However, some modules implement a custom `__getattr__` and can raise an `ImportError` instead, which is not handled by `getattr` and causes the `find_importer` util to raise an exception before it can finish checking the entirety of `sys.modules`.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples
