### PR TITLE
Fix issues related to providing a Jacobian function

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -55,7 +55,7 @@ Roam, Alexander Stark, Alexandre Beelen, Andrey Aristov, Nicholas Zobrist,
 Ethan Welty, Julius Zimmermann, Mark Dean, Arun Persaud, Ray Osborn, @lneuhaus,
 Marcel Stimberg, Yoshiera Huang, Leon Foks, Sebastian Weigand, Florian LB,
 Michael Hudson-Doyle, Ruben Verweij, @jedzill4, @spalato, Jens Hedegaard Nielsen,
-Martin Majli, Kristian Meyer, @azelcer, Ivan Usov, and many others.
+Martin Majli, Kristian Meyer, @azelcer, Ivan Usov, Ville Yrjänä, and many others.
 
 The lmfit code obviously depends on, and owes a very large debt to the code
 in scipy.optimize. Several discussions on the SciPy-user and lmfit mailing

--- a/examples/example_fit_jacobian_benchmark.py
+++ b/examples/example_fit_jacobian_benchmark.py
@@ -1,0 +1,178 @@
+"""
+Benchmarks of methods with and without computing the Jacobian analytically
+==========================================================================
+
+Providing a function that calculates the Jacobian matrix analytically can
+reduce the time spent finding a solution. The results from benchmarks comparing
+two methods (``leastsq`` and ``least_squares``) with and without a function to
+calculate the Jacobian matrix analytically are presented below.
+
+First we define the model function, the residual function, and the appropriate
+Jacobian functions:
+"""
+from timeit import timeit
+from types import SimpleNamespace
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from lmfit import Parameters, minimize
+
+NUM_JACOBIAN_CALLS = 0
+
+
+def func(var, x):
+    return var[0] * np.exp(-var[1]*x) + var[2]
+
+
+def residual(pars, x, data):
+    a, b, c = pars['a'], pars['b'], pars['c']
+    model = func((a, b, c), x)
+    return model - data
+
+
+def dfunc(pars, x, data):
+    global NUM_JACOBIAN_CALLS
+    NUM_JACOBIAN_CALLS += 1
+
+    a, b = pars['a'], pars['b']
+    v = np.exp(-b*x)
+    return np.array([v, -a*x*v, np.ones(len(x))])
+
+
+def jacfunc(pars, x, data):
+    global NUM_JACOBIAN_CALLS
+    NUM_JACOBIAN_CALLS += 1
+
+    a, b = pars['a'], pars['b']
+    v = np.exp(-b*x)
+    jac = np.ones((len(x), 3), dtype=np.float64)
+    jac[:, 0] = v
+    jac[:, 1] = -a * x * v
+    return jac
+
+
+a, b, c = 2.5, 1.3, 0.8
+
+x = np.linspace(0, 4, 50)
+y = func([a, b, c], x)
+
+data = y + 0.15*np.random.RandomState(seed=2021).normal(size=x.size)
+
+
+###############################################################################
+# Then we define the different cases to benchmark (i.e., different methods with
+# and without a function to calculate the Jacobian analytically) and the number
+# of repetitions per case:
+cases = (
+    dict(
+        method='leastsq',
+    ),
+    dict(
+        method='leastsq',
+        Dfun=dfunc,
+        col_deriv=1,
+    ),
+    dict(
+        method='least_squares',
+    ),
+    dict(
+        method='least_squares',
+        jac=jacfunc,
+    ),
+)
+
+num_repeats = 100
+results = []
+
+for kwargs in cases:
+    params = Parameters()
+    params.add('a', value=10)
+    params.add('b', value=10)
+    params.add('c', value=10)
+
+    wrapper = lambda: minimize(
+        residual,
+        params,
+        args=(x,),
+        kws={'data': data},
+        **kwargs,
+    )
+    time = timeit(wrapper, number=num_repeats) / num_repeats
+
+    NUM_JACOBIAN_CALLS = 0
+    fit = wrapper()
+
+    results.append(SimpleNamespace(
+        time=time,
+        num_jacobian_calls=NUM_JACOBIAN_CALLS,
+        fit=fit,
+        kwargs=kwargs,
+    ))
+
+
+###############################################################################
+# Finally, we present the results:
+labels = []
+
+for result in results:
+    label = result.kwargs['method']
+    if result.num_jacobian_calls > 0:
+        label += ' with Jac.'
+
+    labels.append(label)
+
+label_width = max(map(len, labels))
+lines = [
+    '| '
+    + ' | '.join([
+        'Method'.ljust(label_width),
+        'Avg. time (ms)',
+        '# func. (+ Jac.) calls',
+        'Chi-squared',
+        'a'.ljust(5),
+        'b'.ljust(5),
+        'c'.ljust(6),
+    ])
+    + '|'
+]
+
+print(f'The "true" parameters are: a = {a:.3f}, b = {b:.3f}, c = {c:.3f}\n')
+fig, ax = plt.subplots()
+ax.plot(x, data, marker='.', linestyle='none', label='data')
+
+for (result, label) in zip(results, labels):
+    linestyle = '-'
+    if result.num_jacobian_calls > 0:
+        linestyle = '--'
+
+    a = result.fit.params['a'].value
+    b = result.fit.params['b'].value
+    c = result.fit.params['c'].value
+    y = func([a, b, c], x)
+    ax.plot(x, y, label=label, alpha=0.5, linestyle=linestyle)
+
+    columns = [
+        label.ljust(label_width),
+        f'{result.time * 1000:.2f}'.ljust(14),
+        (
+            f'{result.fit.nfev}'
+            + (
+                f' (+{result.num_jacobian_calls})'
+                if result.num_jacobian_calls > 0 else
+                ''
+            )
+        ).ljust(22),
+        f'{result.fit.chisqr:.3f}'.ljust(11),
+        f'{a:.3f}'.ljust(5, '0'),
+        f'{b:.3f}'.ljust(5, '0'),
+        f'{c:.3f}'.ljust(5, '0'),
+    ]
+    lines.append('| ' + ' | '.join(columns) + ' |')
+
+lines.insert(1, '|-' + '-|-'.join('-' * len(col) for col in columns) + '-|')
+print('\n'.join(lines))
+
+ax.set_xlabel('x')
+ax.set_ylabel('y')
+ax.legend()

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -2396,7 +2396,12 @@ def coerce_float64(arr, nan_policy='raise', handle_inf=True,
     lists of numbers, pandas.Series, h5py.Datasets, and many other array-like
     Python objects
     """
-    if np.iscomplexobj(arr):
+    if issparse(arr):
+        arr = arr.toarray().astype(np.float64)
+    elif isinstance(arr, LinearOperator):
+        identity = np.eye(arr.shape[1], dtype=np.float64)
+        arr = (arr * identity).astype(np.float64)
+    elif np.iscomplexobj(arr):
         arr = np.asarray(arr, dtype=np.complex128).view(np.float64)
     else:
         arr = np.asarray(arr, dtype=np.float64)

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -565,8 +565,11 @@ class Minimizer:
         grad_scale = np.ones_like(fvars)
         for ivar, name in enumerate(self.result.var_names):
             val = fvars[ivar]
-            pars[name].value = pars[name].from_internal(val)
-            grad_scale[ivar] = pars[name].scale_gradient(val)
+            if apply_bounds_transformation:
+                pars[name].value = pars[name].from_internal(val)
+                grad_scale[ivar] = pars[name].scale_gradient(val)
+            else:
+                pars[name].value = val
 
         pars.update_constraints()
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -553,7 +553,7 @@ class Minimizer:
         else:
             return coerce_float64(out, nan_policy=self.nan_policy)
 
-    def __jacobian(self, fvars, apply_bounds_transformation=True):
+    def _jacobian(self, fvars, apply_bounds_transformation=True):
         """Return analytical jacobian to be used with Levenberg-Marquardt.
 
         modified 02-01-2012 by Glenn Jones, Aberystwyth University
@@ -934,7 +934,7 @@ class Minimizer:
         # Wrap Jacobian function to deal with bounds
         if 'jac' in fmin_kws:
             self.jacfcn = fmin_kws.pop('jac')
-            fmin_kws['jac'] = self.__jacobian
+            fmin_kws['jac'] = self._jacobian
 
         # Ignore jac argument for methods that do not support it
         if 'jac' in fmin_kws and method not in ('CG', 'BFGS', 'Newton-CG',
@@ -1540,7 +1540,7 @@ class Minimizer:
 
         if callable(least_squares_kws['jac']):
             self.jacfcn = least_squares_kws['jac']
-            least_squares_kws['jac'] = self.__jacobian
+            least_squares_kws['jac'] = self._jacobian
 
         least_squares_kws['kwargs'].update({'apply_bounds_transformation': False})
         result.call_kws = least_squares_kws
@@ -1649,7 +1649,7 @@ class Minimizer:
         if lskws['Dfun'] is not None:
             self.jacfcn = lskws['Dfun']
             self.col_deriv = lskws['col_deriv']
-            lskws['Dfun'] = self.__jacobian
+            lskws['Dfun'] = self._jacobian
 
         # suppress runtime warnings during fit and error analysis
         orig_warn_settings = np.geterr()

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -553,7 +553,7 @@ class Minimizer:
         else:
             return coerce_float64(out, nan_policy=self.nan_policy)
 
-    def __jacobian(self, fvars):
+    def __jacobian(self, fvars, apply_bounds_transformation=True):
         """Return analytical jacobian to be used with Levenberg-Marquardt.
 
         modified 02-01-2012 by Glenn Jones, Aberystwyth University

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -1532,6 +1532,13 @@ class Minimizer:
         least_squares_kws.update(self.kws)
         least_squares_kws.update(kws)
 
+        if least_squares_kws.get('Dfun', None) is not None:
+            least_squares_kws['jac'] = least_squares_kws.pop('Dfun')
+
+        if callable(least_squares_kws['jac']):
+            self.jacfcn = least_squares_kws['jac']
+            least_squares_kws['jac'] = self.__jacobian
+
         least_squares_kws['kwargs'].update({'apply_bounds_transformation': False})
         result.call_kws = least_squares_kws
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -560,6 +560,20 @@ class Minimizer:
         modified 06-29-2015 by M Newville to apply gradient scaling for
         bounded variables (thanks to JJ Helmus, N Mayorov)
 
+        Parameters
+        ----------
+        fvars : numpy.ndarray
+            Array of new parameter values suggested by the minimizer.
+        apply_bounds_transformation : bool, optional
+            Whether to apply lmfits parameter transformation to constrain
+            parameters (default is True). This is needed for solvers
+            without built-in support for bounds.
+
+        Returns
+        -------
+        numpy.ndarray
+             The evaluated Jacobian matrix for given `fvars`.
+
         """
         pars = self.result.params
         grad_scale = np.ones_like(fvars)

--- a/tests/test_jacobian_pickling.py
+++ b/tests/test_jacobian_pickling.py
@@ -1,0 +1,129 @@
+"""Tests for (un)pickling the Minimizer class when providing a Jacobian function."""
+from multiprocessing import get_context
+from pickle import dumps, loads
+
+import numpy as np
+
+from lmfit import Minimizer, Parameters, minimize
+
+
+def func(pars, x, data=None):
+    a, b, c = pars['a'], pars['b'], pars['c']
+    model = a * np.exp(-b*x) + c
+    if data is None:
+        return model
+    return model - data
+
+
+def dfunc(pars, x, data=None):
+    a, b = pars['a'], pars['b']
+    v = np.exp(-b*x)
+    return np.array([v, -a*x*v, np.ones(len(x))])
+
+
+def jacfunc(pars, x, data=None):
+    a, b = pars['a'], pars['b']
+    v = np.exp(-b*x)
+    jac = np.ones((len(x), 3), dtype=np.float64)
+    jac[:, 0] = v
+    jac[:, 1] = -a * x * v
+    return jac
+
+
+def f(var, x):
+    return var[0] * np.exp(-var[1]*x) + var[2]
+
+
+def wrapper(args):
+    (
+        method,
+        x,
+        data,
+    ) = args
+    params = Parameters()
+    params.add('a', value=10)
+    params.add('b', value=10)
+    params.add('c', value=10)
+
+    return minimize(
+        func,
+        params,
+        method=method,
+        args=(x,),
+        kws={'data': data},
+        **(
+            {'Dfun': dfunc, 'col_deriv': 1}
+            if method == 'leastsq' else
+            {'jac': jacfunc}
+        ),
+    )
+
+
+def test_jacobian_with_pickle():
+    """Test using pickle.dumps/loads."""
+    params = Parameters()
+    params.add('a', value=10)
+    params.add('b', value=10)
+    params.add('c', value=10)
+
+    a, b, c = 2.5, 1.3, 0.8
+    x = np.linspace(0, 4, 50)
+    y = f([a, b, c], x)
+    np.random.seed(2021)
+    data = y + 0.15*np.random.normal(size=x.size)
+
+    for method in ('leastsq', 'least_squares'):
+        if method == 'leastsq':
+            kwargs = {'Dfun': dfunc, 'col_deriv': 1}
+        else:
+            kwargs = {'jac': jacfunc}
+
+        min = Minimizer(
+            func,
+            params,
+            fcn_args=(x,),
+            fcn_kws={'data': data},
+            **kwargs,
+        )
+
+        pickled = dumps(min)
+        unpickled = loads(pickled)
+
+        out = unpickled.minimize(method=method)
+
+        assert np.isclose(out.params['a'], 2.5635, atol=1e-4)
+        assert np.isclose(out.params['b'], 1.3585, atol=1e-4)
+        assert np.isclose(out.params['c'], 0.8241, atol=1e-4)
+
+
+def test_jacobian_with_forkingpickler():
+    """Test using multiprocessing.Pool, which uses a subclass of pickle.Pickler."""
+    a, b, c = 2.5, 1.3, 0.8
+    x = np.linspace(0, 4, 50)
+    y = f([a, b, c], x)
+    np.random.seed(2021)
+    data = y + 0.15*np.random.normal(size=x.size)
+
+    with get_context(method='spawn').Pool(1) as pool:
+        iterator = pool.imap_unordered(
+            wrapper,
+            (
+                (
+                    method,
+                    x,
+                    data,
+                )
+                for method in ('leastsq', 'least_squares')
+            ),
+            chunksize=1,
+        )
+
+        while True:
+            try:
+                out = iterator.next(timeout=2)
+            except StopIteration:
+                break
+
+            assert np.isclose(out.params['a'], 2.5635, atol=1e-4)
+            assert np.isclose(out.params['b'], 1.3585, atol=1e-4)
+            assert np.isclose(out.params['c'], 0.8241, atol=1e-4)

--- a/tests/test_jacobian_pickling.py
+++ b/tests/test_jacobian_pickling.py
@@ -120,7 +120,7 @@ def test_jacobian_with_forkingpickler():
 
         while True:
             try:
-                out = iterator.next(timeout=2)
+                out = iterator.next(timeout=30)
             except StopIteration:
                 break
 

--- a/tests/test_least_squares.py
+++ b/tests/test_least_squares.py
@@ -169,3 +169,47 @@ def test_least_squares_jacobian_types():
     assert_allclose(result.covar, result_array.covar)
     assert_allclose(result.covar, result_sparse.covar)
     assert_allclose(result.covar, result_operator.covar)
+
+
+def test_least_squares_jacobian():
+    pars = lmfit.Parameters()
+    pars.add('x0', value=2.0)
+    pars.add('x1', value=2.0, min=1.5)
+
+    global jac_count
+
+    jac_count = 0
+
+    def resid(params):
+        x0 = params['x0']
+        x1 = params['x1']
+        return np.array([10 * (x1 - x0*x0), 1-x0])
+
+    def jac(params):
+        global jac_count
+        jac_count += 1
+        x0 = params['x0']
+        return np.array([[-20*x0, 10], [-1, 0]])
+
+    out0 = lmfit.minimize(resid, pars, method='least_squares', jac='2-point')
+
+    assert_allclose(out0.params['x0'], 1.2243, rtol=1.0e-4)
+    assert_allclose(out0.params['x1'], 1.5000, rtol=1.0e-4)
+    assert jac_count == 0
+
+    out1 = lmfit.minimize(resid, pars, method='least_squares', jac=jac)
+
+    assert_allclose(out1.params['x0'], 1.2243, rtol=1.0e-4)
+    assert_allclose(out1.params['x1'], 1.5000, rtol=1.0e-4)
+    assert out1.nfev < out0.nfev
+    assert jac_count > 5
+
+    jac_count = 0
+
+    out2 = lmfit.minimize(resid, pars, method='least_squares', Dfun=jac)
+
+    assert_allclose(out2.params['x0'], 1.2243, rtol=1.0e-4)
+    assert_allclose(out2.params['x1'], 1.5000, rtol=1.0e-4)
+    assert out2.nfev < out0.nfev
+    assert out2.nfev == out1.nfev
+    assert jac_count > 5

--- a/tests/test_least_squares.py
+++ b/tests/test_least_squares.py
@@ -138,7 +138,7 @@ def test_least_squares_jacobian_types():
     # numpy.ndarray, scipy.sparse.spmatrix, scipy.sparse.linalg.LinearOperator
     # J = [ 2x - 2a , 2y - 2b ]
     def jac_array(params, *args, **kwargs):
-        return np.column_stack((2 * params[0] - 2 * a, 2 * params[1] - 2 * b))
+        return np.column_stack((2 * params['x'] - 2 * a, 2 * params['y'] - 2 * b))
 
     def jac_sparse(params, *args, **kwargs):
         return bsr_matrix(jac_array(params, *args, **kwargs))


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

I encountered some issues while attempting to provide a function to calculate the Jacobian matrix analytically. The issue has been brought up in the mailing list at least a couple of times ([1](https://groups.google.com/g/lmfit-py/c/xwzop5UV82s/m/B-4CexH6EQAJ), [2](https://groups.google.com/g/lmfit-py/c/dTgC_hn-lsw/m/KD_z-SnmBwAJ)). See [PR 908](https://github.com/lmfit/lmfit-py/pull/908) for an earlier pull request (PR) that was ultimately not merged.

The main changes are:

- The `jac` (or `Dfun`) function provided by the user is now wrapped when calling `Minimizer.least_squares`.
  - The signature of `Minimizer.__jacobian` now matches the signature of `Minimizer.__residual`, which fixes a bug where an exception was raised due to `Minimizer.__jacobian` receiving an unexpected `apply_bounds_transformation` parameter. The `apply_bounds_transformation` parameter is taken into account in the body of the `Minimizer.__jacobian` method similarly to `Minimizer.__residual`. This means that the bounds transformation introduced in [PR 234](https://github.com/lmfit/lmfit-py/pull/234) is not applied when `apply_bounds_transformation=False` (e.g., when `Minimizer.least_squares` is called).
  - As a result, the Jacobian function is now provided a `Parameters` object instead of an array of float values. This means that the Jacobian function will receive the same arguments as when providing a Jacobian function to `Minimizer.leastsq` and `Minimizer.scalar_minimize`. **Note, that this should be regarded as a bug fix, but some users may have code that relies on the previous behavior. Thus, this could also be regarded as a breaking change and incrementing the major version number may be warranted.**
- Renamed `Minimizer.__jacobian` to `Minimizer._jacobian` to avoid a bug where an exception is raised when pickling and unpickling private methods using the `ForkingPickler` class that is used by the `multiprocessing` module.
  - See this [long-standing issue in CPython](https://github.com/python/cpython/issues/77188) for more information. There is a pull request to fix the root cause, but it has not been merged (at least not as of the time of writing this).


Some ancillary changes were required to facilitate the changes listed above:

- The `test_least_squares_jacobian_types` in `tests/test_least_squares.py` has been updated so that the parameter values that are being fitted are accessed using the string keys rather than integer indices in the `jac_array` function.
- The `coerce_float64` function in `lmfit/minimizer.py` now has explicit support for sparse matrices and `LinearOperator` objects (same approach as in [PR 589](https://github.com/lmfit/lmfit-py/pull/589)), which was required due to exceptions that were being raised when running `test_least_squares_jacobian_types` after the changes that were made in order to wrap Jacobian functions.


Additionally, the following changes/additions are included:

- Added `test_least_squares_jacobian` to `tests/test_least_squares.py` to verify the expected behavior.
- Added `tests/test_jacobian_pickling.py` to verify that `Minimizer` objects can be pickled when a Jacobian function is provided.
- The docstring of `Minimizer._jacobian` has also been updated to include information about the parameters and return values (similar to `Minimizer.__residual`).


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->

Python: 3.12.6 (main, Sep  8 2024, 13:18:56) [GCC 14.2.1 20240805]

lmfit: 1.3.2.post13+g39354856, scipy: 1.14.1, numpy: 2.1.3, asteval: 1.0.5, uncertainties: 3.2.2


###### Verification <!-- (delete not applicable items) -->
Have you

- [x] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
  - **Yes, once the tests were updated.**
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
  - **Not yet since I'm not sure a) what the version number should be (1.3.3 or 2.0.0) and b) what other kinds of major changes one might wish to do at the same time if it is necessary to increment the major version number.**
- [ ] added an example?
  - **Not sure if it is needed.**


###### Minimal reproducible example

Here's a modified version of [an example from the documentation](https://lmfit.github.io/lmfit-py/examples/example_fit_with_derivfunc.html) that I used to troubleshoot and test various issues.

```python
from multiprocessing import get_context
import matplotlib.pyplot as plt
import numpy as np
from time import time

from lmfit import minimize, Minimizer, Parameters


def func(pars, x, data=None):
    a, b, c = pars['a'], pars['b'], pars['c']
    model = a * np.exp(-b*x) + c
    if data is None:
        return model
    return model - data


def dfunc(pars, x, data=None):
    a, b = pars['a'], pars['b']
    v = np.exp(-b*x)
    return np.array([v, -a*x*v, np.ones(len(x))])


def jacfunc(pars, x, data=None):
    a, b = pars['a'], pars['b']
    v = np.exp(-b*x)
    jac = np.ones((len(x), 3), dtype=np.float64)
    jac[:, 0] = v
    jac[:, 1] = -a * x * v
    return jac


def f(var, x):
    return var[0] * np.exp(-var[1]*x) + var[2]


def wrapper(args):
    (
        params,
        method,
        x,
        data,
        use_least_squares,
    ) = args
    return minimize(
        func,
        params,
        method=method,
        args=(x,),
        kws={'data': data},
        **(
            ({'jac': jacfunc} if use_least_squares else {'Dfun': dfunc, 'col_deriv': 1})
        ),
    )


if __name__ == "__main__":
    use_least_squares = bool(1)
    use_minimize_function = bool(0)
    swap_order = bool(0)
    use_pool = bool(1)
    num_repeats = 100

    method = 'least_squares' if use_least_squares else 'leastsq'
    print(f"{method=}")

    params = Parameters()
    params.add('a', value=10)
    params.add('b', value=10)
    params.add('c', value=10)

    a, b, c = 2.5, 1.3, 0.8
    x = np.linspace(0, 4, 50)
    y = f([a, b, c], x)
    np.random.seed(2021)
    data = y + 0.15*np.random.normal(size=x.size)

    # Just to warm things up. If this is removed, then the first sample
    # is quite a bit slower compared to all subsequent samples (see the
    # num_repeats variable) regardless of whether or not the Jacobian is
    # estimated numerically or calculated analytically (see the swap_order
    # variable).
    minimize(
        func,
        params,
        method=method,
        args=(x,),
        kws={'data': data},
    )

    deltas = []
    for _ in range(num_repeats):
        start = time()

        if use_minimize_function:
            out1 = minimize(
                func,
                params,
                method=method,
                args=(x,),
                kws={'data': data},
                **(
                    ({'jac': jacfunc} if use_least_squares else {'Dfun': dfunc, 'col_deriv': 1})
                    if swap_order else
                    {}
                ),
            )
        else:
            min1 = Minimizer(func, params, fcn_args=(x,), fcn_kws={'data': data})
            if use_least_squares:
                if swap_order:
                    out1 = min1.least_squares(jac=jacfunc)
                else:
                    out1 = min1.least_squares()
            else:
                if swap_order:
                    out1 = min1.leastsq(Dfun=dfunc, col_deriv=1)
                else:
                    out1 = min1.leastsq()

        deltas.append(time() - start)

    if swap_order:
        print(f"   With: {np.mean(deltas):.6f} +/- {np.std(deltas, ddof=1):.6f} s (n={len(deltas)})")
    else:
        print(f"Without: {np.mean(deltas):.6f} +/- {np.std(deltas, ddof=1):.6f} s (n={len(deltas)})")
    fit1 = func(out1.params, x)

    deltas = []
    for _ in range(num_repeats):
        start =  time()

        if use_minimize_function:
            out2 = minimize(
                func,
                params,
                method=method,
                args=(x,),
                kws={'data': data},
                **(
                    {}
                    if swap_order else
                    ({'jac': jacfunc} if use_least_squares else {'Dfun': dfunc, 'col_deriv': 1})
                ),
            )
        else:
            min2 = Minimizer(func, params, fcn_args=(x,), fcn_kws={'data': data})
            if use_least_squares:
                if swap_order:
                    out2 = min2.least_squares()
                else:
                    out2 = min2.least_squares(jac=jacfunc)
            else:
                if swap_order:
                    out2 = min2.leastsq()
                else:
                    out2 = min2.leastsq(Dfun=dfunc, col_deriv=1)

        deltas.append(time() - start)

    if swap_order:
        print(f"Without: {np.mean(deltas):.6f} +/- {np.std(deltas, ddof=1):.6f} s (n={len(deltas)})")
    else:
        print(f"   With: {np.mean(deltas):.6f} +/- {np.std(deltas, ddof=1):.6f} s (n={len(deltas)})")
    fit2 = func(out2.params, x)

    print(f'"true" parameters are: a = {a:.3f}, b = {b:.3f}, c = {c:.3f}\n\n'
          '|=========================================|\n'
          + (
              '| Statistic/Parameter | With    | Without |\n' if swap_order else '| Statistic/Parameter | Without | With    |\n'
          )
          + '|-----------------------------------------|\n'
          f'|  N Function Calls   | {out1.nfev:d}      | {out2.nfev:d}      |\n'
          f'|     Chi-square      | {out1.chisqr:.4f}  | {out2.chisqr:.4f}  |\n'
          f"|         a           | {out1.params['a'].value:.4f}  | {out2.params['a'].value:.4f}  |\n"
          f"|         b           | {out1.params['b'].value:.4f}  | {out2.params['b'].value:.4f}  |\n"
          f"|         c           | {out1.params['c'].value:.4f}  | {out2.params['c'].value:.4f}  |\n"
          '|-----------------------------------------|')

    plt.plot(x, data, 'o', label='data')
    plt.plot(x, fit1, label=('with' if swap_order else 'without') + ' analytical derivative')
    plt.plot(x, fit2, '--', label=('without' if swap_order else 'with') + ' analytical derivative')

    if use_pool:
        # To confirm that everything is working as intended when used together
        # with multiprocessing.Pool.
        with get_context(method="spawn").Pool(1) as pool:
            for out3 in pool.map(
                wrapper,
                ((
                    params,
                    method,
                    x,
                    data,
                    use_least_squares,
                ),),
            ):
                print(f"\n{out3.nfev=}, {out3.chisqr=:.4f}, {out3.params=}")
                fit3 = func(out3.params, x)
                plt.plot(x, fit3, ':', label='with analytical derivative (Pool)')

    plt.legend()
    plt.show()
```