### PR TITLE
Modelfunc barestar

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -529,16 +529,20 @@ class Model:
             for fnam, fpar in sig.parameters.items():
                 if fpar.kind == fpar.VAR_KEYWORD:
                     keywords_ = fnam
-                elif fpar.kind in (fpar.POSITIONAL_ONLY, fpar.POSITIONAL_OR_KEYWORD):
+                elif fpar.kind in (fpar.KEYWORD_ONLY,
+                                   fpar.POSITIONAL_OR_KEYWORD):
                     default_vals[fnam] = fpar.default
                     if (isinstance(fpar.default, (float, int, complex))
                        and not isinstance(fpar.default, bool)):
                         kw_args[fnam] = fpar.default
+                        pos_args.append(fnam)
                     elif fpar.default == fpar.empty:
                         pos_args.append(fnam)
                     else:
                         kw_args[fnam] = fpar.default
                         indep_vars.append(fnam)
+                elif fpar.kind == fpar.POSITIONAL_ONLY:
+                    raise ValueError("positional only arguments with '/' are not supported")
                 elif fpar.kind == fpar.VAR_POSITIONAL:
                     raise ValueError(f"varargs '*{fnam}' is not supported")
         # inspection done

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1710,3 +1710,19 @@ def test_model_barestar():
     modl = lmfit.Model(foo)
     assert modl.independent_vars == ['x', 'kind']
     assert modl._param_names == ['a', 'b']
+
+
+def test_model_bareslash():
+    """Github #976 (and discussion #975)"""
+    def foo(x, /, a=1, b=1, kind='linear'):
+        if kind == 'linear':
+            return a + b * x
+        elif kind == 'exponential':
+            return a * np.exp(b * x)
+    try:
+        lmfit.Model(foo)
+        that_failed = False
+    except ValueError:
+        that_failed = True
+
+    assert that_failed

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1697,3 +1697,16 @@ def test_model_refitting():
     assert result.init_values['peak_amplitude'] < 21
     assert result.init_values['peak_sigma'] > 2
     assert result.init_values['peak_sigma'] < 4
+
+
+def test_model_barestar():
+    """Github #976 (and discussion #975)"""
+    def foo(x, *, a=1, b=1, kind='linear'):
+        if kind == 'linear':
+            return a + b * x
+        elif kind == 'exponential':
+            return a * np.exp(b * x)
+
+    modl = lmfit.Model(foo)
+    assert modl.independent_vars == ['x', 'kind']
+    assert modl._param_names == ['a', 'b']


### PR DESCRIPTION

#### Description

This adds support of "bare star" in signatures of Model functions to specify keyword-only arguments
See #975 and #976.  This might need more extensive tests. An example might be helpful....

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples

###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
```
Python: 3.12.5 | packaged by conda-forge | (main, Aug  8 2024, 18:31:54) [Clang 16.0.6 ]

lmfit: 1.3.2.post14+g6f8551ac.d20241215, scipy: 1.14.0, numpy: 1.26.4, asteval: 1.0.5, uncertainties: 3.2.2.post7+gce16269
```

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
