### PR TITLE
MAINT: drop PY38, support PY313, other miscellaneous updartes 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: 'doc/conf.py'
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.18.0
+    rev: v3.19.1
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     rev: v3.19.1
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ stages:
       steps:
         - task: UsePythonVersion@0
           inputs:
-            versionSpec: '3.12'
+            versionSpec: '3.13'
         - script: |
             python -m pip install --upgrade build pip setuptools wheel
           displayName: 'Install Python build tools and dependencies'
@@ -43,7 +43,7 @@ stages:
       steps:
         - task: UsePythonVersion@0
           inputs:
-            versionSpec: '3.12'
+            versionSpec: '3.13'
         - script: |
             python -m pip install --upgrade build pip setuptools wheel
           displayName: 'Install Python build tools'
@@ -67,8 +67,8 @@ stages:
         vmImage: 'ubuntu-latest'
       strategy:
         matrix:
-          Python38:
-            python.version: '3.8'
+          Python39:
+            python.version: '3.9'
 
       steps:
         - task: UsePythonVersion@0
@@ -117,8 +117,6 @@ stages:
         vmImage: 'ubuntu-latest'
       strategy:
         matrix:
-          Python38:
-            python.version: '3.8'
           Python39:
             python.version: '3.9'
           Python310:
@@ -127,6 +125,8 @@ stages:
             python.version: '3.11'
           Python312:
             python.version: '3.12'
+          Python313:
+            python.version: '3.13'
 
       steps:
         - task: UsePythonVersion@0
@@ -174,8 +174,8 @@ stages:
         vmImage: 'windows-latest'
       strategy:
         matrix:
-          Python312:
-            python.version: '3.12'
+          Python313:
+            python.version: '3.13'
 
       steps:
         - task: UsePythonVersion@0
@@ -209,8 +209,8 @@ stages:
         vmImage: 'macos-latest'
       strategy:
         matrix:
-          Python312:
-            python.version: '3.12'
+          Python313:
+            python.version: '3.13'
 
       steps:
         - task: UsePythonVersion@0
@@ -236,13 +236,13 @@ stages:
   dependsOn: check_codestyle
   condition: succeededOrFailed()
   jobs:
-    - job: Python313_dev
+    - job: Python314_dev
       pool:
         vmImage: 'ubuntu-latest'
       steps:
         - script: |
             sudo add-apt-repository ppa:deadsnakes/nightly
-            sudo apt-get update && sudo apt-get install -y --no-install-recommends python3.13-dev python3.13-venv
+            sudo apt-get update && sudo apt-get install -y --no-install-recommends python3.14-dev python3.14-venv
           displayName: Install Python development version from the deadsnakes PPA
         - script: |
             sudo apt-get update && sudo apt-get install -yq --no-install-suggests --no-install-recommends \
@@ -251,8 +251,8 @@ stages:
           displayName: 'Install dependencies'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            python3.13 -m ensurepip --upgrade
-            pip3.13 install -U build pip setuptools wheel pybind11 cython || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
+            python3.14 -m ensurepip --upgrade
+            pip3.14 install -U build pip setuptools wheel pybind11 cython || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
           displayName: 'Install build, pip, setuptools, wheel, pybind11, and cython'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
@@ -260,12 +260,12 @@ stages:
             wget https://github.com/numpy/numpy/releases/download/v${numpy_version}/numpy-${numpy_version}.tar.gz
             tar xzvf numpy-${numpy_version}.tar.gz
             cd numpy-${numpy_version}
-            python3.13 -m build || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
-            python3.13 -m pip install . --user || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
+            python3.14 -m build || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
+            python3.14 -m pip install . --user || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
           displayName: 'Install latest available version of NumPy'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            pip3.13 install -U pythran || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
+            pip3.14 install -U pythran || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
           displayName: 'Install pythran'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
@@ -273,25 +273,25 @@ stages:
             wget https://github.com/scipy/scipy/releases/download/v${scipy_version}/scipy-${scipy_version}.tar.gz
             tar xzvf scipy-${scipy_version}.tar.gz
             cd scipy-${scipy_version}
-            python3.13 -m build || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
-            python3.13 -m pip install . --user || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
+            python3.14 -m build || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
+            python3.14 -m pip install . --user || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
           displayName: 'Install latest available version of SciPy'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
             # remove numdifftools for now as it pulls in statsmodels, that wants to build with NumPy 1.14.5
-            pip3.13 install asteval uncertainties dill emcee flaky pytest pytest-cov || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
+            pip3.14 install asteval uncertainties dill emcee flaky pytest pytest-cov || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
           displayName: 'Install latest available version of Python dependencies'
         - script: |
-            python3.13 -m build
-            python3.13 -m pip install '.[test]' --user || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
+            python3.14 -m build
+            python3.14 -m pip install '.[test]' --user || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
           displayName: 'Build wheel/sdist and install lmfit'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            pip3.13 list || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
+            pip3.14 list || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
           displayName: 'List installed Python packages'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            pip3.13 install pytest-azurepipelines
+            pip3.14 install pytest-azurepipelines
             cd $(Agent.BuildDirectory)/s/tests
             pytest || echo -e "\043#vso[task.logissue type=warning;] Allowed failure for development version!!"
           displayName: 'Run test-suite'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ stages:
           displayName: 'Install dependencies'
         - script: |
             python -m pip install --upgrade build pip wheel
-            python -m pip install asteval==1.0 numpy==1.23.0 scipy==1.8.0 uncertainties==3.2.2
+            python -m pip install asteval==1.0 numpy==1.24.0 scipy==1.10.0 uncertainties==3.2.2
           displayName: 'Install minimum required version of dependencies'
         - script: |
             python -m build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -256,7 +256,7 @@ stages:
           displayName: 'Install build, pip, setuptools, wheel, pybind11, and cython'
         - script: |
             export PATH=/home/vsts/.local/bin:$PATH
-            export numpy_version=2.1.2
+            export numpy_version=2.2.1
             wget https://github.com/numpy/numpy/releases/download/v${numpy_version}/numpy-${numpy_version}.tar.gz
             tar xzvf numpy-${numpy_version}.tar.gz
             cd numpy-${numpy_version}

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -36,8 +36,8 @@ Lmfit works with `Python`_ versions 3.9 and higher. Version
 0.9.15 is the final version to support Python 2.7.
 
 Lmfit requires the following Python packages, with versions given:
-   * `NumPy`_ version 1.23 or higher.
-   * `SciPy`_ version 1.8 or higher.
+   * `NumPy`_ version 1.24 or higher.
+   * `SciPy`_ version 1.10 or higher.
    * `asteval`_ version 1.0 or higher.
    * `uncertainties`_ version 3.2.2 or higher.
    * `dill`_ version 0.3.4 or higher.

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -32,7 +32,7 @@ Downloading and Installation
 Prerequisites
 ~~~~~~~~~~~~~
 
-Lmfit works with `Python`_ versions 3.8 and higher. Version
+Lmfit works with `Python`_ versions 3.9 and higher. Version
 0.9.15 is the final version to support Python 2.7.
 
 Lmfit requires the following Python packages, with versions given:

--- a/examples/example_fit_multi_datasets.py
+++ b/examples/example_fit_multi_datasets.py
@@ -7,8 +7,6 @@ Fitting multiple (simulated) Gaussian data sets simultaneously.
 All minimizers require the residual array to be one-dimensional. Therefore, in
 the ``objective`` function we need to ``flatten`` the array before returning it.
 
-TODO: this could/should be using the Model interface / built-in models!
-
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/example_fit_multi_datasets_Model-interface.py
+++ b/examples/example_fit_multi_datasets_Model-interface.py
@@ -1,0 +1,82 @@
+"""
+Fit Multiple Data Sets Using Model Interface
+============================================
+
+Fitting multiple (simulated) Gaussian data sets simultaneously, using the
+Model interface.
+
+All minimizers require the residual array to be one-dimensional. Therefore,
+in the ``objective`` function we need to ``flatten`` the array before
+returning it.
+
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+
+from lmfit import Parameters, minimize, report_fit
+from lmfit.models import GaussianModel
+
+##############################################################################
+# Create N simulated Gaussian data sets
+N = 5
+np.random.seed(2021)
+x = np.linspace(-1, 2, 151)
+data = []
+for _ in np.arange(N):
+    params = Parameters()
+    params.add('amplitude', value=0.60 + 9.50*np.random.rand())
+    params.add('center', value=-0.20 + 1.20*np.random.rand())
+    params.add('sigma', value=0.25 + 0.03*np.random.rand())
+    dat = (GaussianModel().eval(x=x, params=params) +
+           np.random.normal(size=x.size, scale=0.1))
+    data.append(dat)
+data = np.array(data)
+
+
+##############################################################################
+# The objective function will extract and evaluate a Gaussian from the
+# compound model
+def objective(params, x, data, model):
+    """Calculate total residual for fits of Gaussians to several data sets."""
+    ndata, _ = data.shape
+    resid = 0.0*data[:]
+
+    # make residual per data set
+    for i in range(ndata):
+        components = model.components[i].eval(params=params, x=x)
+        resid[i, :] = data[i, :] - components
+
+    # now flatten this to a 1D array, as minimize() needs
+    return resid.flatten()
+
+
+##############################################################################
+# Create a composite model by adding Gaussians
+model_arr = [GaussianModel(prefix=f'n{i+1}_') for i, _ in enumerate(data)]
+model = sum(model_arr[1:], start=model_arr[0])
+
+##############################################################################
+# Prepare the fitting parameters and constrain n2_sigma, ..., nN_sigma to be
+# equal to n1_sigma
+fit_params = model.make_params()
+for iy, y in enumerate(data):
+    fit_params.add(f'n{iy+1}_amplitude', value=0.5, min=0.0, max=200)
+    fit_params.add(f'n{iy+1}_center', value=0.4, min=-2.0, max=2.0)
+    fit_params.add(f'n{iy+1}_sigma', value=0.3, min=0.01, max=3.0)
+
+    if iy > 0:
+        fit_params[f'n{iy+1}_sigma'].expr = 'n1_sigma'
+
+##############################################################################
+# Run the global fit and show the fitting result
+out = minimize(objective, fit_params, args=(x, data, model))
+report_fit(out.params)
+
+##############################################################################
+# Plot the data sets and fits
+plt.figure()
+for i, y in enumerate(data):
+    components = model.eval_components(params=out.params, x=x)
+    plt.plot(x, y, 'o', x, components[f'n{i+1}_'], '-')
+
+plt.show()

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -921,7 +921,7 @@ class Minimizer:
             fmin_kws['options']['maxiter'] = self.max_nfev
             self.max_nfev = 5*self.max_nfev
 
-        # FIXME: update when SciPy requirement is >= 1.8
+        # FIXME: update when SciPy requirement is >= 1.11
         # ``maxiter`` deprecated in favor of ``maxfun``
         elif method == "TNC" and int(scipy_version.split('.')[1]) >= 11:
             fmin_kws['options']['maxfun'] = 2*self.max_nfev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "uncertainties>=3.2.2",
     "dill>=0.3.4",
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 authors = [
     {name = "LMFit Development Team", email = "matt.newville@gmail.com"},
 ]
@@ -28,11 +28,11 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ name = "lmfit"
 dynamic = ["version"]
 dependencies = [
     "asteval>=1.0",
-    "numpy>=1.19",
-    "scipy>=1.6",
+    "numpy>=1.24",
+    "scipy>=1.10.0",
     "uncertainties>=3.2.2",
     "dill>=0.3.4",
 ]

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -370,7 +370,7 @@ def test_value_setter(parameter):
 def test__array__(parameter):
     """Test the __array__ magic method."""
     par, _ = parameter
-    assert np.array(par) == np.array(10.0)
+    assert np.asarray(par) == np.asarray(10.0)
 
 
 def test__str__(parameter):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -226,7 +226,7 @@ def test_parameters__array__(parameters):
     """Test the __array__ magic method."""
     pars, _, _ = parameters
 
-    assert_allclose(np.array(pars), np.array([10.0, 20.0]))
+    assert_allclose(np.asarray(pars), np.asarray([10.0, 20.0]))
 
 
 def test_parameters__reduce__(parameters):


### PR DESCRIPTION
#### Description
This PR drops testing PY38, "officially" adds support for PY313, and starts testing with PY314. 

- updates minimum requires NumPy and SciPy versions
- fix NumPy v2 DeprecationWarning
- adds the example of fitting multiple Gaussian lineshapes using the Model interface

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
Python: 3.13.1 (main, Dec  7 2024, 10:29:14) [Clang 16.0.0 (clang-1600.0.26.4)]

lmfit: 1.3.2.post20+g8087a61d, scipy: 1.14.1, numpy: 2.2.1, asteval: 1.0.5, uncertainties: 3.2.2


###### Verification <!-- (delete not applicable items) -->
Have you
- [ ] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [x] added an example?
