### PR TITLE
Matching residual calculations in model.py to the documentation  - Discussion #986

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -55,7 +55,8 @@ Roam, Alexander Stark, Alexandre Beelen, Andrey Aristov, Nicholas Zobrist,
 Ethan Welty, Julius Zimmermann, Mark Dean, Arun Persaud, Ray Osborn, @lneuhaus,
 Marcel Stimberg, Yoshiera Huang, Leon Foks, Sebastian Weigand, Florian LB,
 Michael Hudson-Doyle, Ruben Verweij, @jedzill4, @spalato, Jens Hedegaard Nielsen,
-Martin Majli, Kristian Meyer, @azelcer, Ivan Usov, Ville Yrjänä, and many others.
+Martin Majli, Kristian Meyer, @azelcer, Ivan Usov, Ville Yrjänä, Timothy Warner
+and many others.
 
 The lmfit code obviously depends on, and owes a very large debt to the code
 in scipy.optimize. Several discussions on the SciPy-user and lmfit mailing

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -881,7 +881,7 @@ class Model:
                    'this, using "nan_policy=\'omit\'" will probably not work.')
             raise ValueError(msg)
 
-        diff = model - data
+        diff = data - model
 
         if diff.dtype is complex:
             # data/model are complex
@@ -2323,7 +2323,7 @@ class ModelResult(Minimizer):
         if yerr is None and self.weights is not None:
             yerr = 1.0/self.weights
 
-        residuals = reduce_complex(self.eval()) - reduce_complex(self.data)
+        residuals = reduce_complex(self.data) - reduce_complex(self.eval())
         if yerr is not None:
             ax.errorbar(x_array, residuals,
                         yerr=propagate_err(self.data, yerr, parse_complex),


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? --> Modified model.py code so that residual calculation matches the documentation (data - model) for _residual and plot_residuals in model.py.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->https://github.com/orgs/lmfit/discussions/986


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->Python: 3.13.1 (tags/v3.13.1:0671451, Dec  3 2024, 19:06:28) [MSC v.1942 64 bit (AMD64)]
lmfit: 0.0.post2874+g821af24.d20250121, scipy: 1.15.1, numpy: 2.2.2, asteval: 1.0.6, uncertainties: 3.2.2


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257? - No change to documentation.
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [ ] verified that the documentation builds locally? - No change to documentation.
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes? - No change to tests.
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)? - Unsure of next release.
- [ ] added an example? - Change can be observed in example_Model_interface.py by displaying result.plot() (line 47) with plt.show() (import matplotlib)