### PR TITLE
Optimize _func_allargs by using set instead of list

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -293,7 +293,7 @@ class Model:
 
         self._param_root_names = param_names  # will not include prefixes
         self.independent_vars = independent_vars
-        self._func_allargs = []
+        self._func_allargs = set()
         self._func_haskeywords = False
         self.nan_policy = nan_policy
 
@@ -548,10 +548,10 @@ class Model:
         # inspection done
 
         self._func_haskeywords = keywords_ is not None
-        self._func_allargs = list(default_vals.keys())
+        self._func_allargs = set(default_vals.keys())
         for key in kw_args:
             if key not in self._func_allargs:
-                self._func_allargs.append(key)
+                self._func_allargs.add(key)
 
         if len(self._func_allargs) == 0 and keywords_ is not None:
             return
@@ -1275,7 +1275,7 @@ class CompositeModel(Model):
     def _parse_params(self):
         self._func_haskeywords = (self.left._func_haskeywords or
                                   self.right._func_haskeywords)
-        self._func_allargs = (self.left._func_allargs +
+        self._func_allargs = set(self.left._func_allargs +
                               self.right._func_allargs)
         self.def_vals = deepcopy(self.right.def_vals)
         self.def_vals.update(self.left.def_vals)

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1275,8 +1275,8 @@ class CompositeModel(Model):
     def _parse_params(self):
         self._func_haskeywords = (self.left._func_haskeywords or
                                   self.right._func_haskeywords)
-        self._func_allargs = set(self.left._func_allargs +
-                              self.right._func_allargs)
+        self._func_allargs = (set(self.left._func_allargs)
+                                .union(self.right._func_allargs))
         self.def_vals = deepcopy(self.right.def_vals)
         self.def_vals.update(self.left.def_vals)
         self.opts = deepcopy(self.right.opts)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

Description:
The variable `_func_allargs` is used in 7 cases within an if `key in _func_allargs:` check. When using a `list`, the membership test (`in`) has a time complexity of O(N). By switching to a `set`, this lookup becomes O(1), significantly improving performance, especially when `_func_allargs` grows in size.


##### Changes
- Replaced list initialization with a set.
- Updated .append(key) calls to .add(key).
- Converted list concatenation to set union to maintain efficiency.

This should improve performance while keeping functionality intact. Let me know if any adjustments are needed!


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [ ] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [x] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
