### PR TITLE
Remove stray backticks in docs; fix plural of linked class

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -61,7 +61,7 @@ LaTex distributions).
 Please refer to ``pyproject.toml`` under ``project.optional-dependencies`` for a list of all
 dependencies that are needed if you want to participate in the development of lmfit.
 You can install all these dependencies automatically by doing ``pip install lmfit[all]``,
-or select only a subset (e.g., ``dev```, ``doc``, or ``test``).
+or select only a subset (e.g., ``dev``, ``doc``, or ``test``).
 
 Please note: the "original" ``python setup.py install`` is deprecated, but we will
 provide a shim ``setup.py`` file for as long as ``Python`` and/or ``setuptools``

--- a/doc/model.rst
+++ b/doc/model.rst
@@ -22,7 +22,7 @@ uses a *model function* -- a function that is meant to calculate a model for
 some phenomenon -- and then uses that to best match an array of supplied
 data.  Beyond that similarity, the :class:`Model` interface is rather different
 from :scipydoc:`optimize.curve_fit`.  These differences include a) being
-class-based and so having multiple methods for working with :class:`Model`s,
+class-based and so having multiple methods for working with :class:`Model`\ s,
 b) using :class:`~lmfit.parameter.Parameters`, and all of the advantages they
 provide, and c) being easy to combine into composite models.
 

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -396,7 +396,7 @@ class Minimizer:
 
             - `'negentropy'` : neg entropy, using normal distribution
 
-               = rho*log(rho).sum()`, where rho = exp(-r*r/2)/(sqrt(2*pi))
+               = rho*log(rho).sum(), where rho = exp(-r*r/2)/(sqrt(2*pi))
 
             - `'neglogcauchy'` : neg log likelihood, using Cauchy distribution
 
@@ -1874,7 +1874,7 @@ class Minimizer:
             - upper bound (:attr:`max`) and :attr:`brute_step` are specified:
                 ``range = (max - Ns * brute_step, max, brute_step)``.
             - numerical value (:attr:`value`) and :attr:`brute_step` are specified:
-                ``range = (value - (Ns//2) * brute_step`, value +
+                ``range = (value - (Ns//2) * brute_step, value +
                 (Ns//2) * brute_step, brute_step)``.
 
         """


### PR DESCRIPTION
<!--
Thank you for submitting a PR to lmfit!

To ease the process of reviewing your PR, do make sure to complete the following boxes.
-->

#### Description
This pull request improves the documentation page by removing stray backticks that were previously rendered into the page. It also fixes a plural of a linked class that used incorrect syntax and broke the build on `/model.html`.

Before:

<img width="817" height="124" alt="Screenshot_20250714_112212" src="https://github.com/user-attachments/assets/8a9cad9e-f7a5-4ec5-8afe-2b4369fc17a2" />

After:

<img width="810" height="113" alt="Screenshot_20250714_112613" src="https://github.com/user-attachments/assets/b16c0644-48ed-4f61-829a-738c3851729e" />

<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->


###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [x] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->
Python: 3.13.5 (main, Jun 12 2025, 00:00:00) [GCC 15.1.1 20250521 (Red Hat 15.1.1-2)]

lmfit: 0.0.post2907+g86d7704, scipy: 1.16.0, numpy: 2.3.1, asteval: 1.0.6, uncertainties: 3.2.3

###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [x] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
