### PR TITLE
fix import in test_composite_plotting

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1127,7 +1127,7 @@ class TestUserDefiniedModel(CommonTests, unittest.TestCase):
                         reason="requires matplotlib.pyplot")
     def test_composite_plotting(self):
         # test that a composite model has non-empty best_values
-        import matplotlib
+        import matplotlib.pyplot
         try:
             matplotlib.pyplot.close('all')
         except ValueError:


### PR DESCRIPTION
#### Description
Fix `matplotlib` import to be `matplotlib.pyplot`, as otherwise running the test fails with:

```
$ pytest tests/test_model.py::TestUserDefiniedModel::test_composite_plotting
========================================================= test session starts =========================================================
platform linux -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0
rootdir: /tmp/lmfit-py
configfile: pyproject.toml
plugins: forked-1.6.0, cov-6.2.1, flaky-3.8.1
collected 1 item

tests/test_model.py F                                                                                                           [100%]

============================================================== FAILURES ===============================================================
____________________________________________ TestUserDefiniedModel.test_composite_plotting ____________________________________________

self = <tests.test_model.TestUserDefiniedModel testMethod=test_composite_plotting>

    @pytest.mark.skipif(not lmfit.model._HAS_MATPLOTLIB,
                        reason="requires matplotlib.pyplot")
    def test_composite_plotting(self):
        # test that a composite model has non-empty best_values
        import matplotlib
        try:
>           matplotlib.pyplot.close('all')
            ^^^^^^^^^^^^^^^^^

tests/test_model.py:1132:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'pyplot'

    @functools.cache
    def __getattr__(name):
        if name in props:
            return props[name].__get__(instance)
>       raise AttributeError(
            f"module {cls.__module__!r} has no attribute {name!r}")
E       AttributeError: module 'matplotlib' has no attribute 'pyplot'

.venv/lib/python3.13/site-packages/matplotlib/_api/__init__.py:218: AttributeError
=========================================================== tests coverage ============================================================
___________________________________________ coverage: platform linux, python 3.13.5-final-0 ___________________________________________

Coverage HTML written to dir htmlcov
======================================================= short test summary info =======================================================
FAILED tests/test_model.py::TestUserDefiniedModel::test_composite_plotting - AttributeError: module 'matplotlib' has no attribute 'pyplot'
========================================================== 1 failed in 1.10s ==========================================================
```

This normally does not happen because `matplotlib.pyplot` gets imported elsewhere before, but it makes parallel testing with pytest-xdist flaky.

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
```
Python: 3.13.5 (main, Jun 12 2025, 03:41:01) [GCC 14.3.0]

lmfit: 1.3.4, scipy: 1.16.0, numpy: 2.3.1, asteval: 1.0.6, uncertainties: 3.2.3
````

###### Verification <!-- (delete not applicable items) -->
Have you
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
