### PR TITLE
Add/Modify ModelResult to Dataset class, for Model fitting and preparing for Multi-Dataset fittin

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1078,7 +1078,7 @@ class Model:
 
         Returns
         -------
-        ModelResult
+        Dataset
 
         Notes
         -----
@@ -1091,7 +1091,7 @@ class Model:
         keyword arguments.
 
         3. Parameters are copied on input, so that the original Parameter objects
-        are unchanged, and the updated values are in the returned `ModelResult`.
+        are unchanged, and the updated values are in the returned `Dataset`.
 
         Examples
         --------
@@ -1174,10 +1174,10 @@ class Model:
         if fit_kws is None:
             fit_kws = {}
 
-        output = ModelResult(self, params, method=method, iter_cb=iter_cb,
-                             scale_covar=scale_covar, fcn_kws=kwargs,
-                             nan_policy=self.nan_policy, calc_covar=calc_covar,
-                             max_nfev=max_nfev, **fit_kws)
+        output = Dataset(self, params, method=method, iter_cb=iter_cb,
+                         scale_covar=scale_covar, fcn_kws=kwargs,
+                         nan_policy=self.nan_policy, calc_covar=calc_covar,
+                         max_nfev=max_nfev, **fit_kws)
         output.fit(data=data, weights=weights)
         output.components = self.components
         return output
@@ -1435,45 +1435,49 @@ def _buildmodel(state, funcdefs=None):
         return CompositeModel(lmodel, rmodel, getattr(operator, op))
 
 
-def save_modelresult(modelresult, fname):
-    """Save a ModelResult to a file.
+def save_dataset(dataset, fname):
+    """Save a Dataset to a file.
 
     Parameters
     ----------
-    modelresult : ModelResult
-        ModelResult to be saved.
+    dataset : Dataset
+        Dataset to be saved.
     fname : str
-        Name of file for saved ModelResult.
+        Name of file for saved Dataset
 
     """
     with open(fname, 'w') as fout:
-        modelresult.dump(fout)
+        dataset.dump(fout)
 
 
-def load_modelresult(fname, funcdefs=None):
-    """Load a saved ModelResult from a file.
+def load_dataset(fname, funcdefs=None):
+    """Load a saved Dataset from a file.
 
     Parameters
     ----------
     fname : str
-        Name of file containing saved ModelResult.
+        Name of file containing saved Dataset.
     funcdefs : dict, optional
         Dictionary of custom function names and definitions.
 
     Returns
     -------
-    ModelResult
-        ModelResult object loaded from file.
+    Dataset
+        Datasett object loaded from file.
 
     """
     params = Parameters()
-    modres = ModelResult(Model(lambda x: x, None), params)
+    dset = Dataset(Model(lambda x: x, None), params)
     with open(fname) as fh:
-        mresult = modres.load(fh, funcdefs=funcdefs)
-    return mresult
+        dsout = dset.load(fh, funcdefs=funcdefs)
+    return dsout
 
 
-class ModelResult(Minimizer):
+save_modelresult = save_dataset
+load_modelresult = load_dataset
+
+
+class Dataset(Minimizer):
     """Result from the Model fit.
 
     This has many attributes and methods for viewing and working with the
@@ -1485,7 +1489,7 @@ class ModelResult(Minimizer):
     def __init__(self, model, params, data=None, weights=None,
                  method='leastsq', fcn_args=None, fcn_kws=None,
                  iter_cb=None, scale_covar=True, nan_policy='raise',
-                 calc_covar=True, max_nfev=None, **fit_kws):
+                 calc_covar=True, max_nfev=None, label=None, **fit_kws):
         """
         Parameters
         ----------
@@ -1524,6 +1528,7 @@ class ModelResult(Minimizer):
         self.data = data
         self.weights = weights
         self.method = method
+        self.label = label
         self.ci_out = None
         self.user_options = None
         self.init_params = deepcopy(params)
@@ -1621,7 +1626,7 @@ class ModelResult(Minimizer):
         Parameters
         ----------
         params : Parameters, optional
-            Parameters, defaults to ModelResult.params.
+            Parameters, defaults to Dataset.params.
         **kwargs : optional
             Keyword arguments to pass to model function.
 
@@ -1647,7 +1652,7 @@ class ModelResult(Minimizer):
         Parameters
         ----------
         params : Parameters, optional
-            Parameters, defaults to ModelResult.params.
+            Parameters, defaults to Dataset.params.
         sigma : float, optional
             Confidence level, i.e. how many sigma (default is 1).
         dscale : float, optional
@@ -1850,12 +1855,12 @@ class ModelResult(Minimizer):
         return f"<h2>Fit Result</h2> <p>Model: {modname}</p> {report}"
 
     def summary(self):
-        """Return a dictionary with statistics and attributes of a ModelResult.
+        """Return a dictionary with statistics and attributes of a Dataset.
 
         Returns
         -------
         dict
-            Dictionary of statistics and many attributes from a ModelResult.
+            Dictionary of statistics and many attributes from a Dataset.
 
         Notes
         ------
@@ -1903,7 +1908,7 @@ class ModelResult(Minimizer):
         return summary
 
     def dumps(self, **kws):
-        """Represent ModelResult as a JSON string.
+        """Represent Dataset as a JSON string.
 
         Parameters
         ----------
@@ -1913,14 +1918,14 @@ class ModelResult(Minimizer):
         Returns
         -------
         str
-            JSON string representation of ModelResult.
+            JSON string representation of Dataset.
 
         See Also
         --------
         loads, json.dumps
 
         """
-        out = {'__class__': 'lmfit.ModelResult', '__version__': '2',
+        out = {'__class__': 'lmfit.Dataset', '__version__': '2',
                'model': encode4js(self.model._get_state())}
 
         for attr in ('params', 'init_params'):
@@ -1932,7 +1937,7 @@ class ModelResult(Minimizer):
                      'method', 'nan_policy', 'ndata', 'nfev', 'nfree',
                      'nvarys', 'redchi', 'residual', 'rsquared', 'scale_covar',
                      'calc_covar', 'success', 'userargs', 'userkws', 'values',
-                     'var_names', 'weights', 'user_options'):
+                     'var_names', 'weights', 'user_options', 'label'):
             try:
                 val = getattr(self, attr)
             except AttributeError:
@@ -1948,7 +1953,7 @@ class ModelResult(Minimizer):
         return json.dumps(out, **kws)
 
     def dump(self, fp, **kws):
-        """Dump serialization of ModelResult to a file.
+        """Dump serialization of Dataset to a file.
 
         Parameters
         ----------
@@ -1971,12 +1976,12 @@ class ModelResult(Minimizer):
         return fp.write(self.dumps(**kws))
 
     def loads(self, s, funcdefs=None, **kws):
-        """Load ModelResult from a JSON string.
+        """Load Dataset from a JSON string.
 
         Parameters
         ----------
         s : str
-            String representation of ModelResult, as from `dumps`.
+            String representation of Dataset, as from `dumps`.
         funcdefs : dict, optional
             Dictionary of custom function names and definitions.
         **kws : optional
@@ -1984,35 +1989,36 @@ class ModelResult(Minimizer):
 
         Returns
         -------
-        ModelResult
-            ModelResult instance from JSON string representation.
+        Dataset
+            Dataset instance from JSON string representation.
 
         See Also
         --------
         load, dumps, json.dumps
 
         """
-        modres = json.loads(s, **kws)
-        if 'modelresult' not in modres['__class__'].lower():
-            raise AttributeError('ModelResult.loads() needs saved ModelResult')
+        obj = json.loads(s, **kws)
+        classname = obj['__class__'].lower()
+        if 'modelresult' not in classname and 'dataset' not in classname:
+            raise AttributeError('Dataset.loads() needs a saved ModelResult or Dataset')
 
-        modres = decode4js(modres)
-        if 'model' not in modres or 'params' not in modres:
-            raise AttributeError('ModelResult.loads() needs valid ModelResult')
+        dat = decode4js(obj)
+        if 'model' not in dat or 'params' not in dat:
+            raise AttributeError('Dataset.loads() needs valid Dataset')
 
         # model
-        self.model = _buildmodel(decode4js(modres['model']), funcdefs=funcdefs)
+        self.model = _buildmodel(decode4js(dat['model']), funcdefs=funcdefs)
 
         if funcdefs:
             # Remove model function so as not pass it into the _asteval.symtable
             funcdefs.pop(self.model.func.__name__, None)
 
         # how params are saved was changed with version 2:
-        modres_vers = modres.get('__version__', '1')
-        if modres_vers == '1':
+        _vers = obj.get('__version__', '1')
+        if _vers == '1':
             for target in ('params', 'init_params'):
-                state = {'unique_symbols': modres['unique_symbols'], 'params': []}
-                for parstate in modres['params']:
+                state = {'unique_symbols': dat['unique_symbols'], 'params': []}
+                for parstate in dat['params']:
                     _par = Parameter(name='')
                     _par.__setstate__(parstate)
                     state['params'].append(_par)
@@ -2020,10 +2026,10 @@ class ModelResult(Minimizer):
                 _params.__setstate__(state)
                 setattr(self, target, _params)
 
-        elif modres_vers == '2':
+        elif _vers == '2':
             for target in ('params', 'init_params'):
                 _pars = Parameters()
-                _pars.loads(modres[target])
+                _pars.loads(dat[target])
                 if funcdefs:
                     for key, val in funcdefs.items():
                         _pars._asteval.symtable[key] = val
@@ -2036,8 +2042,8 @@ class ModelResult(Minimizer):
                      'method', 'nan_policy', 'ndata', 'nfev', 'nfree',
                      'nvarys', 'redchi', 'residual', 'rsquared', 'scale_covar',
                      'calc_covar', 'success', 'userargs', 'userkws',
-                     'var_names', 'weights', 'user_options'):
-            setattr(self, attr, decode4js(modres.get(attr, None)))
+                     'var_names', 'weights', 'user_options', 'label'):
+            setattr(self, attr, decode4js(dat.get(attr, None)))
 
         self.best_fit = self.model.eval(self.params, **self.userkws)
         if len(self.userargs) == 2:
@@ -2061,7 +2067,7 @@ class ModelResult(Minimizer):
         return self
 
     def load(self, fp, funcdefs=None, **kws):
-        """Load JSON representation of ModelResult from a file-like object.
+        """Load JSON representation of Dataset from a file-like object.
 
         Parameters
         ----------
@@ -2074,8 +2080,8 @@ class ModelResult(Minimizer):
 
         Returns
         -------
-        ModelResult
-            ModelResult created from `fp`.
+        Dataset
+            Dataset created from `fp`.
 
         See Also
         --------
@@ -2142,8 +2148,8 @@ class ModelResult(Minimizer):
 
         See Also
         --------
-        ModelResult.plot_residuals : Plot the fit residuals using matplotlib.
-        ModelResult.plot : Plot the fit results and residuals using matplotlib.
+        Dataset.plot_residuals : Plot the fit residuals using matplotlib.
+        Dataset.plot : Plot the fit results and residuals using matplotlib.
 
         Notes
         -----
@@ -2273,8 +2279,8 @@ class ModelResult(Minimizer):
 
         See Also
         --------
-        ModelResult.plot_fit : Plot the fit results using matplotlib.
-        ModelResult.plot : Plot the fit results and residuals using matplotlib.
+        Dataset.plot_fit : Plot the fit results using matplotlib.
+        Dataset.plot : Plot the fit results and residuals using matplotlib.
 
         Notes
         -----
@@ -2403,13 +2409,13 @@ class ModelResult(Minimizer):
 
         See Also
         --------
-        ModelResult.plot_fit : Plot the fit results using matplotlib.
-        ModelResult.plot_residuals : Plot the fit residuals using matplotlib.
+        Dataset.plot_fit : Plot the fit results using matplotlib.
+        Dataset.plot_residuals : Plot the fit residuals using matplotlib.
 
         Notes
         -----
-        The method combines `ModelResult.plot_fit` and
-        `ModelResult.plot_residuals`.
+        The method combines `Dataset.plot_fit` and
+        `Dataset.plot_residuals`.
 
         If `yerr` is specified or if the fit model included weights, then
         `matplotlib.axes.Axes.errorbar` is used to plot the data. If
@@ -2466,3 +2472,6 @@ class ModelResult(Minimizer):
         plt.setp(ax_res.get_xticklabels(), visible=False)
         ax_fit.set_title('')
         return fig
+
+
+ModelResult = Dataset

--- a/tests/test_model_saveload.py
+++ b/tests/test_model_saveload.py
@@ -179,7 +179,7 @@ def test_saveload_modelresult_exception():
     model, _pars = create_model_params(x, y)
     save_model(model, SAVE_MODEL)
 
-    with pytest.raises(AttributeError, match=r'needs saved ModelResult'):
+    with pytest.raises(AttributeError, match=r'needs a saved ModelResult'):
         load_modelresult(SAVE_MODEL)
     clear_savefile(SAVE_MODEL)
 


### PR DESCRIPTION

#### Description
<!--- Describe your changes in detail: why is it required, what problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If applicable, please provide the URL to the discussion on the mailing list. -->

This is the start of an effort to support multiple-dataset fitting.  As outlined, discussed a bit at #1012, the basic idea is to make a `Dataset` class that has `data`, `model`, and `params`, and the appropriate independent variables and can do a fit.  

As pointed out in #1012, this is essentially what `ModelResult` is, so the first part of the PR here simply:

   a) renames `ModelResult` to `Dataset`, but retains an alias and functions such as `save_modelresult()` (now an alias for `save_dataset()`).
   b) adds a `label` attribute, defaulting to `None`.


This is not ready for merging, but to be part of the discussion at #1012.

Still needed:

a) use `label` as a prefix-prefix for all model component prefixes.
b) add a `MultiDataset` class (maybe sublcassing from `Dataset`, but probably needing several over-written methods) that contains a dictionary of `Datasets` (keyed by `label`),  and can do the prefix-management to organize the `Parameters` and `Datasets`. 

At this point, all tests pass.  I did fix one test for `load_modelresult` that tests an exception message, which now has better grammar.   So far, I think we can say "nothing is broken by this" ;).

###### Type of Changes
<!--- What type of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [x] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
<!-- Generate version information with this command in the Python shell and copy the output here:
import sys, lmfit, numpy, scipy, asteval, uncertainties
print('Python: {}\n\nlmfit: {}, scipy: {}, numpy: {}, asteval: {}, uncertainties: {}'\
      .format(sys.version, lmfit.__version__, scipy.__version__, numpy.__version__, \
      asteval.__version__, uncertainties.__version__))
-->


###### Verification <!-- (delete not applicable items) -->
Have you
<!--- Put an `x` in all the boxes that apply OR describe why you think this is unnecessary. -->
- [ ] included docstrings that follow PEP 257?
<!-- Please use your favorite linter (e.g., pydocstyle) to check your docstrings. -->
- [x] referenced existing Issue and/or provided relevant link to mailing list?
<!-- Please don't open a new Issue if you are submitting a pull request. -->
- [x] verified that existing tests pass locally?
<!-- Please run the test-suite locally with pytest and make sure it passes. -->
- [x] verified that the documentation builds locally?
<!-- Please build the documentation (i.e., type make in the "doc" directory) and make sure it finishes. -->
- [ ] squashed/minimized your commits and written descriptive commit messages?
<!-- We value a clean history with useful commit messages. Ideally, you will take care of this
         before submitting a PR; otherwise you'll be asked to do so before merging. -->
- [x] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example?
