### PR TITLE
Fix issue when AMPGO method is aborted due to reaching max_nfev

### DIFF
--- a/lmfit/_ampgo.py
+++ b/lmfit/_ampgo.py
@@ -205,8 +205,17 @@ def ampgo(objfun, x0, args=(), local='L-BFGS-B', local_opts=None, bounds=None,
             if local_opts is not None:
                 options.update(local_opts)
 
-            res = minimize(tunnel, x0, args=tunnel_args, method=local,
-                           bounds=bounds, tol=local_tol, options=options)
+            try:
+                res = minimize(tunnel, x0, args=tunnel_args, method=local,
+                               bounds=bounds, tol=local_tol, options=options)
+            except Exception as e:
+                if e.__class__.__name__ == "AbortFitException":
+                    return (best_x, best_f, evaluations,
+                            'Maximum number of function evaluations exceeded',
+                            (all_tunnel, success_tunnel))
+                else:
+                    raise
+
             xf, yf, num_fun = res['x'], res['fun'], res['nfev']
             if isinstance(yf, np.ndarray):
                 yf = yf[0]

--- a/lmfit/minimizer.py
+++ b/lmfit/minimizer.py
@@ -2072,7 +2072,7 @@ class Minimizer:
         except AbortFitException:
             pass
 
-        if not result.aborted:
+        if 'ret' in locals():
             result.ampgo_x0 = ret[0]
             result.ampgo_fval = ret[1]
             result.ampgo_eval = ret[2]
@@ -2082,8 +2082,14 @@ class Minimizer:
             for i, par in enumerate(result.var_names):
                 result.params[par].value = float(result.ampgo_x0[i])
 
+            if not result.aborted:
+                result.nfev -= 1
+
+            elif result.aborted:
+                result.nfev -= 2
+
             result.residual = self.__residual(result.ampgo_x0)
-            result.nfev -= 1
+
         elif result.nfev > self.max_nfev-5:
             result.nfev -= 2
             _best = result.last_internal_values

--- a/tests/test_ampgo.py
+++ b/tests/test_ampgo.py
@@ -111,3 +111,17 @@ def test_ampgo_tunnel_more_than_three_arguments():
     args = [func, 0.1, np.array([1, 2]), 5.0]
     out = tunnel(np.array([10, 5]), *args)
     assert_allclose(out, 185.386275588)
+
+
+def test_ampgo_return_best_found_result():
+    """Test to ensure AMPGO returns best found result, for a fixed example"""
+    def func(x):
+        return x['x']**2
+
+    np.random.seed(0)
+    fit_params = lmfit.Parameters()
+    fit_params.add('x', value=-2, min=-10, max=10, vary=True)
+    result = lmfit.minimize(func, fit_params, method="ampgo", max_nfev=100)
+    best_error = result.chisqr ** 0.5
+
+    assert best_error <= 1E-7


### PR DESCRIPTION
#### Description
This PR adds a fix to the AMPGO method for the `minize()` function. Previously, when AMPGO is aborted due to reaching `max_nfev`, it will return the last evaluated values, instead of the best value found so far, an incorrect behavior per AMPGO paper. This was discussed in #1017. The new behavior fixes this, and will return the best value found so far, even if the process is aborted due to `max_nfev`.

Additionally, a new test is added: It verifies against a known case to exhibit this troubled behavior in the current version, but returns a correct value under the newer version proposed by this PR.

This should improve AMPGO method, specially when minimizing computationally slow functions where an arbitrarily big `max_nfev` is not feasible, and a test to prevent future code to accidentally re-introduce this behavior.


###### Type of Changes
- [X] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.14.0 | packaged by Anaconda, Inc. | (main, Oct  8 2025, 17:15:28) [GCC 11.2.0]

lmfit: 1.3.4, scipy: 1.16.2, numpy: 2.3.4, asteval: 1.0.6, uncertainties: 3.2.3



###### Verification
Have you
- [X] included docstrings that follow PEP 257?
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [X] verified that existing tests pass locally?
- [X] verified that the documentation builds locally?
- [X] squashed/minimized your commits and written descriptive commit messages?
- [X] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [X] added an example?


##### Minimal reproducible example
Here's a minimal example that allows to see the improvements:


```python
import numpy as np
import lmfit

np.random.seed(10)

def parabolic(p):
    x = float(p["x"])
    y = x**2
    print(f"x: {x:.5e}, y:{y:.5e}")
    return y

fit_params = lmfit.Parameters()
fit_params.add('x', value=-2, min=-10, max=10, vary=True)
result = lmfit.minimize(parabolic, fit_params, method="ampgo", max_nfev=100)

print(lmfit.fit_report(result))
```

Under the older version, the fit will return `x: 0.30768323` despite the existence of several evaluations of x in the order of `x=-4.99985e-08`, as evidenced by the prints; new version will correctly return `x: -4.9999e-08`
