### PR TITLE
fix(lineshapes): correct denominator regularization in bose() for scalar input

### DIFF
--- a/lmfit/lineshapes.py
+++ b/lmfit/lineshapes.py
@@ -432,7 +432,7 @@ def bose(x, amplitude=1.0, center=0.0, kt=1.0):
     """
     denom = exp((x - center)/not_zero(kt)) - 1.0
     if isinstance(x, (int, float)):
-        denom = max(tiny, x)*copysign(x, denom)
+        denom = not_zero(denom)
     else:
         denom[where(abs(denom) < tiny*tiny)] = tiny*tiny
     return amplitude/denom


### PR DESCRIPTION
## Problem

`bose()`'s scalar branch replaces the computed denominator with `max(tiny, x)*copysign(x, denom)`, which throws away the actual `exp((x-center)/kt) - 1` value and derives a result from `x`'s magnitude instead. Scalar calls diverge wildly from the array path:

```python
>>> bose(-3.0)                    # scalar
-333333333333333.3
>>> bose(np.array([-3.0]))[0]     # array, correct
-1.052395696491256
```

Same problem for other inputs, e.g. `bose(2.0)` gives `0.25` instead of `0.1565...`, `bose(10.0)` gives `0.01` instead of `4.54e-05`.

## Fix

Use `not_zero(denom)`, the same helper already used a few lines up for `kt`, and used identically in the sibling `fermi()` function. It clamps the denominator to a signed minimum only when it's near zero, otherwise passes the true value through, matching what the array branch already does with `denom[where(abs(denom) < tiny*tiny)] = tiny*tiny`.

## Testing

- Full existing test suite passes (`pytest tests/`: 642 passed, 30 skipped, 1 xfailed, no new failures).
- Manually verified scalar and array inputs now agree:

```python
for x in [2.0, -3.0, 0.5, 10.0, -20.0]:
    assert np.isclose(bose(x), bose(np.array([x]))[0])  # now True for all
```

Before the fix all of these mismatched.