### PR TITLE
Fix TypeError when independent variable is a list of custom objects (Issue #1040)

### DIFF
--- a/doc/whatsnew.rst
+++ b/doc/whatsnew.rst
@@ -28,6 +28,9 @@ Fixes:
 
 - fix cross-Python-version serialization of ``ConstantModel`` and
   ``ComplexConstantModel`` by moving their functions to ``lineshapes`` (Issue #1033)
+- fix ``TypeError`` when an independent variable is a list/tuple of custom,
+  non-float objects by only coercing array-like inputs that can actually be
+  cast to a numeric ndarray (Issue #1040)
 
 .. _whatsnew_134_label:
 

--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -197,12 +197,22 @@ def coerce_arraylike(x):
     coerce lists, tuples, and pandas Series, hdf5 Groups, etc to an
     ndarray float64 or complex128, but leave other data structures
     and objects unchanged
+
+    Only data that can actually be represented as float64/complex128 is
+    coerced. ``numpy.isrealobj`` returns ``True`` for an object-dtype
+    array (for example a list of custom, non-float objects), so relying on
+    it would attempt -- and fail with a ``TypeError`` -- to cast such data
+    to float64 (see GitHub issue #1040). Instead the conversion is tried
+    and any array-like that cannot be cast to a numeric ndarray is returned
+    unchanged.
     """
     if isinstance(x, (list, tuple, Series)) or hasattr(x, '__array__'):
-        if np.isrealobj(x):
-            return np.asarray(x, dtype=np.float64)
         if np.iscomplexobj(x):
             return np.asarray(x, dtype=np.complex128)
+        try:
+            return np.asarray(x, dtype=np.float64)
+        except (TypeError, ValueError):
+            pass
     return x
 
 

--- a/tests/test_custom_independentvar.py
+++ b/tests/test_custom_independentvar.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from lmfit.lineshapes import gaussian
+from lmfit.model import coerce_arraylike
 from lmfit.models import Model
 
 
@@ -14,8 +15,21 @@ class Stepper:
         return np.linspace(self.start, self.stop, self.npts)
 
 
+class CustomObject:
+    """A minimal user-defined object that cannot be coerced to a float."""
+
+    def __init__(self, value):
+        self.value = value
+
+
 def gaussian_mod(obj, amplitude, center, sigma):
     return gaussian(obj.get_x(), amplitude, center, sigma)
+
+
+def gaussian_with_objlist(x, amplitude, center, sigma, custom_object_list=None):
+    """Gaussian model that also accepts a list of custom objects as an
+    independent variable; the list is not used in the calculation."""
+    return gaussian(x, amplitude, center, sigma)
 
 
 def test_custom_independentvar():
@@ -43,3 +57,65 @@ def test_custom_independentvar():
     assert out.params['center'].value < xmax
     assert out.params['amplitude'].value > 1
     assert out.params['amplitude'].value < 5
+
+
+def test_list_of_custom_objects_independentvar():
+    """A list of custom (non-float) objects used as an independent variable
+    must not raise a TypeError in ``coerce_arraylike`` (GitHub issue #1040).
+
+    ``numpy.isrealobj`` returns True for an object-dtype array, so the old
+    code tried to cast the list of objects to float64 and raised.
+    """
+    npts = 501
+    xmin = 1
+    xmax = 21
+    cen = 8
+    x = np.linspace(xmin, xmax, npts)
+    custom_object_list = [CustomObject(1), CustomObject(2), CustomObject(5)]
+
+    y = gaussian(x, amplitude=3.0, center=cen, sigma=2.5)
+    y += np.random.normal(scale=0.2, size=npts)
+
+    gmod = Model(gaussian_with_objlist,
+                 independent_vars=['x', 'custom_object_list'])
+    params = gmod.make_params(amplitude=2, center=5, sigma=8)
+
+    # before the fix this raised:
+    #   TypeError: float() argument must be a string or a real number ...
+    out = gmod.fit(y, params, x=x, custom_object_list=custom_object_list)
+
+    # the list of custom objects must be passed through unchanged
+    assert out.userkws['custom_object_list'] is custom_object_list
+
+    assert out.nvarys == 3
+    assert out.nfev > 10
+    assert out.params['sigma'].value > 2
+    assert out.params['sigma'].value < 3
+    assert out.params['center'].value > xmin
+    assert out.params['center'].value < xmax
+    assert out.params['amplitude'].value > 1
+    assert out.params['amplitude'].value < 5
+
+
+def test_coerce_arraylike_dtypes():
+    """``coerce_arraylike`` casts real-numeric and complex array-likes but
+    leaves non-numeric objects (and scalars) unchanged (GitHub issue #1040)."""
+    # real numeric lists/tuples/arrays -> float64 ndarray
+    for seq in ([1, 2, 3], (1.0, 2.0, 3.0), np.arange(4)):
+        res = coerce_arraylike(seq)
+        assert isinstance(res, np.ndarray)
+        assert res.dtype == np.float64
+        assert np.allclose(res, np.asarray(seq, dtype=np.float64))
+
+    # complex list -> complex128 ndarray
+    res = coerce_arraylike([1 + 2j, 3 + 4j])
+    assert isinstance(res, np.ndarray)
+    assert res.dtype == np.complex128
+
+    # list of custom, non-float objects -> returned unchanged (issue #1040)
+    objs = [CustomObject(1), CustomObject(2)]
+    assert coerce_arraylike(objs) is objs
+
+    # scalars and plain objects pass through unchanged
+    assert coerce_arraylike(5) == 5
+    assert coerce_arraylike('a string') == 'a string'


### PR DESCRIPTION
#### Description

Closes #1040.

When a list/tuple of custom (non-float) objects is used as an independent
variable in a `Model` fit, `Model.fit` passes it through `coerce_arraylike`,
which raised:

```
TypeError: float() argument must be a string or a real number, not 'ExampleClass'
```

**Root cause.** `coerce_arraylike` used `numpy.isrealobj(x)` to decide whether
to cast the input to `float64`. For a list of custom objects, `np.asarray`
produces an **object-dtype** array, and `numpy.isrealobj` returns `True` for
object dtype (it only checks that the dtype is *not* complex). The code then
reached `np.asarray(x, dtype=np.float64)`, which fails because the objects
have no `float()` conversion — contradicting the function's documented intent
to "leave other data structures and objects unchanged". This matches
@newville's diagnosis in the issue that `numpy.isrealobj()` returns `True` for
a list of dataclasses.

**Fix.** Coerce only data that can actually be represented as a numeric
ndarray. Keep the existing `complex128` path, then *attempt* the `float64`
cast and fall back to returning the input unchanged when the cast raises
`TypeError`/`ValueError`:

```python
if isinstance(x, (list, tuple, Series)) or hasattr(x, '__array__'):
    if np.iscomplexobj(x):
        return np.asarray(x, dtype=np.complex128)
    try:
        return np.asarray(x, dtype=np.float64)
    except (TypeError, ValueError):
        pass
return x
```

This preserves current behavior for real numeric arrays/lists and scalars —
including numeric lists that contain `None`, which NumPy still casts to `NaN`
so that `nan_policy` continues to apply (covered by
`test_model.py::TestUserDefiniedModel::test_lists_become_arrays`) — while no
longer raising for a list of non-float objects. This is the try/except
approach @newville suggested in the issue thread. Thanks to @ChristianGeci for
the clear report and minimal reproducer.

**Tests.** `tests/test_custom_independentvar.py` is extended with:
- `test_list_of_custom_objects_independentvar`: a `Model` fit whose
  independent variable is a list of custom objects now completes without
  raising and the list is passed through unchanged (fails before the fix);
- `test_coerce_arraylike_dtypes`: a direct unit test of `coerce_arraylike`
  covering numeric → `float64`, complex → `complex128`, and object/scalar
  pass-through.

###### Type of Changes
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples

###### Tested on
```
Python: 3.14.4
lmfit: 1.4.0.dev (branch), scipy: 1.18.0, numpy: 2.5.1, asteval: 1.0.9, uncertainties: 3.2.3
```

###### Verification
- [x] included docstrings that follow PEP 257 (updated the `coerce_arraylike` docstring)
- [x] referenced existing Issue and/or provided relevant link to mailing list (Closes #1040)
- [x] verified that existing tests pass locally (`pytest tests/` → 672 passed, 30 skipped, 1 xfailed)
- [ ] verified that the documentation builds locally
- [x] squashed/minimized your commits and written descriptive commit messages
- [x] added or updated existing tests to cover the changes
- [x] updated the documentation and/or added an entry to the release notes (`doc/whatsnew.rst`)
- [ ] added an example (not applicable for this bug fix)
